### PR TITLE
chore(release): prepare v0.3.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+No unreleased changes yet.
+
+---
+
+## [0.3.0-rc2] - 2026-06-10
+
 ### Added
 
 - Bounded recursive orchestration primitive: `mini-ork spawn` can approve and
@@ -19,9 +25,28 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Recursive validation coverage: integration, security, e2e, and live Python
   validation scenarios for parent -> child -> grandchild delegation without
   Anthropic-family provider calls.
+- CI release gates for README mechanical claim checks, ShellCheck, bash test
+  layers, Python web tests, UI typecheck/build, CodeQL, GitGuardian, and
+  dependency review.
+- Observability web smoke CI stage that exercises `make web-test`.
+
+### Fixed
+
+- UI typecheck in clean GitHub runners by adding explicit Node 20 type
+  declarations for `vite.config.ts`.
+- ShellCheck parsing of the optional-check comment in `tests/smoke.sh`.
+- Linux/GNU portability for empty plan discovery in `mini-ork-execute` and
+  `mini-ork-verify`.
+- Linux/macOS `stat` portability in the symlink-attack security test.
+- Dependency Review no longer keeps every PR red when GitHub Dependency graph is
+  unavailable; the workflow still runs the strict gate when the graph is
+  enabled.
 
 ### Verified
 
+- GitHub CI for PR #8: README claim check, ShellCheck, bash smoke/unit/
+  integration/e2e/security, Python 3.11/3.12, UI typecheck/build, web smoke,
+  CodeQL, GitGuardian, and Dependency Review all passed.
 - Full test pyramid: 60 files, 543 assertions, 0 failures.
 - Recursive focused tests: `test_bin_spawn.sh` 9 OK, recursive spawn security 3
   OK, recursive e2e 6 OK.

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Auto-promotion is **class-restricted**: task classes with an external oracle (te
 
 ## Roadmap
 
-**Current: v0.3.0-rc1** (release candidate, 2026-06-08) — oracle-hardening primitives shipped: `coalition_gate.sh`, `cw_por.sh`, `mo_promote_synthesis_gate`, `adaptive_stability.sh`, `circuit_breaker.sh`, plus the central `gate_bootstrap.sh` wiring used by execute. Self-evolution is now explicitly class-restricted (`docs/positioning/why-mini-ork.md` §"Self-evolution is class-restricted").
+**Current: v0.3.0-rc2** (release candidate, 2026-06-10) — CI-gated observability, security, and reliability hardening on top of the v0.3 oracle-hardening primitives: `coalition_gate.sh`, `cw_por.sh`, `mo_promote_synthesis_gate`, `adaptive_stability.sh`, `circuit_breaker.sh`, plus the central `gate_bootstrap.sh` wiring used by execute. Self-evolution is now explicitly class-restricted (`docs/positioning/why-mini-ork.md` §"Self-evolution is class-restricted").
 
 The full release log lives in [`ROADMAP.md`](ROADMAP.md) — every section dated and per-commit-attributed. Current shipped totals (regenerable via `bash scripts/readme-claim-check.sh` and filesystem counts):
 

--- a/bin/mini-ork
+++ b/bin/mini-ork
@@ -391,7 +391,7 @@ PY
     done
     ;;
 
-  version) echo "mini-ork 0.3.0-rc1 (universal task loop runtime)" ;;
+  version) echo "mini-ork 0.3.0-rc2 (universal task loop runtime)" ;;
 
   help|--help|-h)
     cat <<'EOF'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mini-ork"
-version = "0.3.0rc1"
+version = "0.3.0rc2"
 description = "Python framework facade for the mini-ork agent workflow runtime"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Prepare the v0.3.0-rc2 release candidate.

## Changes

- Bump Python package version to `0.3.0rc2`.
- Update `mini-ork version` output to `0.3.0-rc2`.
- Move current changelog notes into `0.3.0-rc2`.
- Update README current-release text.

## Testing

- `bash scripts/readme-claim-check.sh`
- `./bin/mini-ork version`
- `python3 - <<PY ... assert pyproject version == 0.3.0rc2`
- `bash -n bin/mini-ork`
- `git diff --check`