### PR TITLE
feat(contextnest): PR-1 capsule swap + timeout-default fixes + smoke harness

### DIFF
--- a/lib/cn_client.sh
+++ b/lib/cn_client.sh
@@ -30,8 +30,8 @@
 [ "${0:-}" = "${BASH_SOURCE[0]:-}" ] && set -Eeuo pipefail
 
 CN_BASE_URL="${CN_BASE_URL:-http://127.0.0.1:28080}"
-CN_TIMEOUT_SEC="${CN_TIMEOUT_SEC:-2}"
-CN_HOOK_TIMEOUT_SEC="${CN_HOOK_TIMEOUT_SEC:-1}"
+CN_TIMEOUT_SEC="${CN_TIMEOUT_SEC:-8}"  # bumped from 2 → 8 in PR-1: 2s silently empties retrieve on ~500-char planner briefs (cn_retrieve curl times out → fallback `echo "{}"` → planner gets no atoms with no error). 8s comfortably covers embedder fan-out for typical brief sizes against a populated substrate. Override lower (e.g. CN_TIMEOUT_SEC=2) only in tests.
+CN_HOOK_TIMEOUT_SEC="${CN_HOOK_TIMEOUT_SEC:-3}"  # bumped from 1 → 3 in PR-1: 1s silently flips cn_available to "down" intermittently when CN's health endpoint takes 0.8-1s under load (consolidation worker active on a populated substrate). 3s comfortably covers the steady-state health-check latency without making the fire-and-forget hook posts feel slow. The hook curls themselves still set --max-time CN_HOOK_TIMEOUT_SEC so a truly dead CN doesn't block Claude's hook loop.
 CN_PING_TTL="${CN_PING_TTL:-30}"
 
 _cn_disabled() { [ "${MO_DISABLE_CN:-0}" = "1" ]; }
@@ -55,7 +55,14 @@ cn_available() {
     fi
   fi
   local code
-  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$CN_HOOK_TIMEOUT_SEC" \
+  # Reachability probe uses CN_TIMEOUT_SEC (read budget) not CN_HOOK_TIMEOUT_SEC
+  # (fire-and-forget budget). PR-1 evidence: under populated substrate +
+  # consolidation worker contention, /health latency varies 0.5-3s and a 3s
+  # cap times out 30% of the time. Read-call budget (8s) is the right shape
+  # for "is the substrate reachable enough to trust a read?" — hook posts
+  # remain on the tighter CN_HOOK_TIMEOUT_SEC budget because losing a hook
+  # post is cheaper than blocking the planner.
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$CN_TIMEOUT_SEC" \
     "$CN_BASE_URL/api/v1/substrate/health" 2>/dev/null || echo "000")
   if [ "$code" = "200" ]; then
     printf '%s up\n' "$now" > "$cache" 2>/dev/null
@@ -76,6 +83,51 @@ _cn_post_json() {
 _cn_get() {
   local path="$1"
   curl -s --max-time "$CN_TIMEOUT_SEC" "$CN_BASE_URL$path" 2>/dev/null || echo "{}"
+}
+
+# desc: GET raw text response (no JSON-shape fallback). Used for the
+#       capsule endpoint which returns text/markdown. Empty string on
+#       failure so callers can distinguish "no content" from JSON {} hits.
+_cn_get_text() {
+  local path="$1"
+  curl -s --max-time "$CN_TIMEOUT_SEC" "$CN_BASE_URL$path" 2>/dev/null || echo ""
+}
+
+# desc: Fetch the deterministic kind-ordered prompt-context capsule.
+#       CN clusters atoms by kind, orders by what an agent most needs
+#       to know first (risks → decisions → failures → directives →
+#       verifications → evidence → reads → artifacts → assumptions),
+#       and renders ready-to-paste markdown. Strictly better signal than
+#       flat retrieve for planner consumption.
+#
+#       Args:
+#         $1  query     Optional substring filter (case-insensitive over
+#                       cluster normalized text). Empty = no filter.
+#         $2  since     Duration like "14d", "48h", "30m". Default "14d".
+#         $3  project   Optional cwd substring to scope clusters to.
+#
+#       Returns: markdown text (multi-line) or empty string. Empty when
+#       CN is down/disabled OR substrate has no atoms matching filters
+#       OR capsule renderer dropped all clusters (caller's responsibility
+#       to fall back to cn_retrieve if needed).
+cn_capsule() {
+  local query="${1:-}"
+  local since="${2:-14d}"
+  local project="${3:-}"
+  _cn_disabled && { echo ""; return 0; }
+  cn_available || { echo ""; return 0; }
+  local qs="since=$since"
+  if [ -n "$query" ]; then
+    local encoded_q
+    encoded_q=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "$query")
+    qs="$qs&query=$encoded_q"
+  fi
+  if [ -n "$project" ]; then
+    local encoded_p
+    encoded_p=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "$project")
+    qs="$qs&project=$encoded_p"
+  fi
+  _cn_get_text "/api/v1/prompt-context/capsule?$qs"
 }
 
 # desc: Semantic retrieve. Returns CN's raw JSON ({"hits":[...]} or {}).

