### PR TITLE
fix(bug-audit-cmgk): planner emits structured JSON, not markdown

### DIFF
--- a/recipes/bug-audit-cmgk/prompts/planner.md
+++ b/recipes/bug-audit-cmgk/prompts/planner.md
@@ -2,29 +2,74 @@
 
 You are the planner for a bug-only audit. Read the kickoff (which
 embeds the validated feature inventory from Phase 1) and produce a
-5-7 step plan covering:
+structured plan JSON that drives the 4-lens panel + synthesizer.
 
 Kickoff content:
 ```text
 {{KICKOFF_CONTENT}}
 ```
 
-1. Bug classes in scope (correctness, race, security, observability,
-   contract drift, fail-open hazards, dead-code-after-cutover)
-2. What the panel definition of a "bug" is — must be a CONCRETE
-   defect, NOT a wishlist item or a future improvement
-3. Per-feature coverage targets — at least 1 bug-find pass per
-   feature listed in the kickoff
-4. Synthesis rules — consensus markers, severity grading, false-positive
-   filter
-5. Output target: unified bug report at
-   `${MINI_ORK_RUN_DIR}/synthesis.md`
+## Required JSON shape
 
-Keep the plan short. Each lens already knows what kind of bug to look
-for — your job is to lock the bug definition + thresholds + format.
+Respond with ONLY valid JSON. No markdown fences, no prose, no
+preamble. The downstream wrapper parses your output directly and
+rejects anything that isn't JSON.
 
-CRITICAL: this audit is REPORT-ONLY. No code edits. No fix proposals
-should land in the synthesis as actionable patches — only AS bug
-descriptions with file:line + reproduction sketch + impact.
+Top-level keys (MUST be present):
 
-Output to `${MINI_ORK_RUN_DIR}/plan.md`. Markdown, ≤500 words.
+```
+{
+  "objective":         string,
+  "assumptions":       string[],
+  "decomposition":     [{ "id": string, "node_type": string, "description": string }],
+  "dependencies":      [{ "from": string, "to": string, "edge_type"?: string }],
+  "risk_notes":        string[],
+  "artifact_contract": { "outputs": string[], "success_verifiers": string[] },
+  "verifier_contract": { "checks": [{ "id": string, "description": string, "command"?: string }] }
+}
+```
+
+Rules:
+
+- `node_type` must be one of: planner | researcher | implementer |
+  reviewer | verifier | reflector | publisher | rollback.
+- `verifier_contract.checks` MUST contain at least one item. The
+  wrapper rejects plans without it (defect D-015). At minimum include
+  a check that asserts `lens-*.md` artifacts exist:
+  ```
+  { "id": "lens-completeness",
+    "description": "all 4 lens reports + synthesis exist and are non-empty",
+    "command": "test -s \"$MINI_ORK_RUN_DIR/synthesis.md\" && [ \"$(ls \"$MINI_ORK_RUN_DIR\"/lens-*.md | wc -l)\" -ge 4 ]" }
+  ```
+- `artifact_contract.success_verifiers` MUST reference
+  `verifiers/lens-completeness.sh` (the recipe ships it).
+
+## Content the JSON must encode
+
+1. **Bug classes in scope** — list as `risk_notes`: correctness, race,
+   security, observability, contract drift, fail-open hazards,
+   dead-code-after-cutover.
+2. **Lens fan-out** — `decomposition` includes 4 researcher nodes
+   (one per lens) + 1 reviewer node (synthesizer). Each lens has
+   `node_type: "researcher"`; the synthesizer has `node_type: "reviewer"`.
+3. **Dependencies** — each lens supplies context to the synthesizer:
+   `{"from": "<lens-id>", "to": "synthesizer", "edge_type": "supplies_context_to"}`.
+4. **Bug-definition threshold** — encode as `assumptions`: a CONCRETE
+   defect with file:line evidence; NOT a wishlist item or future
+   improvement.
+5. **Per-lens coverage target** — each lens must produce at least one
+   bug-find pass per feature listed in the kickoff. Express as a
+   `verifier_contract.checks` entry asserting anchor counts.
+6. **Synthesis rules** — consensus markers, severity grading,
+   false-positive filter. Express as `assumptions` or `risk_notes`.
+
+## Out of scope (DO NOT include)
+
+- No code edits in the synthesis (the recipe is report-only).
+- No fix proposals as actionable patches — only bug descriptions
+  with file:line + reproduction sketch + impact.
+
+## Lifecycle hint
+
+The wrapper writes your JSON to `${MINI_ORK_RUN_DIR}/plan.json`.
+Downstream nodes (`mini-ork execute`) read it serially.


### PR DESCRIPTION
## Summary
Closes the D-015 plan-rejection class for the `bug-audit-cmgk` recipe. The previous planner prompt instructed the LLM to output `plan.md` markdown (≤500 words) but `bin/mini-ork-plan` requires `verifier_contract.checks` on the JSON it parses. Every planner invocation against this recipe rejected at that gate, forcing the user to hand-patch `plan.json`.

## Background
The canonical fallback prompt at `bin/mini-ork-plan:128-151` already requires JSON with `verifier_contract.checks`. The recipe-specific override at `recipes/bug-audit-cmgk/prompts/planner.md` diverged and asked for markdown instead. This PR aligns the recipe prompt with the wrapper's contract.

## What the new prompt requires
- Explicit JSON-only output (no markdown fences, no preamble)
- A minimum `verifier_contract.checks` entry asserting `lens-*.md` + `synthesis.md` exist
- Node-type vocabulary list (planner/researcher/reviewer/...)
- `supplies_context_to` edge type for lens → synthesizer dependencies
- Explicit "Out of scope" reminder — audit stays report-only, no code edits in the synthesis

## Verified pattern
Two recent dispatches hand-patched the planner output with structurally identical JSON to unblock the downstream lens fan-out. The hand-patches converged on the exact shape this prompt now codifies — so the prompt change is "tell the LLM what we've been hand-writing anyway."

## Out of scope
- No code change to `bin/mini-ork-plan`. The wrapper already validates correctly.
- No change to other recipes' planner prompts (this is a per-recipe fix).
- The companion `refactor-audit` recipe's planner has the same shape issue but is left for a separate PR — it has its own prompt conventions worth checking against this template first.

## Test plan
- [ ] Dispatch a fresh `mini-ork run bug-audit-cmgk <kickoff>`
- [ ] Confirm `plan.json` validates without manual patching (no `PLAN REJECTED: verifier_contract.checks is missing or empty`)
- [ ] Confirm the 4 lens nodes + synthesizer fan-out correctly off the generated `decomposition`
