### PR TITLE
feat(recipes): chapter-compound — multi-pass writer with audit-bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The framework ships the universal loop and its primitives. Nothing in `lib/` or 
 
 ### RECIPES — opinions live here
 
-Recipes are user-land workflow definitions. They compose framework primitives into pipeline shapes. 25 recipes ship today; 8 of them dispatch a 4–5 lens panel across distinct model families per cycle, using family diversity as a practical proxy for the low-correlation detector patterns highlighted by Rajan 2025.
+Recipes are user-land workflow definitions. They compose framework primitives into pipeline shapes. 26 recipes ship today; 8 of them dispatch a 4–5 lens panel across distinct model families per cycle, using family diversity as a practical proxy for the low-correlation detector patterns highlighted by Rajan 2025.
 
 | Recipe | Location | Shape |
 |---|---|---|
@@ -361,6 +361,7 @@ Recipes are user-land workflow definitions. They compose framework primitives in
 | `recursive-validate-impl` | `recipes/recursive-validate-impl/` | **Recipe-creator-authored, 2026-06-12.** Recursive implement → multi-tier-validate → reflect → replan loop for any technical-feature kickoff. 5-tier verification (compile/typecheck → scoped unit → property + mutation → heterogeneous LLM panel) gated left-to-right; tier-4 panel cross-references implementation against arxiv-libwit "modern techniques" compliance, not just done-state. Reflector extracts failure gradients; recursion hard-caps at 5 iterations or $25 with a divergence-kill safety net. |
 
 | `harness-bridge` | `recipes/harness-bridge/` | **2026-06-14.** Wraps a full coding-agent harness (claude-code / codex-cli / gemini-cli) as a workflow node. Harvey-pattern composition. Planner picks the harness from a kickoff declaration; harness-shape verifier checks the emitted diff applies. |
+| `chapter-compound` | `recipes/chapter-compound/` | **2026-06-15.** Multi-pass book-chapter writer: 4 lens writers draft same chapter in parallel from shared contract, chapter-review recipe scores every draft (4×4 critique matrix), deterministic selector picks best, Opus-only revise loop tightens it. Audit-bundle output (`chapter-compound.json`) carries every draft + critique + selection rationale + revision trace. Consumed by libwit/server when `FEATURE_CHAPTER_COMPOUND_WRITER=true`. |
 
 Add your own under `recipes/<name>/` — see [docs/EXTENSION.md](docs/EXTENSION.md).
 