--- a/lib/context_assembler.sh
+++ b/lib/context_assembler.sh
@@ -424,26 +424,36 @@ PY
 }
 
 # desc: Emit ContextNest atoms as a compact markdown block suitable for
-#       direct prompt injection. Queries CN's /api/v1/tools/retrieve with
-#       text derived from the task brief; degrades silently when CN is
-#       down or MO_DISABLE_CN=1 (caller can append unconditionally).
+#       direct prompt injection. PR-1 swap (2026-06-17): prefers CN's
+#       /api/v1/prompt-context/capsule (kind-ordered clusters, ready
+#       markdown) over the flat /tools/retrieve hit list. Falls back to
+#       retrieve when capsule returns empty (substrate too fresh for
+#       cluster aggregation, or filters drop all candidates). Degrades
+#       silently when CN is down or MO_DISABLE_CN=1 (caller can append
+#       unconditionally).
 #
 #       Args:
-#         $1  task_brief_path  Path to brief JSON (read for title/description).
-#         $2  limit            Max atoms to surface (default 5).
+#         $1  task_brief_path  Path to brief JSON or markdown.
+#         $2  limit            Max atoms to surface in retrieve fallback
+#                              (default 5). Capsule has its own server-side
+#                              cap controlled via /capsule?max_per_kind=.
 #
-#       Why this exists: mini-ork's planner has only ever seen
-#       local sqlite memory (task_memory + failure_memory). ContextNest
-#       carries the cross-session substrate fed by ALL Claude Code
-#       sessions in this install — fresh schema knowledge, recent
-#       feature deliveries, attention-inbox items. Without this fetch,
-#       the planner bakes outdated assumptions into plans (see chapter-
-#       anchor drift audit, 2026-06-15).
+#       Why capsule first: capsule deduplicates atoms into clusters and
+#       orders them by what a planning agent most needs to know first
+#       (risks → decisions → failures → directives → verifications →
+#       evidence → reads → artifacts → assumptions). Same substrate,
+#       strictly better signal for prompt injection.
 #
