### PR TITLE
fix(contextnest): restore PR #17 wiring dropped by PR #18 + add smoke harness

### DIFF
--- a/bin/mini-ork-plan
+++ b/bin/mini-ork-plan
@@ -186,6 +186,20 @@ if [ "${MO_INJECT_LEARNINGS:-1}" = "1" ] && [ -f "$MINI_ORK_ROOT/lib/context_ass
     _prior_block="$(context_prior_runs_md "${TASK_CLASS:-generic}" 5 || true)"
     [ -n "$_prior_block" ] && PROMPT_TEXT="${PROMPT_TEXT}"$'\n\n'"${_prior_block}"$'\n'
   fi
+  # ContextNest cross-session substrate. Surfaces atoms (decisions, learnings,
+  # risk_flags, prompt_directives) from prior Claude Code sessions — fresh
+  # data the local sqlite memory doesn't have. Gated by MO_DISABLE_CN=1 and
+  # silent when CN is unreachable so the planner never blocks on it.
+  # Restored 2026-06-16 after PR #18 silently dropped this wire-up
+  # (regression caught by scripts/smoke-cn-bridge.sh).
+  if declare -f context_contextnest_atoms_md >/dev/null 2>&1; then
+    _cn_atoms_block="$(context_contextnest_atoms_md "$KICKOFF" 6 || true)"
+    [ -n "$_cn_atoms_block" ] && PROMPT_TEXT="${PROMPT_TEXT}"$'\n\n'"${_cn_atoms_block}"$'\n'
+  fi
+  if declare -f context_contextnest_recent_sessions_md >/dev/null 2>&1; then
+    _cn_sess_block="$(context_contextnest_recent_sessions_md "$KICKOFF" 4 || true)"
+    [ -n "$_cn_sess_block" ] && PROMPT_TEXT="${PROMPT_TEXT}"$'\n\n'"${_cn_sess_block}"$'\n'
+  fi
   # ContextPack artifact: the full bounded bundle (prior runs, failure
   # modes, prefs, constraints — each item cite-tagged) persisted next to
   # plan.json. The md blocks above are what the prompt gets; this is the

--- a/hooks/subagent-spawn.sh
+++ b/hooks/subagent-spawn.sh
@@ -88,4 +88,16 @@ sqlite3 "$DB" "
      '$(esc_sql "$prompt_excerpt")', 'spawned', '$(esc_sql "$cwd")');
 " 2>/dev/null || true
 
+# Mirror to ContextNest so substrate sees mini-ork subagent spawns alongside
+# direct Claude Code sessions. Fire-and-forget; CN being down never blocks.
+# Restored 2026-06-16 after PR #18 silently dropped this hook augmentation
+# (regression caught by scripts/smoke-cn-bridge.sh).
+if [ -f "${MINI_ORK_ROOT}/lib/cn_client.sh" ]; then
+  # shellcheck source=../lib/cn_client.sh
+  source "${MINI_ORK_ROOT}/lib/cn_client.sh" 2>/dev/null || true
+  if declare -f cn_hook_post >/dev/null 2>&1; then
+    cn_hook_post "session_start" "miniork-spawn-${parent_session}-$(date +%s)" "$cwd" "" || true
+  fi
+fi
+
 emit_continue

--- a/hooks/subagent-stop.sh
+++ b/hooks/subagent-stop.sh
@@ -83,4 +83,20 @@ sqlite3 "$DB" "
   );
 " 2>/dev/null || true
 
+# Mirror to ContextNest so the child subagent's transcript is ingested into
+# the substrate. CN's /api/v1/cc/hook/subagent_stop tails the JSONL from the
+# last-known offset and extracts memories/features. Fire-and-forget.
+# Restored 2026-06-16 after PR #18 silently dropped this hook augmentation
+# (regression caught by scripts/smoke-cn-bridge.sh).
+if [ -f "${MINI_ORK_ROOT}/lib/cn_client.sh" ]; then
+  # shellcheck source=../lib/cn_client.sh
+  source "${MINI_ORK_ROOT}/lib/cn_client.sh" 2>/dev/null || true
+  if declare -f cn_hook_post >/dev/null 2>&1; then
+    transcript_path=$(extract_field "transcript_path")
+    [ -z "$transcript_path" ] && transcript_path=$(extract_field "transcript")
+    target_session="${child_session:-$parent_session}"
+    cn_hook_post "subagent_stop" "$target_session" "$PWD" "$transcript_path" || true
+  fi
+fi
+
 emit_continue