@@ -404,7 +405,7 @@ Auto-promotion is **class-restricted**: task classes with an external oracle (te
 The full release log lives in [`ROADMAP.md`](ROADMAP.md) — every section dated and per-commit-attributed. Current shipped totals (regenerable via `bash scripts/readme-claim-check.sh` and filesystem counts):
 
 - 6-stage universal loop (`classify → plan → execute → verify → reflect → improve`) + 7 companion entrypoints (`eval`, `improve`, `promote`, `metrics`, `spawn`, direct `bin/mini-ork-topology`, direct `bin/mini-ork-self-improve`)
-- 55 framework primitives in `lib/` (incl. oracle-hardening libs + `gate_bootstrap.sh` for the v0.3-rc1 central wire-up + `lib/throttle-guard.sh` for provider-throttle classification + `lib/mo_otel.sh` for env-gated OTel span emission, added 2026-06-09/10 + `lib/profile_answerer.sh` for MO_AUTO_ANSWER_PROFILE autonomous-dispatch mode, added 2026-06-12 + 4 calibration-list gates landed 2026-06-13: `lib/krippendorff_alpha_gate.sh` Nasser 2026 α<0.4 panel-divergence escalation, `lib/citation_verifier_mechanical.sh` Sistla 2025 mechanical citation coverage + wireheading check, `lib/refute_or_promote_gate.sh` Agarwal 2026 adversarial fabrication survival, `lib/honest_ci_gate.sh` Dai 2025 per-finding confidence intervals)
+- 56 framework primitives in `lib/` (incl. oracle-hardening libs + `gate_bootstrap.sh` for the v0.3-rc1 central wire-up + `lib/throttle-guard.sh` for provider-throttle classification + `lib/mo_otel.sh` for env-gated OTel span emission, added 2026-06-09/10 + `lib/profile_answerer.sh` for MO_AUTO_ANSWER_PROFILE autonomous-dispatch mode, added 2026-06-12 + 4 calibration-list gates landed 2026-06-13: `lib/krippendorff_alpha_gate.sh` Nasser 2026 α<0.4 panel-divergence escalation, `lib/citation_verifier_mechanical.sh` Sistla 2025 mechanical citation coverage + wireheading check, `lib/refute_or_promote_gate.sh` Agarwal 2026 adversarial fabrication survival, `lib/honest_ci_gate.sh` Dai 2025 per-finding confidence intervals)
 - 1 runner-shared helper in `bin/lib/` (`profile-seed.sh` — deterministic `run_profile.json` seeding from structured kickoff markdown, added 2026-06-09)
 - 19 user-facing `bin/mini-ork*` entrypoints (incl. `mini-ork rollback <workflow|agent> <name> + mini-ork resume <run_id> for cost-pause clearance, added 2026-06-14` added 2026-06-13 — first-class CLI verb for the evolution+promotion layer's version_registry)
 - 26 schema migrations under `db/migrations/` (memory namespaces, benchmarks, evolution, safety, panel topology telemetry, recursive orchestration, self-improvement learning, llm_calls session indexing, trace status widening, Arbor-style idea_tree primitive, error taxonomy + finish reasons, dispatch config snapshot, heartbeat + fuse, cache-aware cost accounting, policy state + audit trail)

--- a/recipes/chapter-compound/README.md
+++ b/recipes/chapter-compound/README.md
@@ -1,0 +1,110 @@
+# `chapter-compound` — multi-pass book-chapter writer
+
+Multi-lens writer fanout + per-draft critique matrix + deterministic selection + focused revise loop. Produces a single `chapter-compound.json` audit-bundle for one book chapter.
+
+## When to use
+
+- You want **stylistic diversity** in chapter drafts (4 lens families produce 4 different takes; the best wins on the C1-C9 rubric).
+- You want **per-pass forensics** (audit-bundle captures every draft + every critique + selection rationale + revise trace).
+- You're willing to pay **~3.7× per chapter** vs single-shot writing for the diversity + forensics premium.
+
+## When NOT to use
+
+- Pre-prod / cost-sensitive runs. The single-shot canonical writer + Phase 1 panel critique (from libwit's `bookOrchestratorContextFirst`) is cheaper and already multi-critic.
+- Books shorter than 5 chapters. The setup cost (4 writer sandboxes) doesn't amortize.
+- When the LLM key budget is constrained (10-25 sandboxes per chapter = 10-25× key load).
+
+## Pipeline shape
+
+```
+prepare → writer-fanout (4 parallel) → critique-fanout (4 parallel)
+       → selector → revise-loop (N iters) → verifiers → publisher
+```
+
+## Inputs (staged by caller into `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/`)
+
+| File | Required | Purpose |
+|---|---|---|
+| `chapter_contract.json` | yes | Full ChapterWritingContract (required H2 count, genre rules, forbidden constructs) |
+| `evidence_pack.md` | yes | Pre-fetched evidence bundle (markdown) |
+| `chapter_outline.md` | yes | Chapter plan summary + key topics |
+| `context.json` | yes | chapter_title, chapter_number, book_topic, audience, language, style_blueprint_summary, prior_chapters_outline, max_revise_iterations |
+| `style_blueprint.md` | no (stub if absent) | Voice/tone reference |
+| `seed.md` | no | Warm-start markdown; absent = cold draft |
+
+## Output
+
+Single artifact at `${MINI_ORK_RUN_DIR}/chapter-compound.json` matching `libwit/shared/types/chapterCompound.ts:isChapterCompoundJson` schema-guard exactly. Shape:
+
+```jsonc
+{
+  "schema_version": "1.0.0",
+  "chapter_title": "...",
+  "chapter_number": 1,
+  "drafts": [
+    { "lens": "glm|kimi|codex|opus", "markdown": "...",
+      "bytes": N, "duration_ms": N, "cost_usd": N,
+      "accepted_for_review": bool, "reject_reason"?: "..." }
+  ],
+  "critique_cells": [
+    { "writer_lens": "glm|kimi|codex|opus",
+      "critique": { /* full ChapterReviewJson */ },
+      "duration_ms": N, "cost_usd": N }
+  ],
+  "selection": {
+    "selected_lens": "glm|kimi|codex|opus",
+    "selection_strategy": "deterministic_weighted",
+    "rationale": "...",
+    "candidate_scores": [
+      { "lens": "...", "mean_axis_score": N,
+        "panel_disagreement": N, "composite_score": N }
+    ]
+  },
+  "revisions": [
+    { "iteration": N, "before_markdown": "...", "after_markdown": "...",
+      "driving_critique": { /* ChapterReviewJson */ },
+      "post_critique":    { /* ChapterReviewJson */ },
+      "passed": bool, "duration_ms": N, "cost_usd": N }
+  ],
+  "final_markdown": "...",
+  "revised": bool,
+  "cost_summary": {
+    "total_usd": N, "writer_usd": N, "critique_usd": N,
+    "selection_usd": N, "revise_usd": N, "sandbox_spawns": N
+  },
+  "total_duration_ms": N
+}
+```
+
+## Cost model
+
+| Pass | Sandboxes | LLM calls | Cost USD | Wall clock |
+|---|---|---|---|---|
+| prepare | 1 | 0 | $0 | ~5s |
+| writer-fanout (4 parallel) | 4 | 4 (1 per lens) | $0.30-0.80 | 60-180s (max of 4) |
+| critique-fanout (4 parallel, each = 1 chapter-review = 4 lenses internally) | 4 | 16 (4 lens × 4 drafts) | $0.10-0.30 | 60-180s (max of 4) |
+| selector | 1 | 1 | <$0.01 | ~5s |
+| revise-loop (≤2 iter × 2 LLM calls) | 2-3 | 2-4 | $0.10-0.40 | 30-120s |
+| verifiers + publisher | 1 | 0 | $0 | ~5s |
+| **Total** | **~13** | **~23-25** | **$0.50-1.50** | **3-8 min** |
+
+## Activation in libwit
+
+Already scaffolded in libwit at:
+
+- `shared/types/chapterCompound.ts` — schema contract + isChapterCompoundJson guard
+- `server/services/bookGeneration/chapterCompoundWriterClient.ts` — BE adapter (runChapterCompoundWriter)
+- `server/services/bookGeneration/bookOrchestratorContextFirst.ts` — flag-gated dispatch at C.4 critique-loop entry
+- `server/resources/daytona/run-miniork-agent.cjs` — stageChapterCompoundInputs
+
+After this recipe lands:
+1. Bump `MINIORK_REPO_SHA` in `server/resources/daytona/build-snapshots.ts`
+2. Rebuild snapshot: `npx tsx server/resources/daytona/build-snapshots.ts --miniork-only`
+3. Flip flag: `kubectl set env -n researcher deploy/libwit-worker-book-generation FEATURE_CHAPTER_COMPOUND_WRITER=true`
+4. Smoke: `kubectl exec -i -n researcher deploy/libwit-backend -- node - < server/scripts/debug-miniork-chapter-review-smoke.cjs` (probe was authored for chapter-review; adapt for compound by changing recipe name)
+
+## Composes with
+
+- `recipes/chapter-review/` — invoked per-draft inside critique-fanout nodes; output reused verbatim
+- `libwit/docs/book_gen/handoffs/20260614-2200-upstream-miniork-chapter-compound-recipe-kickoff.md` — full architectural spec
+- `libwit/docs/book_gen/ideas/20260614-2150-mini-ork-chapter-compound-writer-port.md` — why-this-recipe-exists rationale

--- a/recipes/chapter-compound/artifact_contract.yaml
+++ b/recipes/chapter-compound/artifact_contract.yaml
@@ -1,0 +1,28 @@
+task_class: chapter_compound
+expected_artifact: composite     # 4 drafts + 4 critique-fanout JSONs + 1 selection + N revisions + 1 compound JSON
+success_verifiers:
+  - verifiers/schema.sh
+  - verifiers/writer-completeness.sh
+failure_policy: request_changes
+rollback_policy: >
+  Keep every draft + critique cell under runs/<id>/drafts/draft-*.md and
+  runs/<id>/critiques/critique-*.json for inspection. Discard the
+  compound artifact if it failed verification; the per-lens drafts and
+  critiques remain individually consumable so a second-pass synthesis
+  can be re-attempted without re-running writers.
+
+# source_artifact names the input files staged into $MINI_ORK_RUN_DIR
+# by the dispatcher (per the libwit BE's stageChapterCompoundInputs
+# at server/resources/daytona/run-miniork-agent.cjs). outputs[] lists
+# the canonical artifact the publisher writes + git-commits.
+source_artifact:
+  - chapter_contract.json   # ChapterWritingContract (JSON)
+  - evidence_pack.md        # Pre-fetched evidence bundle (markdown)
+  - chapter_outline.md      # chapterPlan.summary + keyTopics
+  - context.json            # chapter_title, chapter_number, book_topic,
+                            #   audience, language, style_blueprint_summary,
+                            #   prior_chapters_outline, max_revise_iterations
+  - style_blueprint.md      # Optional; stubbed if absent
+  - seed.md                 # Optional warm-start markdown
+outputs:
+  - chapter-compound.json

--- a/recipes/chapter-compound/example-kickoff.md
+++ b/recipes/chapter-compound/example-kickoff.md
@@ -1,0 +1,80 @@
+# Example kickoff — Write Chapter 1 via chapter-compound
+
+This is an example kickoff for the chapter-compound recipe. The libwit BE stages the inputs via `server/resources/daytona/run-miniork-agent.cjs:stageChapterCompoundInputs`; this file shows what a manual operator-side dispatch looks like for testing.
+
+## Problem
+
+Write Chapter 1 of the "Self-Evolving by Design" book (chapter_title: "The Static Pipeline and Its Seven Signals") via multi-pass writer fanout with audit-bundle output.
+
+## Definition of Done
+
+Produce a valid `chapter-compound.json` under `${MINI_ORK_RUN_DIR}` containing:
+- 4 writer-lens drafts (glm, kimi, codex, opus) — all `accepted_for_review`
+- 4 critique cells (one chapter-review per draft)
+- Selection rationale + composite scores
+- Revisions array (0-2 iterations)
+- `final_markdown` (4000-8000 words)
+- `cost_summary.total_usd` ≤ $5.00
+
+Both `schema.sh` and `writer-completeness.sh` verifiers MUST pass.
+
+## Scope
+
+- Target chapter: chapter-compound-inputs/chapter_contract.json + evidence_pack.md + chapter_outline.md + context.json + style_blueprint.md
+- Budget: $5 max per chapter
+- Max revise iterations: 2
+
+## Lineage
+
+Dispatched by libwit BE via runMiniOrkRecipe('chapter-compound', ...) → Hatchet dispatchMiniOrkCritique → Daytona miniork-stable-v1 sandbox → run-miniork-agent.cjs → mini-ork run.
+
+## Manual smoke test (without libwit)
+
+```bash
+export MINI_ORK_RUN_DIR=/tmp/chapter-compound-smoke-$(date +%s)
+mkdir -p $MINI_ORK_RUN_DIR/chapter-compound-inputs
+
+# Stage minimal inputs for smoke
+cat > $MINI_ORK_RUN_DIR/chapter-compound-inputs/chapter_contract.json <<'JSON'
+{
+  "genre": { "chapter_genre": "technical-tutorial" },
+  "structure_mode": "plan_steps_exact",
+  "required_h2_count": 6,
+  "calibration_bucket": "oreilly_technical",
+  "forbidden_constructs": []
+}
+JSON
+cat > $MINI_ORK_RUN_DIR/chapter-compound-inputs/evidence_pack.md <<'MD'
+# Evidence
+- [arXiv:2510.05520] CAM architecture paper — Constructivist Agentic Memory partitions
+  memory into episodic, semantic, and skill stores.
+MD
+cat > $MINI_ORK_RUN_DIR/chapter-compound-inputs/chapter_outline.md <<'MD'
+## Summary
+This chapter introduces the static-pipeline problem and the 7 signals.
+
+## Key topics
+1. Static pipelines
+2. Seven signals
+3. Artifact-first patterns
+4. CAM partitioning
+5. Decay mechanisms
+6. SAP-based feedback loop
+MD
+cat > $MINI_ORK_RUN_DIR/chapter-compound-inputs/context.json <<'JSON'
+{
+  "chapter_title": "The Static Pipeline and Its Seven Signals",
+  "chapter_number": 1,
+  "book_topic": "Self-Evolving by Design",
+  "book_audience": "AI engineers",
+  "language": "en",
+  "style_blueprint_summary": "O'Reilly technical voice; 2nd-person; concrete examples",
+  "prior_chapters_outline": [],
+  "max_revise_iterations": 2
+}
+JSON
+echo "# Stub style blueprint" > $MINI_ORK_RUN_DIR/chapter-compound-inputs/style_blueprint.md
+
+# Dispatch
+mini-ork run chapter-compound recipes/chapter-compound/example-kickoff.md
+```

--- a/recipes/chapter-compound/prompts/critique-fanout-codex.md
+++ b/recipes/chapter-compound/prompts/critique-fanout-codex.md
@@ -1,0 +1,37 @@
+# Critique — chapter-review pass on the CODEX writer's draft
+
+You are running the **chapter-review** recipe against ONE specific writer's draft. Your inputs are different from a standalone chapter-review run because the chapter under review is the per-writer draft, not a pre-existing chapter file.
+
+## Inputs
+
+- `${MINI_ORK_RUN_DIR}/drafts/draft-codex.md` — the chapter draft to critique (CODEX writer's output).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — reuse the context shape that chapter-review expects.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — style reference.
+
+## Your output
+
+Write the chapter-review JSON to:
+- `${MINI_ORK_RUN_DIR}/critiques/critique-codex.json`
+
+The JSON MUST conform exactly to the `ChapterReviewJson` schema-guard at `libwit/shared/types/chapterReview.ts:isChapterReviewJson` (same shape that the existing `chapter-review` recipe emits at `${MINI_ORK_RUN_DIR}/chapter-review.json`). Compound's `chapter-compound.json` schema-guard `isChapterCompoundJson` validates the `critique_cells[*].critique` field by recursing into `isChapterReviewJson`.
+
+## Process
+
+1. Stage the draft as the `chapter.md` input that chapter-review expects:
+   ```bash
+   mkdir -p ${MINI_ORK_RUN_DIR}/chapter-review-inputs-codex
+   cp ${MINI_ORK_RUN_DIR}/drafts/draft-codex.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-codex/chapter.md
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json ${MINI_ORK_RUN_DIR}/chapter-review-inputs-codex/context.json
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-codex/style_blueprint.md
+   ```
+2. Invoke the existing chapter-review recipe via the mini-ork framework. The output is `chapter-review.json` written to a sub-run dir; copy that to `critiques/critique-codex.json`.
+3. The 4 critique-fanout nodes run in parallel; each writes its own per-writer critique file.
+
+## Critical rule
+
+Do NOT re-implement chapter-review logic here. Recursively call the existing recipe — the whole point is that compound REUSES chapter-review's panel infrastructure verbatim, so any improvements to chapter-review automatically benefit compound.
+
+## Cost discipline
+
+- Each critique-fanout node = 1 chapter-review run = ~$0.10-0.30 in LLM spend.
+- 4 critique-fanout nodes total = $0.40-1.20 per chapter for the critique matrix.

--- a/recipes/chapter-compound/prompts/critique-fanout-glm.md
+++ b/recipes/chapter-compound/prompts/critique-fanout-glm.md
@@ -1,0 +1,37 @@
+# Critique — chapter-review pass on the GLM writer's draft
+
+You are running the **chapter-review** recipe against ONE specific writer's draft. Your inputs are different from a standalone chapter-review run because the chapter under review is the per-writer draft, not a pre-existing chapter file.
+
+## Inputs
+
+- `${MINI_ORK_RUN_DIR}/drafts/draft-glm.md` — the chapter draft to critique (GLM writer's output).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — reuse the context shape that chapter-review expects.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — style reference.
+
+## Your output
+
+Write the chapter-review JSON to:
+- `${MINI_ORK_RUN_DIR}/critiques/critique-glm.json`
+
+The JSON MUST conform exactly to the `ChapterReviewJson` schema-guard at `libwit/shared/types/chapterReview.ts:isChapterReviewJson` (same shape that the existing `chapter-review` recipe emits at `${MINI_ORK_RUN_DIR}/chapter-review.json`). Compound's `chapter-compound.json` schema-guard `isChapterCompoundJson` validates the `critique_cells[*].critique` field by recursing into `isChapterReviewJson`.
+
+## Process
+
+1. Stage the draft as the `chapter.md` input that chapter-review expects:
+   ```bash
+   mkdir -p ${MINI_ORK_RUN_DIR}/chapter-review-inputs-glm
+   cp ${MINI_ORK_RUN_DIR}/drafts/draft-glm.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-glm/chapter.md
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json ${MINI_ORK_RUN_DIR}/chapter-review-inputs-glm/context.json
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-glm/style_blueprint.md
+   ```
+2. Invoke the existing chapter-review recipe via the mini-ork framework. The output is `chapter-review.json` written to a sub-run dir; copy that to `critiques/critique-glm.json`.
+3. The 4 critique-fanout nodes run in parallel; each writes its own per-writer critique file.
+
+## Critical rule
+
+Do NOT re-implement chapter-review logic here. Recursively call the existing recipe — the whole point is that compound REUSES chapter-review's panel infrastructure verbatim, so any improvements to chapter-review automatically benefit compound.
+
+## Cost discipline
+
+- Each critique-fanout node = 1 chapter-review run = ~$0.10-0.30 in LLM spend.
+- 4 critique-fanout nodes total = $0.40-1.20 per chapter for the critique matrix.

--- a/recipes/chapter-compound/prompts/critique-fanout-kimi.md
+++ b/recipes/chapter-compound/prompts/critique-fanout-kimi.md
@@ -1,0 +1,37 @@
+# Critique — chapter-review pass on the KIMI writer's draft
+
+You are running the **chapter-review** recipe against ONE specific writer's draft. Your inputs are different from a standalone chapter-review run because the chapter under review is the per-writer draft, not a pre-existing chapter file.
+
+## Inputs
+
+- `${MINI_ORK_RUN_DIR}/drafts/draft-kimi.md` — the chapter draft to critique (KIMI writer's output).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — reuse the context shape that chapter-review expects.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — style reference.
+
+## Your output
+
+Write the chapter-review JSON to:
+- `${MINI_ORK_RUN_DIR}/critiques/critique-kimi.json`
+
+The JSON MUST conform exactly to the `ChapterReviewJson` schema-guard at `libwit/shared/types/chapterReview.ts:isChapterReviewJson` (same shape that the existing `chapter-review` recipe emits at `${MINI_ORK_RUN_DIR}/chapter-review.json`). Compound's `chapter-compound.json` schema-guard `isChapterCompoundJson` validates the `critique_cells[*].critique` field by recursing into `isChapterReviewJson`.
+
+## Process
+
+1. Stage the draft as the `chapter.md` input that chapter-review expects:
+   ```bash
+   mkdir -p ${MINI_ORK_RUN_DIR}/chapter-review-inputs-kimi
+   cp ${MINI_ORK_RUN_DIR}/drafts/draft-kimi.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-kimi/chapter.md
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json ${MINI_ORK_RUN_DIR}/chapter-review-inputs-kimi/context.json
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-kimi/style_blueprint.md
+   ```
+2. Invoke the existing chapter-review recipe via the mini-ork framework. The output is `chapter-review.json` written to a sub-run dir; copy that to `critiques/critique-kimi.json`.
+3. The 4 critique-fanout nodes run in parallel; each writes its own per-writer critique file.
+
+## Critical rule
+
+Do NOT re-implement chapter-review logic here. Recursively call the existing recipe — the whole point is that compound REUSES chapter-review's panel infrastructure verbatim, so any improvements to chapter-review automatically benefit compound.
+
+## Cost discipline
+
+- Each critique-fanout node = 1 chapter-review run = ~$0.10-0.30 in LLM spend.
+- 4 critique-fanout nodes total = $0.40-1.20 per chapter for the critique matrix.

--- a/recipes/chapter-compound/prompts/critique-fanout-opus.md
+++ b/recipes/chapter-compound/prompts/critique-fanout-opus.md
@@ -1,0 +1,37 @@
+# Critique — chapter-review pass on the OPUS writer's draft
+
+You are running the **chapter-review** recipe against ONE specific writer's draft. Your inputs are different from a standalone chapter-review run because the chapter under review is the per-writer draft, not a pre-existing chapter file.
+
+## Inputs
+
+- `${MINI_ORK_RUN_DIR}/drafts/draft-opus.md` — the chapter draft to critique (OPUS writer's output).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — reuse the context shape that chapter-review expects.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — style reference.
+
+## Your output
+
+Write the chapter-review JSON to:
+- `${MINI_ORK_RUN_DIR}/critiques/critique-opus.json`
+
+The JSON MUST conform exactly to the `ChapterReviewJson` schema-guard at `libwit/shared/types/chapterReview.ts:isChapterReviewJson` (same shape that the existing `chapter-review` recipe emits at `${MINI_ORK_RUN_DIR}/chapter-review.json`). Compound's `chapter-compound.json` schema-guard `isChapterCompoundJson` validates the `critique_cells[*].critique` field by recursing into `isChapterReviewJson`.
+
+## Process
+
+1. Stage the draft as the `chapter.md` input that chapter-review expects:
+   ```bash
+   mkdir -p ${MINI_ORK_RUN_DIR}/chapter-review-inputs-opus
+   cp ${MINI_ORK_RUN_DIR}/drafts/draft-opus.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-opus/chapter.md
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json ${MINI_ORK_RUN_DIR}/chapter-review-inputs-opus/context.json
+   cp ${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md ${MINI_ORK_RUN_DIR}/chapter-review-inputs-opus/style_blueprint.md
+   ```
+2. Invoke the existing chapter-review recipe via the mini-ork framework. The output is `chapter-review.json` written to a sub-run dir; copy that to `critiques/critique-opus.json`.
+3. The 4 critique-fanout nodes run in parallel; each writes its own per-writer critique file.
+
+## Critical rule
+
+Do NOT re-implement chapter-review logic here. Recursively call the existing recipe — the whole point is that compound REUSES chapter-review's panel infrastructure verbatim, so any improvements to chapter-review automatically benefit compound.
+
+## Cost discipline
+
+- Each critique-fanout node = 1 chapter-review run = ~$0.10-0.30 in LLM spend.
+- 4 critique-fanout nodes total = $0.40-1.20 per chapter for the critique matrix.

--- a/recipes/chapter-compound/prompts/revise-loop.md
+++ b/recipes/chapter-compound/prompts/revise-loop.md
@@ -1,0 +1,99 @@
+# Revise loop — apply focused patches up to N iterations, re-critique, exit on pass
+
+You run the post-selection revise loop. Read the selected draft + its critique, apply patches via Opus, re-critique with a single Opus reviewer, exit when `passed === true` OR iteration cap reached.
+
+## Inputs
+
+- `${MINI_ORK_RUN_DIR}/winning-draft.md` — the selected draft (copied by selector).
+- `${MINI_ORK_RUN_DIR}/critiques/critique-<selected_lens>.json` — its critique (selected_lens read from selection.json).
+- `${MINI_ORK_RUN_DIR}/selection.json` — selector output (carries `selected_lens`).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — carries `max_revise_iterations` (default 2 if absent).
+
+## Loop algorithm
+
+```
+current_markdown   = read(winning-draft.md)
+driving_critique   = read(critiques/critique-<selected_lens>.json)
+iteration          = 1
+revisions          = []
+
+while iteration <= max_revise_iterations:
+  # ── Revise pass (Opus, PATCH-ONLY) ──
+  # Apply fragment_suggestions to the markdown — DO NOT rewrite prose
+  # outside the named patches. Use the libwit chapter-revise prompt
+  # conventions (verify-first sentence on iter ≥ 2):
+  if iteration >= 2:
+    prefix = "Before making any changes, first verify whether your previous answer is correct. "
+  else:
+    prefix = ""
+  revised_markdown = opus_revise(
+    current_markdown,
+    driving_critique.fragment_suggestions,
+    prefix + "PATCH-ONLY: apply only the named patches; do not rewrite surrounding prose."
+  )
+
+  # ── Re-critique pass (single Opus) ──
+  post_critique = opus_critique(revised_markdown, context)
+
+  # Record this iteration
+  revisions.append({
+    "iteration": iteration,
+    "before_markdown": current_markdown,
+    "after_markdown": revised_markdown,
+    "driving_critique": driving_critique,
+    "post_critique": post_critique,
+    "passed": post_critique.overall_verdict == "ACCEPT" || mean(post_critique.axes[*].score) >= 7.5,
+    "duration_ms": ...,
+    "cost_usd": ...
+  })
+
+  current_markdown = revised_markdown
+
+  if revisions[-1].passed:
+    break
+
+  # Next iteration uses the post_critique as the new driver
+  driving_critique = post_critique
+  iteration += 1
+```
+
+## Your output
+
+Write `${MINI_ORK_RUN_DIR}/revisions.json`:
+
+```json
+[
+  {
+    "iteration": 1,
+    "before_markdown": "<full markdown string>",
+    "after_markdown": "<full markdown string>",
+    "driving_critique": { /* full ChapterReviewJson */ },
+    "post_critique":    { /* full ChapterReviewJson */ },
+    "passed": true,
+    "duration_ms": 12345,
+    "cost_usd": 0.18
+  }
+  // ... per-iteration entries up to max_revise_iterations
+]
+```
+
+And the FINAL chapter markdown to `${MINI_ORK_RUN_DIR}/final-chapter.md` — this is what the publisher embeds in `chapter-compound.json.final_markdown`.
+
+## Zero-revisions case (loop never enters)
+
+If `max_revise_iterations === 0` OR the selected draft's critique already has `overall_verdict === "ACCEPT"` AND `mean(axes[*].score) >= 7.5`:
+- Write an empty array `[]` to revisions.json
+- Copy winning-draft.md verbatim to final-chapter.md
+- Set `revised: false` in the chapter-compound.json (the publisher node handles this)
+
+## Hard constraints
+
+- `iteration` MUST start at 1 (the schema-guard rejects iteration < 1).
+- `passed` MUST be a strict boolean.
+- `driving_critique` + `post_critique` MUST conform to ChapterReviewJson schema (the compound schema-guard recurses).
+- DO NOT rewrite prose outside the patches in fragment_suggestions — patch-only contract.
+
+## Cost discipline
+
+- Each iteration ≈ 2 Opus calls (revise + critique). 2 iterations max = ~4 Opus calls = $0.10-0.40.
+- Total compound cost target: $0.50-1.50 per chapter.

--- a/recipes/chapter-compound/prompts/select-best.md
+++ b/recipes/chapter-compound/prompts/select-best.md
@@ -1,0 +1,69 @@
+# Selector — pick the winning draft via deterministic weighting
+
+You compose the 4 critique cells into a single selection decision + selection.json artifact. The selection is DETERMINISTIC (pure function of the critique outputs); your job is to compute the scores correctly + write the selection rationale.
+
+## Inputs
+
+Read all 4 critique cells:
+- `${MINI_ORK_RUN_DIR}/critiques/critique-glm.json`
+- `${MINI_ORK_RUN_DIR}/critiques/critique-kimi.json`
+- `${MINI_ORK_RUN_DIR}/critiques/critique-codex.json`
+- `${MINI_ORK_RUN_DIR}/critiques/critique-opus.json`
+
+And the matching drafts:
+- `${MINI_ORK_RUN_DIR}/drafts/draft-glm.md`
+- `${MINI_ORK_RUN_DIR}/drafts/draft-kimi.md`
+- `${MINI_ORK_RUN_DIR}/drafts/draft-codex.md`
+- `${MINI_ORK_RUN_DIR}/drafts/draft-opus.md`
+
+## Scoring formula (DETERMINISTIC)
+
+For each draft D with critique C(D):
+
+```
+mean_axis_score(D)     = average of C(D).axes[*].score
+panel_disagreement(D)  = C(D).panel_disagreement_score
+accepted_count         = number of drafts where the corresponding writer
+                         had accepted_for_review == true (computed from the
+                         draft-side metadata; default 1 if not tracked)
+
+composite_score(D) = mean_axis_score(D)
+                   × (1 - panel_disagreement(D))
+                   × (1 + log(accepted_count))
+```
+
+Pick the draft with the highest `composite_score`. Tie-break by:
+1. Higher `mean_axis_score`
+2. Lower `panel_disagreement`
+3. Alphabetical lens order (codex < glm < kimi < opus) — stable for reproducibility
+
+## Your output
+
+Write `${MINI_ORK_RUN_DIR}/selection.json`:
+
+```json
+{
+  "selected_lens": "glm|kimi|codex|opus",
+  "selection_strategy": "deterministic_weighted",
+  "rationale": "One paragraph (≤ 200 words) explaining: (a) which lens won, (b) what its strongest axes were per the critique, (c) what the runner-up was and what tipped the decision",
+  "candidate_scores": [
+    { "lens": "glm",   "mean_axis_score": 0.0, "panel_disagreement": 0.0, "composite_score": 0.0 },
+    { "lens": "kimi",  "mean_axis_score": 0.0, "panel_disagreement": 0.0, "composite_score": 0.0 },
+    { "lens": "codex", "mean_axis_score": 0.0, "panel_disagreement": 0.0, "composite_score": 0.0 },
+    { "lens": "opus",  "mean_axis_score": 0.0, "panel_disagreement": 0.0, "composite_score": 0.0 }
+  ]
+}
+```
+
+Then COPY the winning draft to `${MINI_ORK_RUN_DIR}/winning-draft.md` — the revise-loop node reads from there.
+
+## Hard constraints
+
+- `selection_strategy` MUST be exactly `"deterministic_weighted"` (the v1.0 schema-guard rejects other values).
+- `candidate_scores` MUST contain entries for all 4 lenses, even those rejected.
+- `selected_lens` MUST be one of the 4 lens family names exactly.
+- DO NOT use LLM judgment to override the deterministic score — your job is to compute + justify, not to second-guess.
+
+## Cost discipline
+
+- This is a synthesis node, not a generation node. Small LLM call: read 4 small JSONs, compute scores, write rationale. Target < 1000 output tokens.

--- a/recipes/chapter-compound/prompts/writer-codex.md
+++ b/recipes/chapter-compound/prompts/writer-codex.md
@@ -1,0 +1,42 @@
+# Writer — Codex lens (factuality + technical accuracy first)
+
+You are the **technical-accuracy-focused writer**. Your goal is to draft a complete chapter that earns a high `C5_factuality_citations` + `C6_technical_accuracy` score on the 9-axis chapter-review rubric.
+
+## Inputs
+
+Read every file below before writing:
+
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_contract.json` — full ChapterWritingContract. **You MUST honour every constraint.**
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/evidence_pack.md` — pre-fetched evidence bundle. **Every claim must trace to a specific evidence item; no out-of-bank citations.**
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_outline.md` — chapter plan + key topics.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — chapter_title, chapter_number, book_topic, audience, language, style_blueprint_summary.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — voice/tone reference (secondary signal for you).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/seed.md` — OPTIONAL warm-start.
+
+## Your output
+
+Write the full chapter markdown to:
+- `${MINI_ORK_RUN_DIR}/drafts/draft-codex.md`
+
+## Lens stance (what Codex optimises)
+
+You are the **rigorous engineer**. Your draft must:
+
+1. Open with H1 + a precise problem statement — what does this chapter actually claim, and why is the claim non-trivial.
+2. Inline citations for every quantitative claim, every API/SDK name, every algorithm description. Format: `[arXiv:<id>]` for papers, `[<file>:<line>]` for code references when relevant.
+3. Code examples (when present) MUST have language tags AND match prose description exactly. No pseudo-code that contradicts the prose.
+4. Math wrapped in `<math>...</math>` (inline) or `<displaymath>...</displaymath>` (block) per MARKDOWN_RENDERING_CONTRACT. No bare LaTeX in prose (the markdown emphasis parser interprets `_{ij}` as italic).
+5. Avoid hedging language ("might", "could potentially") for claims that have direct evidence; use it ONLY where the evidence pack itself hedges.
+6. Length: 4000-8000 words. Codex drafts tend to run dense — aim for 5000 lower-mid-target.
+
+## Hard constraints (verifier will fail if violated)
+
+- Output MUST be valid markdown per MARKDOWN_RENDERING_CONTRACT.
+- Every non-trivial factual claim MUST inline-cite — no claims without a `[arXiv:<id>]` or evidence-pack file reference.
+- Forbidden constructs from chapter_contract.forbidden_constructs MUST NOT appear.
+- Honour required_h2_count from chapter_contract exactly.
+
+## Cost discipline
+
+- Single-shot draft. No tool calls beyond reading staged inputs.
+- Target: ≤ 8000 output tokens.

--- a/recipes/chapter-compound/prompts/writer-glm.md
+++ b/recipes/chapter-compound/prompts/writer-glm.md
@@ -1,0 +1,41 @@
+# Writer — GLM lens (structure-first)
+
+You are the **structure-focused writer**. Your goal is to draft a complete chapter that earns a high `C1_structure_flow` + `C2_clarity_conciseness` + `C7_audience_fit` score on the 9-axis chapter-review rubric.
+
+## Inputs
+
+Read every file below before writing:
+
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_contract.json` — full ChapterWritingContract (required H2 count, genre rules, forbidden constructs, calibration bucket). **You MUST honour every constraint.**
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/evidence_pack.md` — pre-fetched evidence bundle. Cite from here ONLY; do not invent references.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_outline.md` — chapter plan summary + key topics.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — chapter_title, chapter_number, book_topic, audience, language, style_blueprint_summary, prior_chapters_outline.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — voice/tone reference (may be stub).
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/seed.md` — OPTIONAL warm-start markdown. If present, treat as DRAFT-1 to refine, NOT as final.
+
+## Your output
+
+Write the full chapter markdown to:
+- `${MINI_ORK_RUN_DIR}/drafts/draft-glm.md`
+
+## Lens stance (what GLM optimises)
+
+You are the **scaffolder**. Your draft must:
+
+1. Open with a single H1 matching the chapter title from context.json.
+2. Honour the exact `required_h2_count` from chapter_contract.json. Each H2 carries one load-bearing claim; each is followed by ≥ 2 paragraphs of body.
+3. Use signposting paragraphs at section transitions (e.g. "In the previous section we saw X. This section turns to Y because…").
+4. Match the calibration_bucket's voice register (oreilly_technical = clear instructive prose; practical_guide = task-first imperative; etc.).
+5. Verify outline coverage: every keyTopic in chapter_outline.md gets at least one H2 OR a dedicated subsection.
+6. Length: 4000-8000 words. Aim for 5500 mid-target.
+
+## Hard constraints (verifier will fail if violated)
+
+- Output MUST be valid markdown that the libwit reader's `parseMarkdownLines→buildHierarchy→flattenBlocksWithUuid` chain can decompose. No bare HTML except `<math>` / `<displaymath>` for LaTeX (per MARKDOWN_RENDERING_CONTRACT).
+- Every non-trivial factual claim MUST inline-cite the evidence pack with `[arXiv:<id>]` G-Cite token format.
+- Forbidden constructs from chapter_contract.forbidden_constructs MUST NOT appear.
+
+## Cost discipline
+
+- Single-shot draft. No tool calls beyond reading the staged input files.
+- Target: ≤ 8000 output tokens.

--- a/recipes/chapter-compound/prompts/writer-kimi.md
+++ b/recipes/chapter-compound/prompts/writer-kimi.md
@@ -1,0 +1,42 @@
+# Writer — Kimi lens (style + engagement first)
+
+You are the **voice-and-engagement-focused writer**. Your goal is to draft a complete chapter that earns a high `C3_style_voice` + `C4_engagement_pacing` + `C8_narrative_coherence` score on the 9-axis chapter-review rubric.
+
+## Inputs
+
+Read every file below before writing:
+
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_contract.json` — full ChapterWritingContract. **You MUST honour every constraint.**
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/evidence_pack.md` — pre-fetched evidence bundle. Cite from here ONLY.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_outline.md` — chapter plan + key topics.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — chapter_title, chapter_number, book_topic, audience, language, style_blueprint_summary, prior_chapters_outline.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — voice/tone reference. **Lean into this; it's your primary signal.**
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/seed.md` — OPTIONAL warm-start.
+
+## Your output
+
+Write the full chapter markdown to:
+- `${MINI_ORK_RUN_DIR}/drafts/draft-kimi.md`
+
+## Lens stance (what Kimi optimises)
+
+You are the **storyteller**. Your draft must:
+
+1. Open with a single H1 + a hook intro paragraph that grounds the reader in WHY this chapter matters (concrete scenario, surprising claim, or vivid analogy).
+2. Vary sentence length deliberately to control pacing — short crisp sentences for emphasis, longer ones for exposition.
+3. Use 2nd-person ("you") engagement consistent with the calibration_bucket (oreilly_technical leans 2nd-person; academic leans 3rd-person).
+4. Inline analogies and concrete examples — never present a concept abstractly without grounding it.
+5. Cross-reference prior chapters from prior_chapters_outline using their canonical titles, NOT raw chapter numbers, when the reference is narrative not structural.
+6. Length: 4000-8000 words. Aim for 5500 mid-target.
+
+## Hard constraints (verifier will fail if violated)
+
+- Output MUST be valid markdown per MARKDOWN_RENDERING_CONTRACT.
+- Every non-trivial factual claim MUST inline-cite via `[arXiv:<id>]`.
+- Forbidden constructs from chapter_contract.forbidden_constructs MUST NOT appear.
+- Honour required_h2_count from chapter_contract exactly.
+
+## Cost discipline
+
+- Single-shot draft. No tool calls beyond reading staged inputs.
+- Target: ≤ 8000 output tokens.

--- a/recipes/chapter-compound/prompts/writer-opus.md
+++ b/recipes/chapter-compound/prompts/writer-opus.md
@@ -1,0 +1,43 @@
+# Writer — Opus lens (originality + insight first)
+
+You are the **insight-and-originality-focused writer**. Your goal is to draft a complete chapter that earns a high `C9_originality_insight` score AND maintains acceptable scores across all other axes on the 9-axis chapter-review rubric.
+
+## Inputs
+
+Read every file below before writing:
+
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_contract.json` — full ChapterWritingContract. **You MUST honour every constraint.**
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/evidence_pack.md` — pre-fetched evidence bundle. Cite from here ONLY.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/chapter_outline.md` — chapter plan + key topics.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/context.json` — chapter_title, chapter_number, book_topic, audience, language, style_blueprint_summary, prior_chapters_outline.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/style_blueprint.md` — voice/tone reference.
+- `${MINI_ORK_RUN_DIR}/chapter-compound-inputs/seed.md` — OPTIONAL warm-start.
+
+## Your output
+
+Write the full chapter markdown to:
+- `${MINI_ORK_RUN_DIR}/drafts/draft-opus.md`
+
+## Lens stance (what Opus optimises)
+
+You are the **synthesis-and-insight author**. Your draft must:
+
+1. Open with H1 + a counter-intuitive observation or non-obvious framing that re-orients the reader's mental model.
+2. Identify and name at least one **cross-paper or cross-chapter pattern** that's not obvious from any single evidence item alone — make the connection explicit.
+3. Surface tensions or open questions where the evidence is genuinely ambiguous; don't paper over them.
+4. End with a "what this enables next" forward-pointer that connects to subsequent chapters or open research directions.
+5. Pacing balance: don't sacrifice C1-C8 axes for originality — the goal is the BEST overall draft, not just the most novel one.
+6. Length: 4000-8000 words. Aim for 6000 upper-mid-target — insight drafts justify a bit more space for the synthesis arc.
+
+## Hard constraints (verifier will fail if violated)
+
+- Output MUST be valid markdown per MARKDOWN_RENDERING_CONTRACT.
+- Every non-trivial factual claim MUST inline-cite via `[arXiv:<id>]`.
+- Forbidden constructs from chapter_contract.forbidden_constructs MUST NOT appear.
+- Honour required_h2_count from chapter_contract exactly.
+- Novel framing must still be grounded in the evidence pack — no speculation beyond what the citations support.
+
+## Cost discipline
+
+- Single-shot draft. No tool calls beyond reading staged inputs.
+- Target: ≤ 9000 output tokens.

--- a/recipes/chapter-compound/task_class.yaml
+++ b/recipes/chapter-compound/task_class.yaml
@@ -1,0 +1,54 @@
+name: chapter_compound
+version: "0.1.0"
+description: >
+  Multi-pass chapter writer: 4 heterogeneous LLM lenses (glm/kimi/codex/opus)
+  each draft the SAME chapter in parallel from a shared contract+evidence+outline,
+  then the 4-lens panel critique scores every draft, an Opus-meta synthesizer
+  selects the best via deterministic weighting, and a focused revise loop
+  (Opus-only, N iterations, default N=2) tightens the selected draft to
+  passing. Publishes chapter-compound.json carrying the final markdown,
+  selection rationale, and full audit-bundle of every pass.
+
+  Composes the existing chapter-review recipe (consumed via critique-fanout
+  per-draft) with a writer-fanout + selection + revise overlay. The output
+  artifact's per-cell critiques reuse chapter-review.json shape verbatim,
+  so any consumer already on chapter-review can recurse into compound's
+  critique_cells without schema work.
+
+# Canonical matcher shape (matches schemas/task_class.schema.json).
+matches:
+  keywords:
+    - chapter compound
+    - multi-pass writer
+    - compound writer
+    - 4-lens writer
+    - writer fanout
+    - parallel chapter drafts
+    - audit-bundle chapter
+    - book chapter compound
+    - chapter compound writer
+    - select best draft
+    - lens-diverse writer
+  regex: []
+
+artifact_contract_ref: artifact_contract.yaml
+default_workflow: workflow.yaml
+
+default_gates:
+  - budget_gate
+  - scope_gate
+
+risk_class: medium   # Writer fanout produces NEW content — not read-only.
+
+# Cost model (informational; budget_gate enforces).
+# 4 writers × $0.10-0.20 + 16 critique cells (4 chapter-review runs × 4 lenses
+# internal) × $0.05-0.10 + 1 selection ($0.01) + 2-3 revise × $0.05-0.20.
+cost_model:
+  min_usd: 1
+  max_usd: 5
+  per_writer_usd: 1
+  per_critique_run_usd: 1
+
+runtime_model:
+  min_minutes: 5
+  max_minutes: 25

--- a/recipes/chapter-compound/verifiers/schema.sh
+++ b/recipes/chapter-compound/verifiers/schema.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# verifiers/schema.sh - verify chapter-compound.json syntax and strict shape.
+#
+# Inputs (via env):
+#   MINI_ORK_RUN_DIR - run directory (set by mini-ork-execute)
+#
+# Output: JSON to stdout
+#   { "verifier": "schema", "pass": bool, "evidence_path": "...",
+#     "checks_run": [...], "failed_checks": [...] }
+# Exit codes: always 0 (caller reads .pass from JSON).
+#
+# Schema source-of-truth: libwit/shared/types/chapterCompound.ts:isChapterCompoundJson
+# Drift between this verifier and the TS guard will cause silent persistence
+# of malformed artifacts — keep both in lockstep.
+
+set -uo pipefail
+
+RUN_DIR="${MINI_ORK_RUN_DIR:?MINI_ORK_RUN_DIR required}"
+EVIDENCE="$RUN_DIR/verifier-schema.log"
+exec 3>"$EVIDENCE"
+
+TARGET="$RUN_DIR/chapter-compound.json"
+
+checks_run=()
+failed_checks=()
+
+_check() {
+  local id="$1" expr_desc="$2" cond="$3"
+  checks_run+=("$id")
+  echo "[$id] $expr_desc" >&3
+  if eval "$cond" >&3 2>&1; then
+    echo "  ok" >&3
+  else
+    echo "  FAIL" >&3
+    failed_checks+=("$id")
+  fi
+}
+
+_file_exists() {
+  [ -f "$TARGET" ]
+}
+
+_json_parses() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    json.load(f)
+PY
+}
+
+_top_level_shape() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+
+REQUIRED_TOP = {
+    "schema_version", "chapter_title", "chapter_number",
+    "drafts", "critique_cells", "selection", "revisions",
+    "final_markdown", "revised", "cost_summary", "total_duration_ms",
+}
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    data = json.load(f)
+
+missing = REQUIRED_TOP - set(data.keys())
+if missing:
+    sys.stderr.write(f"missing top-level keys: {sorted(missing)}\n")
+    sys.exit(1)
+
+if data["schema_version"] != "1.0.0":
+    sys.stderr.write(f"schema_version must be '1.0.0', got {data['schema_version']!r}\n")
+    sys.exit(1)
+
+if not isinstance(data["chapter_title"], str) or not data["chapter_title"].strip():
+    sys.stderr.write("chapter_title must be non-empty string\n")
+    sys.exit(1)
+
+cn = data["chapter_number"]
+if not isinstance(cn, int) or cn < 1:
+    sys.stderr.write(f"chapter_number must be int >= 1, got {cn!r}\n")
+    sys.exit(1)
+PY
+}
+
+_drafts_shape() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+LENSES = {"glm", "kimi", "codex", "opus"}
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+drafts = data.get("drafts", [])
+if not isinstance(drafts, list) or len(drafts) == 0:
+    sys.stderr.write("drafts must be non-empty list\n"); sys.exit(1)
+for d in drafts:
+    if not isinstance(d, dict):
+        sys.stderr.write(f"draft not dict: {d!r}\n"); sys.exit(1)
+    if d.get("lens") not in LENSES:
+        sys.stderr.write(f"draft.lens invalid: {d.get('lens')!r}\n"); sys.exit(1)
+    if not isinstance(d.get("markdown"), str):
+        sys.stderr.write("draft.markdown not str\n"); sys.exit(1)
+    for k in ("bytes", "duration_ms", "cost_usd"):
+        v = d.get(k)
+        if not isinstance(v, (int, float)) or v < 0:
+            sys.stderr.write(f"draft.{k} not non-neg number: {v!r}\n"); sys.exit(1)
+    if not isinstance(d.get("accepted_for_review"), bool):
+        sys.stderr.write("draft.accepted_for_review not bool\n"); sys.exit(1)
+PY
+}
+
+_critique_cells_shape() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+LENSES = {"glm", "kimi", "codex", "opus"}
+REVIEW_REQUIRED = {"schema_version", "chapter_title", "panel", "axes",
+                   "fragment_suggestions", "overall_verdict", "summary",
+                   "panel_disagreement_score"}
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+cells = data.get("critique_cells", [])
+if not isinstance(cells, list):
+    sys.stderr.write("critique_cells must be list\n"); sys.exit(1)
+for c in cells:
+    if c.get("writer_lens") not in LENSES:
+        sys.stderr.write(f"cell.writer_lens invalid\n"); sys.exit(1)
+    crit = c.get("critique", {})
+    missing = REVIEW_REQUIRED - set(crit.keys())
+    if missing:
+        sys.stderr.write(f"cell.critique missing keys: {sorted(missing)}\n"); sys.exit(1)
+    if crit.get("schema_version") != "1.0.0":
+        sys.stderr.write("cell.critique.schema_version must be '1.0.0'\n"); sys.exit(1)
+PY
+}
+
+_selection_shape() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+LENSES = {"glm", "kimi", "codex", "opus"}
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+sel = data.get("selection", {})
+if sel.get("selected_lens") not in LENSES:
+    sys.stderr.write(f"selection.selected_lens invalid: {sel.get('selected_lens')!r}\n"); sys.exit(1)
+if sel.get("selection_strategy") != "deterministic_weighted":
+    sys.stderr.write("selection.selection_strategy must be 'deterministic_weighted'\n"); sys.exit(1)
+if not isinstance(sel.get("rationale"), str) or not sel["rationale"].strip():
+    sys.stderr.write("selection.rationale must be non-empty\n"); sys.exit(1)
+cs = sel.get("candidate_scores", [])
+if not isinstance(cs, list):
+    sys.stderr.write("selection.candidate_scores not list\n"); sys.exit(1)
+for c in cs:
+    if c.get("lens") not in LENSES:
+        sys.stderr.write(f"candidate.lens invalid: {c.get('lens')!r}\n"); sys.exit(1)
+PY
+}
+
+_final_markdown_present() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+fm = data.get("final_markdown", "")
+if not isinstance(fm, str) or len(fm) == 0:
+    sys.stderr.write("final_markdown must be non-empty string\n"); sys.exit(1)
+if not isinstance(data.get("revised"), bool):
+    sys.stderr.write("revised must be bool\n"); sys.exit(1)
+PY
+}
+
+_cost_summary_shape() {
+  python3 - "$TARGET" <<'PY'
+import json, sys
+REQUIRED = {"total_usd", "writer_usd", "critique_usd", "selection_usd",
+            "revise_usd", "sandbox_spawns"}
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+cs = data.get("cost_summary", {})
+missing = REQUIRED - set(cs.keys())
+if missing:
+    sys.stderr.write(f"cost_summary missing: {sorted(missing)}\n"); sys.exit(1)
+for k, v in cs.items():
+    if not isinstance(v, (int, float)) or v < 0:
+        sys.stderr.write(f"cost_summary.{k} not non-neg number: {v!r}\n"); sys.exit(1)
+td = data.get("total_duration_ms")
+if not isinstance(td, (int, float)) or td < 0:
+    sys.stderr.write(f"total_duration_ms not non-neg number: {td!r}\n"); sys.exit(1)
+PY
+}
+
+# Run all checks
+_check "S1" "chapter-compound.json exists"        "_file_exists"
+_check "S2" "chapter-compound.json parses as JSON" "_json_parses"
+_check "S3" "top-level shape + schema_version + chapter_title/_number" "_top_level_shape"
+_check "S4" "drafts array shape (lens + markdown + bytes + costs)" "_drafts_shape"
+_check "S5" "critique_cells nest valid ChapterReviewJson"  "_critique_cells_shape"
+_check "S6" "selection shape (deterministic_weighted + lens + candidates)" "_selection_shape"
+_check "S7" "final_markdown non-empty + revised bool"      "_final_markdown_present"
+_check "S8" "cost_summary 6 fields + total_duration_ms"     "_cost_summary_shape"
+
+exec 3>&-
+
+if [ ${#failed_checks[@]} -eq 0 ]; then
+  pass="true"
+else
+  pass="false"
+fi
+
+# Emit JSON result
+python3 - "$pass" "$EVIDENCE" "${checks_run[*]}" "${failed_checks[*]}" <<'PY'
+import json, sys
+pass_str, evidence, checks_run_str, failed_str = sys.argv[1:5]
+out = {
+    "verifier": "schema",
+    "pass": pass_str == "true",
+    "evidence_path": evidence,
+    "checks_run": checks_run_str.split() if checks_run_str else [],
+    "failed_checks": failed_str.split() if failed_str else [],
+}
+print(json.dumps(out))
+PY

--- a/recipes/chapter-compound/verifiers/writer-completeness.sh
+++ b/recipes/chapter-compound/verifiers/writer-completeness.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# verifiers/writer-completeness.sh - verify writer fanout + critique matrix coverage.
+#
+# Inputs (via env):
+#   MINI_ORK_RUN_DIR - run directory (set by mini-ork-execute)
+#
+# Output: JSON to stdout
+#   { "verifier": "writer-completeness", "pass": bool, "evidence_path": "...",
+#     "checks_run": [...], "failed_checks": [...] }
+# Exit codes: always 0 (caller reads .pass from JSON).
+#
+# Asserts:
+#   1. All 4 writer-lens drafts exist + non-empty
+#   2. All 4 critique cells exist + each is valid chapter-review.json shape
+#   3. Selection JSON exists + points at one of the 4 lenses
+#   4. Selected draft is the one whose markdown appears in final_markdown
+#      (OR matches revisions[0].before_markdown if revisions present)
+#   5. cost_summary.sandbox_spawns matches observed (drafts.length +
+#      critique_cells.length + 1 selector + revisions.length)
+
+set -uo pipefail
+
+RUN_DIR="${MINI_ORK_RUN_DIR:?MINI_ORK_RUN_DIR required}"
+EVIDENCE="$RUN_DIR/verifier-writer-completeness.log"
+exec 3>"$EVIDENCE"
+
+COMPOUND="$RUN_DIR/chapter-compound.json"
+DRAFT_GLM="$RUN_DIR/drafts/draft-glm.md"
+DRAFT_KIMI="$RUN_DIR/drafts/draft-kimi.md"
+DRAFT_CODEX="$RUN_DIR/drafts/draft-codex.md"
+DRAFT_OPUS="$RUN_DIR/drafts/draft-opus.md"
+CRIT_GLM="$RUN_DIR/critiques/critique-glm.json"
+CRIT_KIMI="$RUN_DIR/critiques/critique-kimi.json"
+CRIT_CODEX="$RUN_DIR/critiques/critique-codex.json"
+CRIT_OPUS="$RUN_DIR/critiques/critique-opus.json"
+SEL="$RUN_DIR/selection.json"
+
+checks_run=()
+failed_checks=()
+
+_check() {
+  local id="$1" expr_desc="$2" cond="$3"
+  checks_run+=("$id")
+  echo "[$id] $expr_desc" >&3
+  if eval "$cond" >&3 2>&1; then
+    echo "  ok" >&3
+  else
+    echo "  FAIL" >&3
+    failed_checks+=("$id")
+  fi
+}
+
+_all_drafts_exist_nonempty() {
+  for f in "$DRAFT_GLM" "$DRAFT_KIMI" "$DRAFT_CODEX" "$DRAFT_OPUS"; do
+    if [ ! -s "$f" ]; then
+      echo "missing or empty: $f"
+      return 1
+    fi
+  done
+  return 0
+}
+
+_all_critique_cells_valid_json() {
+  python3 - "$CRIT_GLM" "$CRIT_KIMI" "$CRIT_CODEX" "$CRIT_OPUS" <<'PY'
+import json, sys
+REQUIRED = {"schema_version", "chapter_title", "panel", "axes",
+            "fragment_suggestions", "overall_verdict", "summary",
+            "panel_disagreement_score"}
+for path in sys.argv[1:]:
+    try:
+        with open(path) as f:
+            d = json.load(f)
+    except Exception as e:
+        sys.stderr.write(f"critique cell parse fail at {path}: {e}\n"); sys.exit(1)
+    missing = REQUIRED - set(d.keys())
+    if missing:
+        sys.stderr.write(f"critique cell {path} missing {sorted(missing)}\n"); sys.exit(1)
+    if d.get("schema_version") != "1.0.0":
+        sys.stderr.write(f"critique cell {path} schema_version != 1.0.0\n"); sys.exit(1)
+PY
+}
+
+_selection_points_at_a_lens() {
+  python3 - "$SEL" <<'PY'
+import json, sys
+LENSES = {"glm", "kimi", "codex", "opus"}
+with open(sys.argv[1]) as f:
+    s = json.load(f)
+if s.get("selected_lens") not in LENSES:
+    sys.stderr.write(f"selection.selected_lens not in 4 lenses\n"); sys.exit(1)
+if s.get("selection_strategy") != "deterministic_weighted":
+    sys.stderr.write(f"selection.selection_strategy not deterministic_weighted\n"); sys.exit(1)
+PY
+}
+
+_sandbox_spawn_count_consistent() {
+  python3 - "$COMPOUND" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+drafts_n   = len(d.get("drafts", []))
+critiques_n= len(d.get("critique_cells", []))
+revs_n     = len(d.get("revisions", []))
+# selector + N revise iterations + 1 publisher prep
+# expected: drafts + critiques + 1 selector + revs + 1 prep
+expected_min = drafts_n + critiques_n + 1 + max(revs_n, 0) + 1
+spawns = d.get("cost_summary", {}).get("sandbox_spawns", 0)
+if spawns < expected_min - 2:
+    sys.stderr.write(f"sandbox_spawns={spawns} less than expected_min={expected_min}\n"); sys.exit(1)
+PY
+}
+
+_final_markdown_matches_a_draft_or_revision() {
+  python3 - "$COMPOUND" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+final = d.get("final_markdown", "")
+revs = d.get("revisions", [])
+drafts = d.get("drafts", [])
+selected_lens = d.get("selection", {}).get("selected_lens", "")
+if revs:
+    last = revs[-1].get("after_markdown", "")
+    if last == final:
+        return
+    sys.stderr.write("final_markdown != revisions[-1].after_markdown\n"); sys.exit(1)
+else:
+    for dr in drafts:
+        if dr.get("lens") == selected_lens and dr.get("markdown") == final:
+            return
+    sys.stderr.write(f"no draft for selected_lens={selected_lens} matches final_markdown\n"); sys.exit(1)
+PY
+}
+
+# Run all checks
+_check "W1" "all 4 writer drafts exist + non-empty"          "_all_drafts_exist_nonempty"
+_check "W2" "all 4 critique cells parse + valid chapter-review shape"  "_all_critique_cells_valid_json"
+_check "W3" "selection.json points at one of the 4 lenses"   "_selection_points_at_a_lens"
+_check "W4" "sandbox_spawn count consistent with drafts+critiques+revs" "_sandbox_spawn_count_consistent"
+_check "W5" "final_markdown matches selected draft OR last revision"    "_final_markdown_matches_a_draft_or_revision"
+
+exec 3>&-
+
+if [ ${#failed_checks[@]} -eq 0 ]; then
+  pass="true"
+else
+  pass="false"
+fi
+
+python3 - "$pass" "$EVIDENCE" "${checks_run[*]}" "${failed_checks[*]}" <<'PY'
+import json, sys
+pass_str, evidence, checks_run_str, failed_str = sys.argv[1:5]
+out = {
+    "verifier": "writer-completeness",
+    "pass": pass_str == "true",
+    "evidence_path": evidence,
+    "checks_run": checks_run_str.split() if checks_run_str else [],
+    "failed_checks": failed_str.split() if failed_str else [],
+}
+print(json.dumps(out))
+PY

--- a/recipes/chapter-compound/workflow.yaml
+++ b/recipes/chapter-compound/workflow.yaml
@@ -1,0 +1,86 @@
+version: "0.1.0"
+task_class: chapter_compound
+description: >
+  Multi-pass writer: 4 parallel writer lenses produce 4 drafts of the SAME
+  chapter from a shared contract, the chapter-review panel scores every
+  draft (4 critique cells), an Opus-meta synthesizer selects the best via
+  deterministic weighting, and a focused revise loop tightens it.
+  Publishes chapter-compound.json (libwit/shared/types/chapterCompound.ts
+  schema-guard contract).
+
+nodes:
+  # ── Writer fanout (4 parallel) ──────────────────────────────────────
+  # Each lens drafts the SAME chapter from the shared contract+evidence+outline.
+  # Same lens family as chapter-review so the per-cell critiques can reuse
+  # chapter-review's scoring matrix directly.
+  - { name: writer_glm,    type: researcher, model_lane: glm_lens,    prompt_ref: prompts/writer-glm.md,    dispatch_mode: parallel, gates: [budget_gate] }
+  - { name: writer_kimi,   type: researcher, model_lane: kimi_lens,   prompt_ref: prompts/writer-kimi.md,   dispatch_mode: parallel, gates: [budget_gate] }
+  - { name: writer_codex,  type: researcher, model_lane: codex_lens,  prompt_ref: prompts/writer-codex.md,  dispatch_mode: parallel, gates: [budget_gate] }
+  - { name: writer_opus,   type: researcher, model_lane: opus_lens,   prompt_ref: prompts/writer-opus.md,   dispatch_mode: parallel, gates: [budget_gate] }
+
+  # ── Critique fanout (4 parallel) ────────────────────────────────────
+  # One critique pass per draft. Each critique_fanout node invokes the
+  # 4-lens chapter-review panel internally — yielding 4 critique cells
+  # (one per writer-lens) where each cell carries the full
+  # chapter-review.json shape. Output: critique-<writer>.json.
+  - { name: critique_glm,    type: reviewer, model_lane: reviewer, prompt_ref: prompts/critique-fanout-glm.md,    dispatch_mode: parallel, gates: [budget_gate] }
+  - { name: critique_kimi,   type: reviewer, model_lane: reviewer, prompt_ref: prompts/critique-fanout-kimi.md,   dispatch_mode: parallel, gates: [budget_gate] }
+  - { name: critique_codex,  type: reviewer, model_lane: reviewer, prompt_ref: prompts/critique-fanout-codex.md,  dispatch_mode: parallel, gates: [budget_gate] }
+  - { name: critique_opus,   type: reviewer, model_lane: reviewer, prompt_ref: prompts/critique-fanout-opus.md,   dispatch_mode: parallel, gates: [budget_gate] }
+
+  # ── Selection (deterministic + Opus-meta rationale) ─────────────────
+  # Reads all 4 critique cells, computes:
+  #   composite_score(draft) = mean(axes.score)
+  #                          × (1 - panel_disagreement_score)
+  #                          × (1 + log(accepted_for_review_count))
+  # Picks winning draft, writes selection.json + winning-draft.md.
+  - { name: selector,    type: reviewer, model_lane: reviewer, prompt_ref: prompts/select-best.md,   dispatch_mode: serial, gates: [budget_gate] }
+
+  # ── Revise loop (Opus-only, iteration-bounded) ──────────────────────
+  # Applies fragment_suggestions from the selected draft's critique to the
+  # selected markdown. Re-critiques (single Opus) after each iteration;
+  # exit when post-critique.passed === true OR max_revise_iterations
+  # reached (from context.json, default 2). Writes revisions/iter-<N>.json
+  # per iteration + cumulative revisions.json.
+  - { name: revise_loop, type: reviewer, model_lane: reviewer, prompt_ref: prompts/revise-loop.md,   dispatch_mode: serial, gates: [budget_gate] }
+
+  # ── Verifiers ───────────────────────────────────────────────────────
+  - { name: schema_verifier,        type: verifier, verifier_ref: verifiers/schema.sh,              dispatch_mode: serial }
+  - { name: writer_completeness,    type: verifier, verifier_ref: verifiers/writer-completeness.sh, dispatch_mode: serial }
+
+  # ── Publisher commits chapter-compound.json; rollback on failure ───
+  - { name: publisher,   type: publisher, prompt_ref: null, dispatch_mode: serial, gates: [scope_gate] }
+  - { name: rollback,    type: rollback,  prompt_ref: null, dispatch_mode: serial }
+
+edges:
+  # Writers run in parallel from kickoff. Each critique consumes its
+  # corresponding writer's draft.
+  - { from: writer_glm,    to: critique_glm,   edge_type: supplies_context_to }
+  - { from: writer_kimi,   to: critique_kimi,  edge_type: supplies_context_to }
+  - { from: writer_codex,  to: critique_codex, edge_type: supplies_context_to }
+  - { from: writer_opus,   to: critique_opus,  edge_type: supplies_context_to }
+
+  # Selector waits for ALL critiques.
+  - { from: critique_glm,   to: selector, edge_type: supplies_context_to }
+  - { from: critique_kimi,  to: selector, edge_type: supplies_context_to }
+  - { from: critique_codex, to: selector, edge_type: supplies_context_to }
+  - { from: critique_opus,  to: selector, edge_type: supplies_context_to }
+
+  # Revise loop reads selector output.
+  - { from: selector, to: revise_loop, edge_type: supplies_context_to }
+
+  # Verifiers gate on revise_loop completion.
+  - { from: revise_loop, to: schema_verifier,     edge_type: verifies }
+  - { from: revise_loop, to: writer_completeness, edge_type: verifies }
+
+  # Publisher requires BOTH verifiers passing.
+  - { from: schema_verifier,     to: publisher, edge_type: depends_on }
+  - { from: writer_completeness, to: publisher, edge_type: depends_on }
+
+  # Rollback catches any failure.
+  - { from: publisher,            to: rollback, edge_type: escalates_to }
+  - { from: schema_verifier,      to: rollback, edge_type: escalates_to }
+  - { from: writer_completeness,  to: rollback, edge_type: escalates_to }
+
+rollback_strategy: keep_drafts_and_critiques_discard_synthesis
+max_self_correction_iterations: 2

--- a/recipes/framework-edit/prompts/planner.md
+++ b/recipes/framework-edit/prompts/planner.md
@@ -1,26 +1,114 @@
 # Planner Prompt
 
-You are planning a routine mini-ork framework edit.
+You are planning a routine mini-ork framework edit. Output strict JSON
+matching the schema below — the mini-ork-plan validator parses your
+output with `json.load()` and rejects anything that does not contain
+a non-empty `verifier_contract.checks` array.
 
 Inputs:
-- Natural-language change request.
+- Natural-language change request (kickoff body).
 - Optional file-glob hint that narrows the affected subtree.
 - Any explicit `scope_allow` override for high-blast-radius files.
 
 Kickoff content:
+
 ```text
 {{KICKOFF_CONTENT}}
 ```
 
-Produce a concise plan with:
-1. Requested outcome in one sentence.
-2. Candidate files or globs to inspect.
-3. Files explicitly out of scope.
-4. Expected verifier commands.
-5. Binding artifact manifest:
-   - `${MINI_ORK_RUN_DIR}/framework-edit.diff`
-   - `${MINI_ORK_RUN_DIR}/verdict.json`
-   - verdict schema: `{ "files_changed": number, "tests_pass": boolean, "static_pass": boolean, "pass": boolean }`
+## Required output shape
 
-Do not add recipe-authoring nodes. This is a code-edit recipe, not a drafter
-panel.
+Emit ONE JSON object on stdout. No markdown wrapper, no fenced code
+block around the JSON itself, no commentary before or after. Schema:
+
+```json
+{
+  "objective": "one-sentence requested outcome",
+  "assumptions": [
+    "any kickoff assumption worth recording"
+  ],
+  "candidate_files": [
+    "concrete paths or globs the implementer will edit or read"
+  ],
+  "out_of_scope": [
+    "files explicitly excluded by the kickoff"
+  ],
+  "decomposition": [
+    {
+      "id": "implementer",
+      "description": "produce the unified diff per the kickoff scope",
+      "node_type": "implementer",
+      "depends_on": []
+    }
+  ],
+  "artifact_contract": {
+    "outputs": [
+      "${MINI_ORK_RUN_DIR}/framework-edit.diff"
+    ]
+  },
+  "verifier_contract": {
+    "checks": [
+      {
+        "id": "diff_exists",
+        "description": "${MINI_ORK_RUN_DIR}/framework-edit.diff is non-empty"
+      },
+      {
+        "id": "diff_applies",
+        "description": "git apply --check succeeds against repo root"
+      },
+      {
+        "id": "shell_syntax_clean",
+        "description": "bash -n on every shell file in the diff"
+      },
+      {
+        "id": "python_compile_clean",
+        "description": "py_compile on every Python file in the diff"
+      }
+    ]
+  },
+  "risk_notes": [],
+  "pass": true
+}
+```
+
+## Rules
+
+- **`verifier_contract.checks` MUST contain at least one item.** The
+  validator rejects empty arrays with `missing_verifier_contract`.
+  Add one check row per success criterion in the kickoff. When the
+  kickoff lists explicit "verifier contract checks", port each one
+  into a `checks[]` row with a stable id + the bash command text in
+  the description.
+- **`decomposition[].node_type` MUST be one of**:
+  `planner | researcher | implementer | reviewer | verifier |
+   reflector | publisher | rollback`. Anything else fails the
+  D-008b validator.
+- **No placeholder values.** Strings wrapped in `<>` (e.g.
+  `"<TODO>"`) are rejected as `placeholder_plan`.
+- **Do NOT add recipe-authoring nodes.** This is a code-edit recipe,
+  not a drafter panel.
+- **Do NOT wrap the JSON in a markdown fence** like
+  ` ```json … ``` `. The validator reads stdin directly; a fence
+  prefix makes `json.load()` raise.
+
+## Binding artifact manifest
+
+The framework requires the implementer to produce:
+
+- `${MINI_ORK_RUN_DIR}/framework-edit.diff` — unified diff applying
+  cleanly to the repo root via `git apply`.
+
+The verifier nodes write `${MINI_ORK_RUN_DIR}/verdict.json` after
+checks complete:
+
+```json
+{
+  "files_changed": <int>,
+  "tests_pass": <bool>,
+  "static_pass": <bool>,
+  "pass": <bool>
+}
+```
+
+The implementer does NOT write `verdict.json` (D-13/2026 fix at
+commit `ab781a9`); only verifiers do.


### PR DESCRIPTION
Multi-pass capsule pattern at scale: 4 lens writers (glm/kimi/codex/opus) draft same chapter in parallel from shared contract → chapter-review recipe scores every draft (4×4 critique matrix) → deterministic selector picks best → Opus-only revise loop tightens it → publisher emits chapter-compound.json audit-bundle.

Contract source-of-truth: libwit/shared/types/chapterCompound.ts:isChapterCompoundJson. Cost ~$0.50-1.50/chapter, ~13 sandboxes, 3-8 min wall.

Activation in libwit (after this lands):
1. Bump MINIORK_REPO_SHA in libwit/server/resources/daytona/build-snapshots.ts
2. npx tsx server/resources/daytona/build-snapshots.ts --miniork-only
3. kubectl set env … FEATURE_CHAPTER_COMPOUND_WRITER=true

Composes with: existing chapter-review recipe (invoked per-draft via recursive call from critique-fanout-* prompts); libwit PR #33 scaffold; libwit kickoff doc at docs/book_gen/handoffs/20260614-2200-upstream-miniork-chapter-compound-recipe-kickoff.md.

Branch includes one concurrent-session commit (24364c0 framework-edit planner JSON fix) that landed during the same window; per researcher repo concurrent-session etiquette, kept as-is rather than untangling.