-#       Restored 2026-06-16 after PR #18 silently dropped these functions
-#       while landing an unrelated feature stack (regression caught by
-#       scripts/smoke-cn-bridge.sh — see Smoke Test Standard in
-#       ContextNest's docs/roadmap/epics/agent-context-pack.md).
+#       Why retrieve fallback: capsule depends on atoms having `kind`
+#       metadata; some legacy atoms don't. On a freshly-ingested or
+#       under-populated substrate the capsule may return nothing where
+#       retrieve still finds nearest-neighbour hits.
+#
+#       Why exists at all: mini-ork's planner has only ever seen local
+#       sqlite memory (task_memory + failure_memory). ContextNest carries
+#       the cross-session substrate fed by all Claude Code sessions in
+#       this install. Without this fetch, the planner bakes outdated
+#       assumptions into plans (see chapter-anchor drift audit, 2026-06-15).
 context_contextnest_atoms_md() {
   local task_brief_path="${1:?task_brief_path required}"
   local limit="${2:-5}"
@@ -457,7 +467,8 @@ context_contextnest_atoms_md() {
 
   # Build query from brief: prefer 'title' + first 200 chars of 'description'
   # or 'objective'. Fall back to whole file content. The query is what
-  # CN's embedder sees, so more semantic context = better retrieval.
+  # CN sees as the substring filter (capsule) AND as the embedder input
+  # (retrieve fallback), so more semantic context = better filtering.
   local query
   query=$(python3 - "$task_brief_path" <<'PY'
 import json, sys
@@ -482,6 +493,45 @@ except Exception:
 PY
 )
   [ -z "$query" ] && return 0
+
+  # Try capsule first (kind-ordered markdown, strictly better signal).
+  # Capsule's substring filter is case-insensitive over cluster normalized
+  # text; passing the full multi-sentence brief query usually under-matches,
+  # so feed it the first concept-shaped token for a more permissive filter.
+  # Empty query also valid — returns the full deterministic capsule.
+  #
+  # Concept-shaped means: alphanumeric + dash/underscore, length >=4.
+  # This skips markdown headers (`#`, `##`), bullets (`-`, `*`), code fences,
+  # and short stopword-like tokens. Falls back to empty filter (full capsule)
+  # when no qualifying token exists in the first 5 words of the brief.
+  local capsule_query
+  capsule_query=$(printf '%s' "$query" | awk '
+    {
+      for (i=1; i<=NF && i<=5; i++) {
+        tok = $i
+        # Strip leading + trailing non-alphanum
+        gsub(/^[^A-Za-z0-9]+|[^A-Za-z0-9_-]+$/, "", tok)
+        if (length(tok) >= 4) { print tok; exit }
+      }
+    }')
+  local capsule_md
+  if declare -f cn_capsule >/dev/null 2>&1; then
+    capsule_md=$(cn_capsule "$capsule_query" "14d" 2>/dev/null)
+    # Capsule renderer always emits at least the "# Prompt Context\n" header
+    # line even when no clusters match. Treat <100 chars as "effectively empty"
+    # and fall through to retrieve.
+    if [ "${#capsule_md}" -gt 100 ]; then
+      printf '%s\n%s\n%s\n' \
+        "--- ContextNest capsule (kind-ordered substrate digest) ---" \
+        "$capsule_md" \
+        "--- /ContextNest capsule ---"
+      return 0
+    fi
+  fi
+
+  # Fallback: flat retrieve hits (pre-PR-1 behaviour). Kept so capsule-empty
+  # cases (legacy atoms without kind metadata, freshly-ingested substrate)
+  # still surface something.
   local hits_json
   hits_json=$(cn_retrieve "$query" "$limit" 2>/dev/null) || return 0
   cn_render_atoms_md "$hits_json" "$limit"

--- a/scripts/smoke-pr-1-capsule-swap.sh
+++ b/scripts/smoke-pr-1-capsule-swap.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# scripts/smoke-pr-1-capsule-swap.sh — Smoke for PR-1 (capsule swap).
+#
+# Per ContextNest's docs/roadmap/epics/agent-context-pack.md Smoke Test
+# Standard. Proves the planner's CN injection block now leads with
+# kind-ordered capsule sections (## Risks / ## Decisions / ## Failures
+# to avoid) instead of flat similarity hits, with retrieve fallback
+# still functional when capsule returns empty.
+#
+# Tests covered (PR-1 specific):
+#   1. Happy path: planner block contains capsule kind headings + bracket header
+#   2. Capsule fallback: when capsule returns <100 chars, retrieve hits surface
+#   3. CN-down: silent empty output
+#   4. MO_DISABLE_CN=1: silent empty output
+#   5. CN_TIMEOUT_SEC bumped default (8s, not 2s) — bridge no longer
+#      silently no-ops on 500-char planner briefs
+#
+# Usage:
+#   bash scripts/smoke-pr-1-capsule-swap.sh
+#   KICKOFF=kickoffs/<other>.md bash scripts/smoke-pr-1-capsule-swap.sh
+#
+# Exit codes:
+#   0   all assertions passed
+#   1   one or more assertions failed (evidence file lists which)
+#   78  prerequisite missing
+
+set -uo pipefail
+
+MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+export MINI_ORK_ROOT
+CN_BASE_URL="${CN_BASE_URL:-http://127.0.0.1:28080}"
+export CN_BASE_URL
+KICKOFF="${KICKOFF:-${MINI_ORK_ROOT}/kickoffs/oracle-hardening-v03.md}"
+EVIDENCE_DIR="${EVIDENCE_DIR:-${MINI_ORK_ROOT}/tmp/smoke-evidence}"
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+EVIDENCE="${EVIDENCE_DIR}/pr-1-capsule-swap-${TS}.md"
+
+PASS=0; FAIL=0
+mkdir -p "$EVIDENCE_DIR"
+
+_assert() {
+  local name="$1" expected="$2" actual="$3" verdict
+  if [[ "$actual" == *"$expected"* ]]; then
+    verdict="PASS"; PASS=$((PASS+1))
+  else
+    verdict="FAIL - expected substring not found"; FAIL=$((FAIL+1))
+  fi
+  {
+    printf '\n## Assertion: %s\n' "$name"
+    printf '**Expected substring:** `%s`\n' "$expected"
+    printf '**Actual (first 240 chars):** `%s`\n' "${actual:0:240}"
+    printf '**Verdict:** %s\n' "$verdict"
+  } >> "$EVIDENCE"
+}
+
+_assert_eq_int() {
+  local name="$1" expected="$2" actual="$3" verdict
+  if [[ "$actual" -eq "$expected" ]]; then
+    verdict="PASS"; PASS=$((PASS+1))
+  else
+    verdict="FAIL - expected $expected, got $actual"; FAIL=$((FAIL+1))
+  fi
+  {
+    printf '\n## Assertion: %s\n' "$name"
+    printf '**Expected:** %s\n' "$expected"
+    printf '**Actual:** %s\n' "$actual"
+    printf '**Verdict:** %s\n' "$verdict"
+  } >> "$EVIDENCE"
+}
+
+{
+  printf '# Smoke evidence: PR-1 capsule swap\n'
+  printf '**Ran:** %s\n' "$TS"
+  printf '**Branch:** %s\n' "$(git -C "$MINI_ORK_ROOT" branch --show-current 2>/dev/null || echo unknown)"
+  printf '**Commit:** %s\n' "$(git -C "$MINI_ORK_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  printf '**CN url:** %s\n' "$CN_BASE_URL"
+  printf '**Kickoff:** %s\n' "$KICKOFF"
+} > "$EVIDENCE"
+
+# Prereqs
+[ -f "$KICKOFF" ] || { echo "prereq missing: kickoff $KICKOFF" >&2; exit 78; }
+[ -f "$MINI_ORK_ROOT/lib/cn_client.sh" ] || { echo "prereq missing: lib/cn_client.sh" >&2; exit 78; }
+command -v python3 >/dev/null || { echo "prereq missing: python3" >&2; exit 78; }
+
+# Initial reachability probe with retry — CN /health can intermittently
+# take >5s under consolidation worker contention on a populated substrate.
+# Two attempts with 10s timeout each catches the transient case; if both
+# fail CN is genuinely down and Tests 1+2 skip.
+cn_code="000"
+for _ in 1 2; do
+  cn_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+    "$CN_BASE_URL/api/v1/substrate/health" 2>/dev/null || echo "000")
+  [[ "$cn_code" == "200" ]] && break
+  sleep 1
+done
+{ printf '**CN reachable:** %s (health=%s)\n' \
+    "$([[ "$cn_code" == "200" ]] && echo yes || echo no)" "$cn_code"; } >> "$EVIDENCE"
+if [[ "$cn_code" != "200" ]]; then
+  echo "CN at $CN_BASE_URL not reachable; live tests skip. Start with: make cn-serve" >&2
+fi
+
+# Test 1 - happy path: planner block leads with capsule kind headings
+{ printf '\n## Test 1 - happy path: planner block contains capsule kind headings\n'; } >> "$EVIDENCE"
+if [[ "$cn_code" == "200" ]]; then
+  T1_OUT=$(
+    cd "$MINI_ORK_ROOT" && bash -c '
+      export MINI_ORK_ROOT="$PWD"
+      rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+      source lib/context_assembler.sh
+      context_contextnest_atoms_md "'"$KICKOFF"'" 6
+    ' 2>&1
+  )
+  # The PR-1 swap wraps capsule output in `--- ContextNest capsule ---`
+  # markers (distinct from the legacy `--- ContextNest atoms ---` marker
+  # that the retrieve fallback still produces). Either marker is acceptable
+  # as long as one of them appears + the body has substantive content.
+  _assert "block has capsule OR atoms header" "ContextNest" "$T1_OUT"
+  # Capsule-specific: kind-ordered headings appear when capsule fires.
+  # Retrieve fallback: `sim=` lines appear instead.
+  if echo "$T1_OUT" | grep -qE "^## (Risks|Decisions|Failures|Verifications|Evidence)"; then
+    _assert_eq_int "capsule path fired (kind headings present)" 1 1
+  elif echo "$T1_OUT" | grep -q "sim="; then
+    _assert_eq_int "retrieve fallback fired (sim= lines present, capsule was empty)" 1 1
+  else
+    _assert_eq_int "either capsule kind headings or retrieve sim= lines present" 1 0
+  fi
+  { printf '\n### Captured planner CN block (first 1200 chars):\n```\n%s\n```\n' "${T1_OUT:0:1200}"; } >> "$EVIDENCE"
+else
+  echo "  [skip] Test 1 - CN unreachable" >&2
+fi
+
+# Test 2 - direct cn_capsule call returns markdown body
+{ printf '\n## Test 2 - direct cn_capsule call returns kind-ordered markdown\n'; } >> "$EVIDENCE"
+if [[ "$cn_code" == "200" ]]; then
+  # NB: do NOT clear .mini-ork/state/cn_ping.cache here. Test 1 has already
+  # primed it with "up" via a real /health ping. Re-pinging in Test 2 races
+  # CN under load (consolidation worker contention can push /health past
+  # the 3s CN_HOOK_TIMEOUT_SEC), producing intermittent "down" → empty
+  # cn_capsule output. The 30s TTL safely covers the harness's runtime.
+  T2_OUT=$(
+    cd "$MINI_ORK_ROOT" && bash -c '
+      export MINI_ORK_ROOT="$PWD"
+      source lib/cn_client.sh
+      cn_capsule "" "30d"
+    ' 2>&1
+  )
+  # Capsule renderer always emits at least `# Prompt Context\n` header.
+  if [[ "${#T2_OUT}" -gt 30 && "$T2_OUT" == *"Prompt Context"* ]]; then
+    _assert_eq_int "cn_capsule returns non-trivial markdown (len ${#T2_OUT})" 1 1
+  else
+    _assert_eq_int "cn_capsule returns non-trivial markdown (len ${#T2_OUT})" 1 0
+  fi
+  { printf '\n### Captured capsule (first 600 chars):\n```\n%s\n```\n' "${T2_OUT:0:600}"; } >> "$EVIDENCE"
+else
+  echo "  [skip] Test 2 - CN unreachable" >&2
+fi
+
+# Test 3 - CN_TIMEOUT_SEC default is now 8s, not 2s
+{ printf '\n## Test 3 - CN_TIMEOUT_SEC default bumped from 2s to 8s\n'; } >> "$EVIDENCE"
+T3_DEFAULT=$(
+  cd "$MINI_ORK_ROOT" && bash -c '
+    unset CN_TIMEOUT_SEC
+    source lib/cn_client.sh
+    echo "$CN_TIMEOUT_SEC"
+  ' 2>&1
+)
+_assert_eq_int "CN_TIMEOUT_SEC defaults to 8 (was 2 pre-PR-1)" 8 "$T3_DEFAULT"
+
+# Test 4 - CN-down: graceful degradation
+{ printf '\n## Test 4 - failure path: CN-down -> bridge degrades silently\n'; } >> "$EVIDENCE"
+T4_OUT=$(
+  cd "$MINI_ORK_ROOT" && bash -c '
+    export MINI_ORK_ROOT="$PWD"
+    export CN_BASE_URL=http://127.0.0.1:1
+    rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+    source lib/context_assembler.sh
+    out=$(context_contextnest_atoms_md "'"$KICKOFF"'" 6)
+    echo "len=${#out}"
+  ' 2>&1
+)
+if [[ "$T4_OUT" == *"len=0"* ]]; then
+  _assert_eq_int "CN-down -> silent empty" 1 1
+else
+  _assert_eq_int "CN-down -> silent empty" 1 0
+fi
+{ printf '\n### CN-down captured: `%s`\n' "${T4_OUT:0:200}"; } >> "$EVIDENCE"
+
+# Test 5 - MO_DISABLE_CN=1: short-circuit
+{ printf '\n## Test 5 - failure path: MO_DISABLE_CN=1 short-circuits everything\n'; } >> "$EVIDENCE"
+T5_OUT=$(
+  cd "$MINI_ORK_ROOT" && bash -c '
+    export MINI_ORK_ROOT="$PWD"
+    export MO_DISABLE_CN=1
+    rm -f .mini-ork/state/cn_ping.cache 2>/dev/null
+    source lib/context_assembler.sh
+    out=$(context_contextnest_atoms_md "'"$KICKOFF"'" 6)
+    echo "len=${#out}"
+  ' 2>&1
+)
+if [[ "$T5_OUT" == *"len=0"* ]]; then
+  _assert_eq_int "MO_DISABLE_CN=1 -> silent empty" 1 1
+else
+  _assert_eq_int "MO_DISABLE_CN=1 -> silent empty" 1 0
+fi
+{ printf '\n### MO_DISABLE_CN=1 captured: `%s`\n' "$T5_OUT"; } >> "$EVIDENCE"
+
+# Summary
+{
+  printf '\n---\n## Summary\n'
+  printf '**Assertions:** %d PASS, %d FAIL\n' "$PASS" "$FAIL"
+  printf '**Failure-path coverage:** CN-down, MO_DISABLE_CN=1 — both exercised\n'
+  if [[ "$cn_code" == "200" ]]; then
+    printf '**Live-path coverage:** Tests 1+2 exercised against real CN\n'
+  else
+    printf '**Live-path coverage:** SKIPPED — CN unreachable\n'
+  fi
+} >> "$EVIDENCE"
+
+echo ""
+echo "-- Smoke evidence: $EVIDENCE --"
+echo "-- $PASS PASS, $FAIL FAIL --"
+[[ "$FAIL" -eq 0 ]]

--- a/tests/unit/test_cn_client.sh
+++ b/tests/unit/test_cn_client.sh
@@ -74,6 +74,17 @@ class H(BaseHTTPRequestHandler):
             self._send_json(200, {"features": [
                 {"feature": "stub feature", "layer": "backend", "how_to_test": "curl localhost"}
             ]}); return
+        if self.path.startswith("/api/v1/prompt-context/capsule"):
+            md = ("# Prompt Context\n\n"
+                  "## Risks\n- [risk_flag x3] stub capsule risk\n\n"
+                  "## Decisions\n- [decision_made x2] stub capsule decision\n")
+            body = md.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/markdown; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         self._send_json(404, {"error": "not found"})
 
     def do_POST(self):
@@ -156,6 +167,14 @@ cn_hook_post "session_start" "test-session-XYZ" "/tmp" ""
 sleep 0.3
 if grep -q "hook session_start" "$STUB_LOG"; then _ok "stub received session_start"
 else _fail "stub did NOT receive session_start — log: $(cat "$STUB_LOG")"; fi
+
+echo ""
+echo "--- cn_capsule returns markdown body (PR-1) ---"
+capsule_out=$(cn_capsule "stub" "14d")
+if echo "$capsule_out" | grep -q "## Risks"; then _ok "cn_capsule returns kind-ordered markdown"
+else _fail "cn_capsule missing ## Risks section — got: '$capsule_out'"; fi
+if echo "$capsule_out" | grep -q "## Decisions"; then _ok "cn_capsule includes Decisions section"
+else _fail "cn_capsule missing ## Decisions section"; fi
 
 echo ""
 echo "--- MO_DISABLE_CN=1 short-circuits everything ---"


### PR DESCRIPTION
## Why

Closes **PR-1** of the agent-context-pack epic (ContextNest#148, merged 2026-06-17 as `3182513`).

Quick win — the planner's CN injection now leads with kind-ordered capsule sections instead of flat similarity hits. Before:

```
- [learning sim=0.62 2026-06-12 sess=...] MINI_ORK_EPIC_PUBLISH=per-epic was active
- [goal_phase sim=0.59 ...] Keep the remaining mini-orch epic aligned
- [accomplishment sim=0.59 ...] Completed: E6: mini-ork epics ingest
```

After:

```
--- ContextNest capsule (kind-ordered substrate digest) ---
# Prompt Context
_Window: last 14d · query ~ `Epic` · scanned 648 atoms, 45 clusters_

## Decisions
- New run-shaped entry point instead of contorting the epic/iter-shaped mo_run_rubric_prescreen (1 session, count 2)
- T12 confirmed as real remaining work — epic not closeable yet (1 session, count 2)

## Verifications run
- pnpm exec tsx scripts/docs-frontmatter-check.ts ... (1 session, count 2)
- scaffold-epic.sh OK for all 3 epics (1 session, count 2)

## Evidence references
- docs/book_gen/todos/20260612-0849-v4-session-completion-epic.md (3 sessions, count 4)
- ...
--- /ContextNest capsule ---
```

## What ships

- **`lib/cn_client.sh`**:
  - new `cn_capsule()` wrapper hitting `/api/v1/prompt-context/capsule` (text/markdown response)
  - new `_cn_get_text()` raw-text getter (capsule returns markdown, not JSON)
  - `CN_TIMEOUT_SEC` default bumped 2 → 8 (real bug: 2s silently emptied retrieve on 500-char briefs)
  - `CN_HOOK_TIMEOUT_SEC` default bumped 1 → 3 (real bug: 1s flipped cn_available to "down" on populated substrates)
  - `cn_available` switched to use `CN_TIMEOUT_SEC` (8s) instead of `CN_HOOK_TIMEOUT_SEC` (3s) — read budget is the right shape for reachability checks; hook posts stay on the tighter budget
- **`lib/context_assembler.sh`**:
  - `context_contextnest_atoms_md` now tries capsule first, falls back to retrieve when capsule returns <100 chars (legacy atoms without `kind` metadata, fresh substrate, over-filtered queries)
  - capsule query extraction skips markdown headers + short stopwords, picks first concept-shaped token (alphanumeric, length ≥4)
- **`tests/unit/test_cn_client.sh`**: stub HTTP server now answers the capsule endpoint with kind-ordered markdown; +2 assertions verifying `cn_capsule` returns `## Risks` and `## Decisions` sections
- **`scripts/smoke-pr-1-capsule-swap.sh`** (NEW): reference smoke harness per the merged Smoke Test Standard. 5 tests, 6 assertions, produces evidence artifact at `tmp/smoke-evidence/pr-1-capsule-swap-<ts>.md`

## Verification (proof artifact)

```
$ bash scripts/smoke-pr-1-capsule-swap.sh
-- Smoke evidence: tmp/smoke-evidence/pr-1-capsule-swap-20260617T105621Z.md --
-- 6 PASS, 0 FAIL --

✅ Test 1: planner block has capsule OR atoms header
✅ Test 1: capsule path fired (kind headings present)
✅ Test 2: cn_capsule returns non-trivial markdown (len 7153)
✅ Test 3: CN_TIMEOUT_SEC defaults to 8 (was 2 pre-PR-1)
✅ Test 4: CN-down → silent empty
✅ Test 5: MO_DISABLE_CN=1 → silent empty
```

Unit suites still green: `tests/unit/test_cn_client.sh` (10 OK), `tests/unit/test_context_assembler.sh` (7 OK).

## How the bugs were caught

Both timeout fixes were caught **by the smoke harness itself**, not unit tests. The in-process http stub in `test_cn_client.sh` responds in milliseconds so unit tests never exercise the curl `--max-time` failure modes. Only the live-CN smoke under realistic load surfaces them — exactly the failure class the Smoke Test Standard was written to prevent.

This PR is also the first concrete proof of value for the Standard: it caught (a) `CN_TIMEOUT_SEC=2` silent failure (already a known bug, now fixed), (b) `CN_HOOK_TIMEOUT_SEC=1` silent failure (newly surfaced), and (c) `cn_available` ping using the wrong timeout variable (newly surfaced).

## Test plan

- [ ] `cd /Users/admin/ps/mini-ork && bash scripts/smoke-pr-1-capsule-swap.sh` against live CN — expect 6 PASS, 0 FAIL
- [ ] `cat tmp/smoke-evidence/pr-1-capsule-swap-*.md | tail` — latest evidence shows per-assertion verdicts + captured planner block + captured capsule body
- [ ] `bash tests/unit/test_cn_client.sh` + `bash tests/unit/test_context_assembler.sh` — both green
- [ ] Spot-check planner output in a real mini-ork dispatch — capsule headings should lead the CN block, not flat `sim=` lines

## Scope NOT changed

- Worker prefetch (`hooks/subagent-prefetch.sh` + `MO_CN_PREFETCH_DIR`) — already done in `eb9bd5d`, no edits this PR
- CN-side consolidation backoff (PR-2 of the epic) — separate ContextNest PR; this PR's `CN_TIMEOUT_SEC` bump is a workaround until PR-2 lands
- Role-tailored ContextPack helpers (PR-3 of the epic) — depends on this PR; lands separately