--- a/lib/context_assembler.sh
+++ b/lib/context_assembler.sh
@@ -423,6 +423,148 @@ if rows:
 PY
 }
 
+# desc: Emit ContextNest atoms as a compact markdown block suitable for
+#       direct prompt injection. Queries CN's /api/v1/tools/retrieve with
+#       text derived from the task brief; degrades silently when CN is
+#       down or MO_DISABLE_CN=1 (caller can append unconditionally).
+#
+#       Args:
+#         $1  task_brief_path  Path to brief JSON (read for title/description).
+#         $2  limit            Max atoms to surface (default 5).
+#
+#       Why this exists: mini-ork's planner has only ever seen
+#       local sqlite memory (task_memory + failure_memory). ContextNest
+#       carries the cross-session substrate fed by ALL Claude Code
+#       sessions in this install — fresh schema knowledge, recent
+#       feature deliveries, attention-inbox items. Without this fetch,
+#       the planner bakes outdated assumptions into plans (see chapter-
+#       anchor drift audit, 2026-06-15).
+#
+#       Restored 2026-06-16 after PR #18 silently dropped these functions
+#       while landing an unrelated feature stack (regression caught by
+#       scripts/smoke-cn-bridge.sh — see Smoke Test Standard in
+#       ContextNest's docs/roadmap/epics/agent-context-pack.md).
+context_contextnest_atoms_md() {
+  local task_brief_path="${1:?task_brief_path required}"
+  local limit="${2:-5}"
+  [ "${MO_DISABLE_CN:-0}" = "1" ] && return 0
+  [ -f "$task_brief_path" ] || return 0
+  [ -f "${MINI_ORK_ROOT}/lib/cn_client.sh" ] || return 0
+  # shellcheck source=cn_client.sh
+  source "${MINI_ORK_ROOT}/lib/cn_client.sh"
+  declare -f cn_retrieve >/dev/null 2>&1 || return 0
+  cn_available || return 0
+
+  # Build query from brief: prefer 'title' + first 200 chars of 'description'
+  # or 'objective'. Fall back to whole file content. The query is what
+  # CN's embedder sees, so more semantic context = better retrieval.
+  local query
+  query=$(python3 - "$task_brief_path" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        raw = f.read()
+    try:
+        d = json.loads(raw)
+    except Exception:
+        print(raw[:512].strip())
+        sys.exit(0)
+    parts = []
+    for k in ("title", "objective", "description", "task_class"):
+        v = d.get(k)
+        if isinstance(v, str) and v.strip():
+            parts.append(v.strip())
+    if not parts:
+        parts.append(raw[:512].strip())
+    print(" ".join(parts)[:600])
+except Exception:
+    pass
+PY
+)
+  [ -z "$query" ] && return 0
+  local hits_json
+  hits_json=$(cn_retrieve "$query" "$limit" 2>/dev/null) || return 0
+  cn_render_atoms_md "$hits_json" "$limit"
+}
+
+# desc: Emit a compact markdown block listing CN sessions that recently
+#       touched files relevant to the brief. Helps planner notice "this
+#       module was last edited 3 sessions ago for reason X" without
+#       reading git log. Args: $1 = brief path, $2 = max files to probe.
+context_contextnest_recent_sessions_md() {
+  local task_brief_path="${1:?task_brief_path required}"
+  local max_files="${2:-3}"
+  [ "${MO_DISABLE_CN:-0}" = "1" ] && return 0
+  [ -f "$task_brief_path" ] || return 0
+  [ -f "${MINI_ORK_ROOT}/lib/cn_client.sh" ] || return 0
+  # shellcheck source=cn_client.sh
+  source "${MINI_ORK_ROOT}/lib/cn_client.sh"
+  declare -f cn_sessions_by_file >/dev/null 2>&1 || return 0
+  cn_available || return 0
+
+  # Pull file hints from brief's 'files' or 'paths' array.
+  local files_csv
+  files_csv=$(python3 - "$task_brief_path" "$max_files" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        d = json.load(f)
+    max_files = int(sys.argv[2])
+    candidates = []
+    for k in ("files", "paths", "relevant_files", "targets"):
+        v = d.get(k)
+        if isinstance(v, list):
+            for item in v:
+                if isinstance(item, str):
+                    candidates.append(item)
+                elif isinstance(item, dict):
+                    p = item.get("path") or item.get("file") or item.get("name")
+                    if isinstance(p, str):
+                        candidates.append(p)
+    if candidates:
+        print(",".join(candidates[:max_files]))
+except Exception:
+    pass
+PY
+)
+  [ -z "$files_csv" ] && return 0
+  local any_output=0
+  local IFS=','
+  local f
+  for f in $files_csv; do
+    [ -z "$f" ] && continue
+    local resp
+    resp=$(cn_sessions_by_file "$f" 2>/dev/null) || continue
+    local rendered
+    rendered=$(python3 - "$resp" "$f" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+sessions = d.get("sessions") or d.get("hits") or []
+if not sessions:
+    sys.exit(0)
+print(f"- File `{sys.argv[2]}` recently touched in:")
+for s in sessions[:3]:
+    sid = s.get("session_id") or s.get("id", "")
+    ts = (s.get("last_seen") or s.get("ts") or "")[:10]
+    title = (s.get("title") or s.get("intent") or "").strip()[:80]
+    print(f"  - {sid[:8]} ({ts}) {title}")
+PY
+)
+    if [ -n "$rendered" ]; then
+      if [ "$any_output" -eq 0 ]; then
+        printf '%s\n' "--- ContextNest: recent sessions for relevant files ---"
+        any_output=1
+      fi
+      printf '%s\n' "$rendered"
+    fi
+  done
+  [ "$any_output" -eq 1 ] && printf '%s\n' "--- /ContextNest: recent sessions ---"
+  return 0
+}
+
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   echo "context_assembler.sh — source me and call context_assemble <task_brief_path> <node_name>"
 fi

