### PR TITLE
fix(execute): run verifier tiers in the implementer's worktree, not the main checkout

### DIFF
--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -70,11 +70,33 @@ _run_verifier_ref() {
   local _script="$1" _evidence="$2"
   local _exit _json_rc _errexit_set=0
 
+  # Run the verifier in the tree where the implementer actually wrote + committed
+  # its files — NOT the executor's $PWD (the kickoff repo's MAIN checkout). The
+  # implementer applies the plan in an isolated worktree (prompts/implementer.md)
+  # and records its absolute path as `worktree_path` in implementer-summary.json.
+  # tier1/tier2/tier3 read RELATIVE touched_files and run tsc/eslint/jest from
+  # $PWD; without this cd they fail-closed ("No files matching the pattern …" /
+  # empty test_files) on any worktree-isolated change → false ESCALATE of clean
+  # code (recurring researcher-repo gotcha, 2026-06-25). Fallback order:
+  # worktree_path (if a real dir) → MO_TARGET_CWD → current $PWD.
+  local _verify_cwd="" _summary="${MINI_ORK_RUN_DIR:-$RUN_DIR}/implementer-summary.json"
+  if [ -f "$_summary" ]; then
+    _verify_cwd="$(python3 -c 'import json,sys
+try:
+    print(json.load(open(sys.argv[1])).get("worktree_path") or "")
+except Exception:
+    print("")' "$_summary" 2>/dev/null)"
+  fi
+  if [ -z "$_verify_cwd" ] || [ ! -d "$_verify_cwd" ]; then
+    _verify_cwd="${MO_TARGET_CWD:-$PWD}"
+  fi
+
   case "$-" in
     *e*) _errexit_set=1; set +e ;;
   esac
-  MINI_ORK_PLAN_PATH="$PLAN_PATH" ARTIFACT_PATH="$ARTIFACT_PATH" \
-    bash "$_script" > "$_evidence" 2>&1
+  echo "[verifier-cwd] $(basename "$_script") → $_verify_cwd" >&2
+  ( cd "$_verify_cwd" && MINI_ORK_PLAN_PATH="$PLAN_PATH" ARTIFACT_PATH="$ARTIFACT_PATH" \
+    bash "$_script" ) > "$_evidence" 2>&1
   _exit=$?
 
   # Minimum-evidence assertion: exit 0 with an empty evidence file is a

--- a/recipes/recursive-validate-impl/prompts/implementer.md
+++ b/recipes/recursive-validate-impl/prompts/implementer.md
@@ -5,14 +5,17 @@ the patch scoped to the kickoff, the plan, and any reflector/replanner guidance
 from the current iteration. Preserve user changes in the main checkout.
 
 After editing, write `${MINI_ORK_RUN_DIR}/implementer-summary.json` as strict
-JSON with a mandatory `touched_files[]` array. Verifier tiers read that array
-to scope compile, lint, unit, property, and mutation checks.
+JSON with a mandatory `touched_files[]` array AND a mandatory `worktree_path`.
+Verifier tiers `cd` into `worktree_path` and read `touched_files[]` to scope
+compile, lint, unit, property, and mutation checks — so the relative paths must
+resolve against that tree.
 
 Required JSON shape:
 
 ```json
 {
   "iteration": 1,
+  "worktree_path": "/absolute/path/to/the/worktree/or/clean/tree/you/wrote/in",
   "summary": "one paragraph",
   "touched_files": [
     "relative/path/from/repo/root.ts"
@@ -30,6 +33,13 @@ Required JSON shape:
 ```
 
 Rules:
+- `worktree_path` MUST be the ABSOLUTE path of the tree where you created +
+  committed the files — the isolated worktree you applied the plan in, or the
+  main checkout if you worked there directly. Verifier tiers `cd` into it before
+  running scoped checks; an absent/wrong `worktree_path` makes them run in the
+  main checkout and fail-closed ("No files matching the pattern …") on changes
+  that live only in your worktree. Get it from `git rev-parse --show-toplevel`
+  in the tree you edited.
 - Do not mark `ready_for_tier1` true when `touched_files[]` is empty.
 - Do not edit files outside the kickoff scope unless the plan explicitly names
   them.


### PR DESCRIPTION
## Problem
`_run_verifier_ref` ran each tier verifier (tier1 compile/lint, tier2 unit, tier3 property) in the executor's $PWD — the kickoff repo's **main checkout**. But the implementer applies the plan in an isolated worktree (`prompts/implementer.md`), so the relative `touched_files` don't exist in $PWD: eslint emits *'No files matching the pattern …'*, jest gets empty `test_files`, both fail-closed → a clean worktree-isolated change **false-ESCALATEs**. Recurring researcher-repo gotcha; panel verdicts repeatedly flagged it operator-owned.

## Fix
- The implementer now records `worktree_path` (absolute) in `implementer-summary.json`.
- `_run_verifier_ref` cd's into it before running the verifier (fallback: `MO_TARGET_CWD` → $PWD), logging `[verifier-cwd] <tier> → <dir>`.

## Smoke (real tier1 verifier, not a mock)
- tier1 against a worktree-only file: *'no source files'* from the main checkout (bug) vs *'touched files are clean'* cd'd into the worktree (fixed).
- worktree_path extraction picks the path when present, falls back when absent.
- `bash -n bin/mini-ork-execute` clean.

Safe + backward-compatible: when `worktree_path` is absent it falls back to today's behavior (`MO_TARGET_CWD`).