### PR TITLE
fix(contextnest): restore PR-4 worker prefetch wiring dropped by PR #18

### DIFF
--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -271,6 +271,17 @@ trap 'exit 130' INT
 # on filesystem scan, breaking the recipe's expected artifact layout.
 export MINI_ORK_RUN_DIR="$RUN_DIR"
 
+# ContextNest prefetch dir — populated by hooks/subagent-prefetch.sh on
+# every worker's first UserPromptSubmit when MINI_ORK_RUN_ID is set. The
+# hook writes <session_id>.md per spawned subagent. Prompt templates can
+# reference {{MO_CN_PREFETCH_DIR}} to instruct workers to `ls` + cat the
+# files before their first turn (semantic-retrieve atoms + recent
+# features + inbox items relevant to the cwd + prompt).
+# Restored 2026-06-17 after PR #18 (d87e40c, same regression class as
+# PR #19's restoration) silently dropped the eb9bd5d wiring.
+export MO_CN_PREFETCH_DIR="$RUN_DIR/cn_prefetch"
+mkdir -p "$MO_CN_PREFETCH_DIR" 2>/dev/null || true
+
 # Live OTel span buffering (MO_OTEL=1 gated; best-effort, never breaks runs).
 # shellcheck source=/dev/null
 source "$MINI_ORK_ROOT/lib/mo_otel.sh" 2>/dev/null || true

--- a/recipes/code-fix/prompts/implementer.md
+++ b/recipes/code-fix/prompts/implementer.md
@@ -6,6 +6,14 @@ the repository using the Edit and Write tools, then emit a JSON summary on stdou
 
 ---
 
+## Step 0 — ContextNest prefetch (read first if present)
+
+Run `ls {{MO_CN_PREFETCH_DIR}}` — if any `*.md` files exist there, cat each one and incorporate the semantic-retrieve atoms, recent features, and inbox items into your understanding of the task. These are populated by the `subagent-prefetch.sh` UserPromptSubmit hook from the ContextNest substrate (gated on `MINI_ORK_RUN_ID`). They are short (<2KB typically) and high-signal; skim them BEFORE reading the plan so you can cross-reference prior work.
+
+If the directory is empty or doesn't exist, skip this step silently — ContextNest is optional infra.
+
+---
+
 ## Inputs
 
 | Input | Source |

--- a/recipes/code-fix/prompts/planner.md
+++ b/recipes/code-fix/prompts/planner.md
@@ -6,6 +6,12 @@ You do NOT suggest UI copy or wording. You produce structured JSON.
 
 ---
 
+## Step 0 — ContextNest prefetch (read first if present)
+
+Run `ls {{MO_CN_PREFETCH_DIR}}` — if any `*.md` files exist there, cat each one before drafting the plan. They contain semantic-retrieve atoms about prior work, recent features (last 48h), and inbox items. Use them to: (a) avoid duplicating work a sibling session shipped, (b) cite prior decisions/learnings in your reasoning_notes, (c) tighten step scopes when a recent feature already touched the same surface. Skip silently when the dir is empty.
+
+---
+
 ## Inputs (provided via context_assemble)
 
 The following context sections will be injected before this prompt when the node runs.

--- a/recipes/code-fix/prompts/reviewer.md
+++ b/recipes/code-fix/prompts/reviewer.md
@@ -13,6 +13,12 @@ no "looks good but…" answers. One of three outcomes, nothing in between.
 
 ---
 
+## Step 0 — ContextNest prefetch (read first if present)
+
+Run `ls {{MO_CN_PREFETCH_DIR}}` — if any `*.md` files exist there, cat each one. They contain semantic-retrieve atoms about prior work in this area + recent features + inbox items. Use them to spot regressions (a feature recently shipped that this PR might break) or duplicated work (a sibling session shipped the same fix). Skip silently when empty.
+
+---
+
 ## Inputs
 
 | Input | Source |


### PR DESCRIPTION
Second instance of the same regression class as PR #19 — PR #18 (`d87e40c`) single-commit cross-merge silently overwrote eb9bd5d's prefetch wiring (`MO_CN_PREFETCH_DIR` export in `bin/mini-ork-execute` + Step 0 sections in 3 code-fix prompt templates).

## Verification
```
$ grep -c 'export MO_CN_PREFETCH_DIR' bin/mini-ork-execute  →  1
$ grep -l 'Step 0 — ContextNest prefetch' recipes/code-fix/prompts/*.md
recipes/code-fix/prompts/planner.md
recipes/code-fix/prompts/implementer.md
recipes/code-fix/prompts/reviewer.md
$ bash -n bin/mini-ork-execute  →  clean
```

## How caught
Live smoke test of PR-1 (capsule swap) on main surfaced `MO_CN_PREFETCH_DIR` missing. Direct grep against the post-merge tree returned 0, despite eb9bd5d being in git log — the commit existed in history but the file changes had been silently overwritten by d87e40c.

Restore content matches eb9bd5d's diff exactly (with added 'restored 2026-06-17' comment).

## Follow-up
Third confirmed instance of this regression class (PR #17 → #18 → #19; eb9bd5d → #18 → this PR). Future cross-merges touching CN-bridge files should run `bash scripts/smoke-cn-bridge.sh` + `bash scripts/smoke-pr-1-capsule-swap.sh` as part of the merge check.