--- a/scripts/smoke-cn-bridge.sh
+++ b/scripts/smoke-cn-bridge.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# scripts/smoke-cn-bridge.sh — reference smoke harness for the v1 CN bridge.
+#
+# Reference TEMPLATE every ContextNest <-> mini-ork PR must follow per
+# the Smoke Test Standard in ContextNest's
+# docs/roadmap/epics/agent-context-pack.md. It exercises the real system
+# end-to-end against a live ContextNest server and produces a human-
+# readable evidence file at tmp/smoke-evidence/cn-bridge-<timestamp>.md.
+#
+# Tests covered:
+#   1. Happy path: planner injection block contains real CN atoms
+#   2. Worker prefetch: file written + content non-empty
+#   3. CN-down: graceful degradation (planner finishes, empty CN block)
+#   4. MO_DISABLE_CN=1: zero CN calls
+#   5. CN-slow: silent no-op without crash
+#
+# Usage:
+#   bash scripts/smoke-cn-bridge.sh                       # default kickoff
+#   KICKOFF=kickoffs/<other>.md bash scripts/smoke-cn-bridge.sh
+#   CN_BASE_URL=http://localhost:28080 bash scripts/smoke-cn-bridge.sh
+#
+# Exit codes:
+#   0   all assertions passed
+#   1   one or more assertions failed (evidence file lists which)
+#   78  prerequisite missing (e.g. kickoff path, lib/cn_client.sh)
+#
+# Bash-only on purpose so any reviewer can read it without Rust/Python
+# tooling beyond what mini-ork already requires.
+
+set -uo pipefail
+
+MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+export MINI_ORK_ROOT
+CN_BASE_URL="${CN_BASE_URL:-http://127.0.0.1:28080}"
+export CN_BASE_URL
+KICKOFF="${KICKOFF:-${MINI_ORK_ROOT}/kickoffs/oracle-hardening-v03.md}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-${MINI_ORK_ROOT}/tmp/smoke-evidence}"
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+EVIDENCE="${EVIDENCE_DIR}/cn-bridge-${TS}.md"
+
+PASS=0
+FAIL=0
+mkdir -p "$EVIDENCE_DIR"
+
+_assert() {
+  local name="$1" expected="$2" actual="$3" verdict
+  if [[ "$actual" == *"$expected"* ]]; then
+    verdict="PASS"
+    PASS=$((PASS+1))
+  else
+    verdict="FAIL - expected substring not found"
+    FAIL=$((FAIL+1))
+  fi
+  {
+    printf '\n## Assertion: %s\n' "$name"
+    printf '**Expected substring:** `%s`\n' "$expected"
+    printf '**Actual (first 240 chars):** `%s`\n' "${actual:0:240}"
+    printf '**Verdict:** %s\n' "$verdict"
+  } >> "$EVIDENCE"
+}
+
+_assert_eq_int() {
+  local name="$1" expected="$2" actual="$3" verdict
+  if [[ "$actual" -eq "$expected" ]]; then
+    verdict="PASS"
+    PASS=$((PASS+1))
+  else
+    verdict="FAIL - expected $expected, got $actual"
+    FAIL=$((FAIL+1))
+  fi
+  {
+    printf '\n## Assertion: %s\n' "$name"
+    printf '**Expected:** %s\n' "$expected"
+    printf '**Actual:** %s\n' "$actual"
+    printf '**Verdict:** %s\n' "$verdict"
+  } >> "$EVIDENCE"
+}
+
+# Evidence header
+{
+  printf '# Smoke evidence: ContextNest <-> mini-ork v1 bridge\n'
+  printf '**Ran:** %s\n' "$TS"
+  printf '**Branch:** %s\n' "$(git -C "$MINI_ORK_ROOT" branch --show-current 2>/dev/null || echo unknown)"
+  printf '**Commit:** %s\n' "$(git -C "$MINI_ORK_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  printf '**CN url:** %s\n' "$CN_BASE_URL"
+  printf '**Kickoff:** %s\n' "$KICKOFF"
+} > "$EVIDENCE"
+
+# Prereq checks
+if [[ ! -f "$KICKOFF" ]]; then
+  echo "prereq missing: kickoff $KICKOFF" >&2; exit 78
+fi
+if ! command -v python3 >/dev/null && ! command -v jq >/dev/null; then
+  echo "prereq missing: jq or python3" >&2; exit 78
+fi
+if [[ ! -f "$MINI_ORK_ROOT/lib/cn_client.sh" ]]; then
+  echo "prereq missing: lib/cn_client.sh (v1 bridge not installed)" >&2; exit 78
+fi
+
+# CN reachability probe. Bumped timeout so the harness itself
+# doesn't trip on the 2s default that motivated this harness.
+cn_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  "$CN_BASE_URL/api/v1/substrate/health" 2>/dev/null || echo "000")
+{
+  printf '**CN reachable:** %s (health code=%s)\n' \
+    "$([[ "$cn_code" == "200" ]] && echo yes || echo no)" "$cn_code"
+} >> "$EVIDENCE"
+
+if [[ "$cn_code" != "200" ]]; then
+  echo "CN at $CN_BASE_URL not reachable; live-path tests will skip. Start with: make cn-serve" >&2
+fi
+
+# Test 1 - happy path: planner CN injection block populated
+{ printf '\n## Test 1 - happy path: planner injection block contains CN atoms\n'; } >> "$EVIDENCE"
+if [[ "$cn_code" == "200" ]]; then
+  T1_OUT=$(
+    cd "$MINI_ORK_ROOT" && bash -c '
+      export MINI_ORK_ROOT="$PWD"
+      export CN_TIMEOUT_SEC=10
+      rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+      source lib/context_assembler.sh
+      context_contextnest_atoms_md "'"$KICKOFF"'" 6
+    ' 2>&1
+  )
+  _assert "atoms block has header" "--- ContextNest atoms" "$T1_OUT"
+  _assert "atoms block lists at least one atom" "sim=" "$T1_OUT"
+  { printf '\n### Captured planner CN block (1000 chars):\n```\n%s\n```\n' "${T1_OUT:0:1000}"; } >> "$EVIDENCE"
+else
+  echo "  [skip] Test 1 - CN unreachable" >&2
+fi
+
+# Test 2 - worker prefetch: file written + content non-empty
+{ printf '\n## Test 2 - worker prefetch hook writes populated context file\n'; } >> "$EVIDENCE"
+if [[ "$cn_code" == "200" ]]; then
+  T2_RUN="smoke-cn-bridge-${TS}"
+  T2_DIR=$(mktemp -d "/tmp/smoke-cn-bridge-XXXXXX")
+  mkdir -p "$T2_DIR/runs"
+  T2_PREFETCH="$T2_DIR/runs/$T2_RUN/cn_prefetch/test-sid.md"
+  T2_PAYLOAD='{"session_id":"test-sid","prompt":"chapter anchor schema audit and consolidation backoff design","cwd":"'"$MINI_ORK_ROOT"'"}'
+  echo "$T2_PAYLOAD" | \
+    MINI_ORK_ROOT="$MINI_ORK_ROOT" \
+    MINI_ORK_RUN_ID="$T2_RUN" \
+    MINI_ORK_RUN_DIR="$T2_DIR/runs" \
+    CN_TIMEOUT_SEC=10 \
+    CN_PREFETCH_REFRESH_SEC=0 \
+    bash "$MINI_ORK_ROOT/hooks/subagent-prefetch.sh" >/dev/null 2>&1
+  if [[ -f "$T2_PREFETCH" ]]; then
+    T2_SIZE=$(wc -c < "$T2_PREFETCH" | tr -d ' ')
+    _assert_eq_int "prefetch file exists" 1 1
+    _assert_eq_int "prefetch file > 100 bytes (got $T2_SIZE)" 1 "$([[ "$T2_SIZE" -gt 100 ]] && echo 1 || echo 0)"
+    _assert "prefetch markdown has session header" "ContextNest prefetch for session test-sid" "$(cat "$T2_PREFETCH" 2>/dev/null)"
+    { printf '\n### Captured prefetch file (first 50 lines):\n```\n%s\n```\n' "$(head -50 "$T2_PREFETCH" 2>/dev/null)"; } >> "$EVIDENCE"
+  else
+    _assert_eq_int "prefetch file exists" 1 0
+  fi
+  rm -rf "$T2_DIR"
+else
+  echo "  [skip] Test 2 - CN unreachable" >&2
+fi
+
+# Test 3 - CN-down: graceful degradation
+{ printf '\n## Test 3 - failure path: CN-down -> bridge degrades silently\n'; } >> "$EVIDENCE"
+T3_OUT=$(
+  cd "$MINI_ORK_ROOT" && bash -c '
+    export MINI_ORK_ROOT="$PWD"
+    export CN_BASE_URL=http://127.0.0.1:1
+    rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+    source lib/context_assembler.sh
+    out=$(context_contextnest_atoms_md "'"$KICKOFF"'" 6)
+    echo "len=${#out}"
+  ' 2>&1
+)
+if [[ "$T3_OUT" == *"len=0"* ]]; then
+  _assert_eq_int "CN-down -> silent empty output" 1 1
+else
+  _assert_eq_int "CN-down -> silent empty output" 1 0
+fi
+{ printf '\n### CN-down captured output:\n```\n%s\n```\n' "${T3_OUT:0:500}"; } >> "$EVIDENCE"
+
+# Test 4 - MO_DISABLE_CN=1: short-circuit
+{ printf '\n## Test 4 - failure path: MO_DISABLE_CN=1 short-circuits everything\n'; } >> "$EVIDENCE"
+T4_OUT=$(
+  cd "$MINI_ORK_ROOT" && bash -c '
+    export MINI_ORK_ROOT="$PWD"
+    export MO_DISABLE_CN=1
+    rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+    source lib/context_assembler.sh
+    out=$(context_contextnest_atoms_md "'"$KICKOFF"'" 6)
+    echo "len=${#out}"
+  ' 2>&1
+)
+if [[ "$T4_OUT" == *"len=0"* ]]; then
+  _assert_eq_int "MO_DISABLE_CN=1 -> empty output" 1 1
+else
+  _assert_eq_int "MO_DISABLE_CN=1 -> empty output" 1 0
+fi
+{ printf '\n### MO_DISABLE_CN=1 captured output:\n```\n%s\n```\n' "$T4_OUT"; } >> "$EVIDENCE"
+
+# Test 5 - CN-slow: silent no-op when timeout exceeded
+{ printf '\n## Test 5 - failure path: CN-slow (forced timeout) -> silent no-op\n'; } >> "$EVIDENCE"
+T5_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("",0)); print(s.getsockname()[1]); s.close()' 2>/dev/null || echo "")
+if [[ -z "$T5_PORT" ]]; then
+  echo "  [skip] Test 5 - cannot allocate port" >&2
+else
+  T5_PID_FILE=$(mktemp /tmp/smoke-slow-pid-XXXXXX)
+  python3 - "$T5_PORT" "$T5_PID_FILE" <<'PY' &
+import os, sys, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+port, pid_file = int(sys.argv[1]), sys.argv[2]
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw): pass
+    def do_GET(self): time.sleep(5); self.send_response(200); self.end_headers(); self.wfile.write(b'{}')
+    def do_POST(self): time.sleep(5); self.send_response(200); self.end_headers(); self.wfile.write(b'{}')
+with open(pid_file, 'w') as f: f.write(str(os.getpid()))
+HTTPServer(("127.0.0.1", port), H).serve_forever()
+PY
+  sleep 0.4
+  T5_STUB_PID=$(cat "$T5_PID_FILE" 2>/dev/null || echo "")
+  T5_START=$(date +%s)
+  T5_OUT=$(
+    cd "$MINI_ORK_ROOT" && bash -c '
+      export MINI_ORK_ROOT="$PWD"
+      export CN_BASE_URL=http://127.0.0.1:'"$T5_PORT"'
+      export CN_TIMEOUT_SEC=1
+      export CN_HOOK_TIMEOUT_SEC=1
+      rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+      source lib/context_assembler.sh
+      out=$(context_contextnest_atoms_md "'"$KICKOFF"'" 3)
+      echo "len=${#out}"
+    ' 2>&1
+  )
+  T5_DUR=$(( $(date +%s) - T5_START ))
+  [[ -n "$T5_STUB_PID" ]] && kill "$T5_STUB_PID" 2>/dev/null || true
+  rm -f "$T5_PID_FILE"
+  if [[ "$T5_OUT" == *"len=0"* && "$T5_DUR" -lt 10 ]]; then
+    _assert_eq_int "CN-slow -> empty + finishes <10s (took ${T5_DUR}s)" 1 1
+  else
+    _assert_eq_int "CN-slow -> empty + finishes <10s (took ${T5_DUR}s)" 1 0
+  fi
+  { printf '\n### CN-slow captured output (took %ss):\n```\n%s\n```\n' "$T5_DUR" "$T5_OUT"; } >> "$EVIDENCE"
+fi
+
+# Summary
+{
+  printf '\n---\n## Summary\n'
+  printf '**Assertions:** %d PASS, %d FAIL\n' "$PASS" "$FAIL"
+  printf '**Failure-path coverage:** CN-down, MO_DISABLE_CN=1, CN-slow - all exercised\n'
+  if [[ "$cn_code" == "200" ]]; then
+    printf '**Live-path coverage:** Tests 1+2 exercised against real CN\n'
+  else
+    printf '**Live-path coverage:** SKIPPED - CN was not reachable (start it with `make cn-serve` and re-run)\n'
+  fi
+} >> "$EVIDENCE"
+
+echo ""
+echo "-- Smoke evidence written to: $EVIDENCE --"
+echo "-- $PASS PASS, $FAIL FAIL --"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Why

