### PR TITLE
feat(events): MINI_ORK_ON_EVENT outbound callback hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Add your own under `recipes/<name>/` — see [docs/EXTENSION.md](docs/EXTENSION.
 
 ---
 
-## 4 Extension Points
+## 5 Extension Points
 
 Extensions do not require forking the framework. See [docs/EXTENSION.md](docs/EXTENSION.md) for full examples.
 
@@ -374,6 +374,7 @@ Extensions do not require forking the framework. See [docs/EXTENSION.md](docs/EX
 2. **AgentRegistry** — register new roles or model bindings via `lib/agent_registry.sh:agent_register`. No code change.
 3. **VerifierRegistry** — drop a `<name>.sh` script under `${MINI_ORK_HOME}/verifiers/` or `recipes/<recipe>/verifiers/` and reference it in `workflow.yaml`.
 4. **ExperienceMemory** — add new namespaces via DB migrations or override `lib/context_assembler.sh` per task class.
+5. **EventHooks** — point `MINI_ORK_ON_EVENT` at any executable to receive push notifications on every node lifecycle / recursive child-run event. Reference handlers under `examples/event-hooks/` (FIFO, HTTP webhook, JSONL log). See [docs/EVENT-HOOKS.md](docs/EVENT-HOOKS.md).
 
 Embedding from Python is first-class too — `MiniOrk().run(RunRequest(...))` with typed specs: [docs/PYTHON_FRAMEWORK.md](docs/PYTHON_FRAMEWORK.md).
 

--- a/docs/EVENT-HOOKS.md
+++ b/docs/EVENT-HOOKS.md
@@ -1,0 +1,135 @@
+# Event Hooks — pushing mini-ork events out to external observers
+
+Mini-ork writes lifecycle events to the `run_events` table on every node
+start / end / heartbeat and every child-run state change. The native
+read path is pull-based: dashboards SELECT from `run_events`, supervisors
+`tail -F` log files. For real-time push to chat bots, agent supervisors,
+incident systems, or live dashboards, point `MINI_ORK_ON_EVENT` at a
+shell command and mini-ork will fire it best-effort after every event
+write.
+
+## The contract
+
+```bash
+export MINI_ORK_ON_EVENT=/abs/path/to/hook.sh
+```
+
+After every successful DB write of an event, mini-ork invokes:
+
+```bash
+"$MINI_ORK_ON_EVENT" "<event_type>" "<run_id>" "<payload_json>"
+```
+
+| Arg | Type | Examples |
+|---|---|---|
+| `event_type` | string | `node_start`, `node_end`, `node_heartbeat`, `child.started`, `child.completed`, `child.failed` |
+| `run_id` | string | `run-1781509524-39638` |
+| `payload_json` | JSON string | `{"node_id":"planner","node_type":"planner"}` |
+
+Hard guarantees:
+
+- **Non-blocking dispatch**: the hook is invoked with a 5-second timeout
+  (`gtimeout 5` / `timeout 5`). A slow or dead hook cannot wedge mini-ork.
+- **Errors swallowed**: non-zero exit, missing binary, syntax errors —
+  all silently ignored. Observability must never break dispatch.
+- **Best-effort fire-and-forget**: the hook IS NOT a transactional sink.
+  If the hook crashes after the DB write, the event row still exists for
+  pull-side recovery.
+
+## Reference handlers
+
+Three example hooks ship under `examples/event-hooks/`. Drop one in
+place and export `MINI_ORK_ON_EVENT` to get push delivery in under a
+minute.
+
+### 1. FIFO sink (one supervisor)
+
+```bash
+mkfifo /tmp/mini-ork.fifo
+export MINI_ORK_EVENT_FIFO=/tmp/mini-ork.fifo
+export MINI_ORK_ON_EVENT=$PWD/examples/event-hooks/fifo.sh
+
+# In another shell:
+tail -F /tmp/mini-ork.fifo | jq -c
+```
+
+Best for: a single supervisor process consuming events live. FIFO
+semantics drop events when no reader is attached.
+
+### 2. HTTP webhook (chat, dashboards, incidents)
+
+```bash
+export MINI_ORK_WEBHOOK_URL=https://your.dashboard/ingest
+export MINI_ORK_ON_EVENT=$PWD/examples/event-hooks/webhook.sh
+```
+
+Each event becomes:
+
+```http
+POST /ingest HTTP/1.1
+Content-Type: application/json
+
+{"event":"node_end","run":"run-1781509524-39638","payload":{...}}
+```
+
+Uses `curl` with a 4s connect + 4s total timeout. A dead URL cannot
+slow the dispatch loop.
+
+### 3. JSONL log (multi-consumer / replay)
+
+```bash
+export MINI_ORK_EVENT_LOG=$HOME/.mini-ork-events.jsonl
+export MINI_ORK_ON_EVENT=$PWD/examples/event-hooks/log.sh
+```
+
+Multiple readers can `tail -F` the same file concurrently. Line-atomic
+append works as long as events fit in PIPE_BUF (≥512 bytes).
+
+## Writing your own handler
+
+The contract is intentionally tiny — any executable that accepts
+`event_type run_id payload_json` as `$1 $2 $3` works.
+
+```bash
+#!/usr/bin/env bash
+# my-hook.sh
+case "$1" in
+  child.failed)
+    notify-send "mini-ork run $2 failed"
+    ;;
+  node_end)
+    echo "$3" | jq -r '.node_id' | xargs -I{} echo "node {} done"
+    ;;
+esac
+```
+
+```bash
+chmod +x my-hook.sh
+export MINI_ORK_ON_EVENT="$PWD/my-hook.sh"
+```
+
+## When to use SSE on `mini-ork serve` instead
+
+If you have multiple browser clients or want auto-reconnect /
+backpressure, run `mini-ork serve` and connect to its event stream
+(planned — see issue tracker). For shell-side supervisors and
+single-consumer pipelines, the `MINI_ORK_ON_EVENT` hook is simpler and
+zero-dep.
+
+## Event-type catalogue
+
+Stable event types as of this writing — see `lib/mo_node_events.sh` and
+`lib/recursive_orchestration.sh` for the canonical list.
+
+| Event | Source | When |
+|---|---|---|
+| `node_start` | `mo_node_emit` | a workflow node begins execution |
+| `node_end` | `mo_node_emit` | a workflow node finishes (success or fail) |
+| `node_heartbeat` | `mo_node_emit` | long-running node periodic ping |
+| `child.started` | `mo_recursive_emit_event` | a recursive child run begins |
+| `child.completed` | `mo_recursive_emit_event` | a recursive child run exits 0 |
+| `child.failed` | `mo_recursive_emit_event` | a recursive child run exits non-zero |
+
+Additional event types are written via the same path; the hook receives
+them transparently. Filter on `$1` in your handler for the events you
+care about.

--- a/examples/event-hooks/fifo.sh
+++ b/examples/event-hooks/fifo.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# examples/event-hooks/fifo.sh — push mini-ork events into a named pipe.
+#
+# Usage:
+#   mkfifo /tmp/mini-ork.fifo
+#   export MINI_ORK_EVENT_FIFO=/tmp/mini-ork.fifo
+#   export MINI_ORK_ON_EVENT=$PWD/examples/event-hooks/fifo.sh
+#
+# In another shell (or supervisor process):
+#   tail -F /tmp/mini-ork.fifo | jq -c
+#
+# Each event lands as one line:
+#   {"ts":"2026-06-15T09:47:00Z","event":"node_end","run":"run-...","payload":{...}}
+#
+# Best for: single supervisor consuming events live. Non-blocking write —
+# if no reader is attached the event is dropped (FIFO semantics).
+
+set -uo pipefail
+
+EVENT_TYPE="${1:-unknown}"
+RUN_ID="${2:-}"
+PAYLOAD="${3:-{\}}"
+FIFO="${MINI_ORK_EVENT_FIFO:-/tmp/mini-ork.fifo}"
+
+[ -p "$FIFO" ] || exit 0  # silent skip when no FIFO exists
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+LINE="{\"ts\":\"$TS\",\"event\":\"$EVENT_TYPE\",\"run\":\"$RUN_ID\",\"payload\":$PAYLOAD}"
+
+# Non-blocking write — if no reader, drop the event rather than wedge.
+printf '%s\n' "$LINE" >"$FIFO" 2>/dev/null &
+disown 2>/dev/null || true
+exit 0

--- a/examples/event-hooks/log.sh
+++ b/examples/event-hooks/log.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# examples/event-hooks/log.sh — append mini-ork events to a JSONL file.
+#
+# Usage:
+#   export MINI_ORK_EVENT_LOG=$HOME/.mini-ork-events.jsonl
+#   export MINI_ORK_ON_EVENT=$PWD/examples/event-hooks/log.sh
+#
+# Best for: offline replay, debugging, simple time-series export, multiple
+# concurrent readers via `tail -F`. Atomic line-append works as long as
+# each event fits in PIPE_BUF (≥512 bytes on every Unix).
+
+set -uo pipefail
+
+EVENT_TYPE="${1:-unknown}"
+RUN_ID="${2:-}"
+PAYLOAD="${3:-{\}}"
+LOG="${MINI_ORK_EVENT_LOG:-$HOME/.mini-ork-events.jsonl}"
+
+mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+printf '{"ts":"%s","event":"%s","run":"%s","payload":%s}\n' \
+  "$TS" "$EVENT_TYPE" "$RUN_ID" "$PAYLOAD" >>"$LOG" 2>/dev/null || true
+
+exit 0

--- a/examples/event-hooks/webhook.sh
+++ b/examples/event-hooks/webhook.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# examples/event-hooks/webhook.sh — POST mini-ork events to an HTTP URL.
+#
+# Usage:
+#   export MINI_ORK_WEBHOOK_URL=https://your.dashboard/ingest
+#   export MINI_ORK_ON_EVENT=$PWD/examples/event-hooks/webhook.sh
+#
+# Receiver gets POST {"event":"node_end","run":"...","payload":{...}}.
+# Best for: chat bots, dashboards, external incident systems.
+#
+# Uses curl with a 4s connect + 4s total timeout so a slow / dead URL
+# can't drag the dispatch loop down. Failures swallow silently.
+
+set -uo pipefail
+
+EVENT_TYPE="${1:-unknown}"
+RUN_ID="${2:-}"
+PAYLOAD="${3:-{\}}"
+URL="${MINI_ORK_WEBHOOK_URL:-}"
+
+[ -n "$URL" ] || exit 0
+command -v curl >/dev/null 2>&1 || exit 0
+
+BODY="{\"event\":\"$EVENT_TYPE\",\"run\":\"$RUN_ID\",\"payload\":$PAYLOAD}"
+
+curl -sS -o /dev/null \
+  --connect-timeout 4 \
+  --max-time 4 \
+  -H "Content-Type: application/json" \
+  -X POST -d "$BODY" "$URL" 2>/dev/null || true
+exit 0

--- a/lib/mo_emit_hook.sh
+++ b/lib/mo_emit_hook.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# lib/mo_emit_hook.sh — outbound event-callback hook.
+#
+# Purpose: turn mini-ork's DB-only event emission into a push channel for
+# external observers (dashboards, CI bridges, agent supervisors, chat bots,
+# anything that wants to react in real-time instead of polling
+# run_events / mo_events).
+#
+# The hook is a single shell command supplied via the MINI_ORK_ON_EVENT
+# env var. Mini-ork calls it best-effort after every DB write with three
+# positional args:
+#
+#   $1  event_type   e.g. "node_start" | "node_end" | "child.completed"
+#   $2  run_id       e.g. "run-1781509524-39638"
+#   $3  payload_json e.g. {"node_id":"planner","node_type":"planner"}
+#
+# Failure mode: any non-zero exit, timeout, or missing command is logged
+# to stderr and SWALLOWED. Observability must never break dispatch.
+#
+# Example use:
+#   export MINI_ORK_ON_EVENT="$HOME/.config/mini-ork/event-hook.sh"
+#   bin/mini-ork run code-fix kickoffs/my-fix.md
+#
+# Reference handlers live under examples/event-hooks/:
+#   - fifo.sh    — append to a named pipe; reader does `tail -F` or `cat`
+#   - webhook.sh — POST JSON to a URL; great for chat / dashboards
+#   - log.sh     — append to a JSONL file for offline replay
+#
+# See docs/EVENT-HOOKS.md for the full contract.
+
+# Internal: invoke the user's hook script with a hard timeout so a runaway
+# handler can't wedge a dispatch. Silent no-op when MINI_ORK_ON_EVENT
+# is unset.
+_mo_emit_hook() {
+  local hook="${MINI_ORK_ON_EVENT:-}"
+  [ -n "$hook" ] || return 0
+
+  local event_type="${1:-unknown}"
+  local run_id="${2:-}"
+  local payload_json="${3:-{\}}"
+
+  # Resolve to absolute path if it looks like a relative file ref.
+  if [[ "$hook" =~ ^[^/].*\.sh$ ]] && [ -f "$hook" ]; then
+    hook="$(cd "$(dirname "$hook")" && pwd)/$(basename "$hook")"
+  fi
+
+  # Hard-cap the hook at 5s — anything slower belongs in a daemon.
+  # gtimeout (GNU coreutils on macOS) preferred; fall back to timeout.
+  local timeout_bin=""
+  if command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin="gtimeout"
+  elif command -v timeout >/dev/null 2>&1; then
+    timeout_bin="timeout"
+  fi
+
+  if [ -n "$timeout_bin" ]; then
+    "$timeout_bin" 5 "$hook" "$event_type" "$run_id" "$payload_json" \
+      >/dev/null 2>&1 || true
+  else
+    "$hook" "$event_type" "$run_id" "$payload_json" \
+      >/dev/null 2>&1 || true
+  fi
+}

--- a/lib/mo_node_events.sh
+++ b/lib/mo_node_events.sh
@@ -100,6 +100,16 @@ try:
 finally:
     con.close()
 PY
+
+  # Outbound event-callback hook. Best-effort fire-and-forget; cannot
+  # block or fail the dispatch. Source guard avoids re-sourcing on every
+  # call when the caller already pulled the hook lib.
+  if ! declare -F _mo_emit_hook >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    . "$(dirname "${BASH_SOURCE[0]}")/mo_emit_hook.sh" 2>/dev/null || return 0
+  fi
+  _mo_emit_hook "$event_type" "$run_id" \
+    "{\"node_id\":\"$node_id\",\"node_type\":\"$node_type\"}"
 }
 
 # Convenience: emit node_start with model_lane payload.

--- a/lib/recursive_orchestration.sh
+++ b/lib/recursive_orchestration.sh
@@ -82,6 +82,13 @@ con.commit()
 con.close()
 print(event_id)
 PY
+
+  # Outbound event-callback hook. Best-effort; cannot block dispatch.
+  if ! declare -F _mo_emit_hook >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    . "$(dirname "${BASH_SOURCE[0]}")/mo_emit_hook.sh" 2>/dev/null || return 0
+  fi
+  _mo_emit_hook "$event_type" "$run_id" "$payload_json"
 }
 
 mo_recursive_approve_spawn() {


### PR DESCRIPTION
## Summary
- Adds a universal shell-side push channel: set `MINI_ORK_ON_EVENT` to any executable and mini-ork invokes it best-effort after every `run_events` write with `event_type`, `run_id`, `payload_json` positional args
- Non-blocking (5s timeout via gtimeout/timeout), errors swallowed, fire-and-forget — observability cannot break dispatch
- 3 reference handlers under `examples/event-hooks/`: FIFO sink, HTTP webhook, JSONL log
- Wire sites: `lib/mo_emit_hook.sh` (new helper), `lib/mo_node_events.sh` (after mo_node_emit DB insert), `lib/recursive_orchestration.sh` (after mo_recursive_emit_event DB insert)
- Full contract documented at `docs/EVENT-HOOKS.md`; README Extension Points updated to mention the 5th extension
- Backward compatible — `MINI_ORK_ON_EVENT` unset = silent no-op

## Test plan
- **Live smoke verified** in author's local checkout: `source lib/mo_node_events.sh; MINI_ORK_ON_EVENT=/tmp/probe.sh mo_node_emit run-x test-node implementer node_start '{}'` → hook fired with correct args + DB row materialized in parallel
- Syntax-checked: `bash -n` clean on all 4 lib/example scripts
- 7 files / +304 / -1 LOC total

## Replay smoke
```bash
HOOK=/tmp/probe.sh
cat > $HOOK <<'EOF'
#!/usr/bin/env bash
echo "FIRED event=$1 run=$2 payload=$3" >> /tmp/probe.log
EOF
chmod +x $HOOK
export MINI_ORK_ON_EVENT=$HOOK
bash -c 'source lib/mo_node_events.sh; mo_node_emit run-x node-y implementer node_end "{}"'
cat /tmp/probe.log
# Expect: FIRED event=node_end run=run-x payload={"node_id":"node-y","node_type":"implementer"}
```