PR #17 (`feat(contextnest): bridge planner + workers to CN substrate`, merged 2026-06-15 as `896ab88`) wired mini-ork's planner and worker subagents to ContextNest's substrate. PR #18 (`feat(loop): autonomous multi-epic delivery...`, merged 2026-06-16 as `d87e40c`) landed a different feature stack as a single-commit cross-merge from `feat/operator-steering-injection` and silently overwrote three of the files PR #17 had augmented:

| File | What PR #17 added | After PR #18 |
|---|---|---|
| `lib/context_assembler.sh` | `context_contextnest_atoms_md` + `context_contextnest_recent_sessions_md` | **removed** |
| `hooks/subagent-spawn.sh` | `cn_hook_post` mirror to `/api/v1/cc/hook/session_start` | **removed** |
| `hooks/subagent-stop.sh` | `cn_hook_post` mirror to `/api/v1/cc/hook/subagent_stop` | **removed** |
| `bin/mini-ork-plan` | invocation of the two new context_contextnest_* helpers in the `MO_INJECT_LEARNINGS` block | **removed** |

The new files PR #17 added (`lib/cn_client.sh`, `hooks/subagent-prefetch.sh`, `tests/unit/test_cn_client.sh`) survived because they were untouched by PR #18's branch. Only the augmentations to pre-existing files were lost — a classic cross-merge hazard with single-commit landings.

Net effect: the planner stopped seeing any ContextNest atoms, and mini-ork subagent lifecycle events stopped reaching the CN substrate.

## How this was caught

Running the new reference smoke harness `scripts/smoke-cn-bridge.sh` (added in this PR) against the live CN server produced:

```
## Assertion: atoms block has header
Expected substring: --- ContextNest atoms
Actual: bash: line 6: context_contextnest_atoms_md: command not found
Verdict: FAIL
```

Unit tests with in-process http stubs (`tests/unit/test_cn_client.sh`) stayed green because they only exercise `lib/cn_client.sh` directly, not the planner's wiring of it. **Only an end-to-end smoke against the live CN catches the regression** — which is the entire motivation for the Smoke Test Standard now defined in ContextNest's `docs/roadmap/epics/agent-context-pack.md`.

## What this PR ships

**Restored from `896ab88`:**
- `lib/context_assembler.sh`: both `context_contextnest_atoms_md` and `context_contextnest_recent_sessions_md` functions
- `hooks/subagent-spawn.sh`: CN hook mirror block
- `hooks/subagent-stop.sh`: CN hook mirror block
- `bin/mini-ork-plan`: invocation block within `MO_INJECT_LEARNINGS`

**Added:**
- `scripts/smoke-cn-bridge.sh`: reference smoke harness, ~250 lines, bash-only. Exercises the live system, produces evidence artifact at `tmp/smoke-evidence/cn-bridge-<timestamp>.md`, covers happy path + 3 failure paths (CN-down, MO_DISABLE_CN=1, CN-slow).

## Verification (proof artifact)

```
$ bash scripts/smoke-cn-bridge.sh
-- Smoke evidence written to: /Users/admin/ps/mini-ork/tmp/smoke-evidence/cn-bridge-20260616T120132Z.md --
-- 8 PASS, 0 FAIL --

## Test 1 - happy path: planner injection block contains CN atoms
  ✅ atoms block has header
  ✅ atoms block lists at least one atom

## Test 2 - worker prefetch hook writes populated context file
  ✅ prefetch file exists
  ✅ prefetch file > 100 bytes (got 3335)
  ✅ prefetch markdown has session header

## Test 3 - failure path: CN-down -> bridge degrades silently
  ✅ CN-down -> silent empty output

## Test 4 - failure path: MO_DISABLE_CN=1 short-circuits everything
  ✅ MO_DISABLE_CN=1 -> empty output

## Test 5 - failure path: CN-slow (forced timeout) -> silent no-op
  ✅ CN-slow -> empty + finishes <10s (took 0s)
```

## Test plan for reviewer

- [ ] `bash scripts/smoke-cn-bridge.sh` against your own running CN — expect 8 PASS, 0 FAIL; if CN unreachable, only Tests 3-5 run (failure paths) and 3 PASS.
- [ ] `cat tmp/smoke-evidence/cn-bridge-*.md | tail` — the latest evidence file should show the full per-assertion verdict block plus captured planner output and prefetch file contents.
- [ ] `bash tests/unit/test_cn_client.sh` + `bash tests/unit/test_context_assembler.sh` — unit suites still green after restoration.
- [ ] Diff against `896ab88` to confirm restored code matches the original PR #17 except for added "restored 2026-06-16" comments and a small `{}` brace fix for the security regex compliance from `e6cb6b0` (the PR #17 security-fix follow-up).

## Follow-up

- The Smoke Test Standard formalizing this pattern lands in ContextNest's `docs/roadmap/epics/agent-context-pack.md` on a separate docs PR.
- Future cross-merges of long-lived branches should run this harness as part of the merge check to prevent the same regression class.
