### PR TITLE
fix(codex): pass codex stream via file path, not env/argv (E2BIG)

### DIFF
--- a/lib/providers/cl_codex.sh
+++ b/lib/providers/cl_codex.sh
@@ -184,13 +184,25 @@ fi
 #   MO_TURNS_FILE → turns.jsonl lines matching the stream-json per-turn shape
 # Both optional — absent env vars skip the sidecar (standalone CLI use).
 if [ -n "${MO_USAGE_FILE:-}" ] || [ -n "${MO_TURNS_FILE:-}" ] || [ -n "${MO_COST_FILE:-}" ]; then
-  RAW_OUT="$RAW_OUT" python3 - "${MO_USAGE_FILE:-}" "${MO_TURNS_FILE:-}" "${MO_COST_FILE:-}" <<'PY' || true
+  # Pass the stream file PATH (short), not its content — exec() counts env
+  # + argv toward ARG_MAX, so a multi-KB RAW_OUT in the environment is E2BIG
+  # ("Argument list too long"). RAW_OUT here is a verbatim cat of this file.
+  MO_RAW_FILE="$_CODEX_STREAM_FILE" python3 - "${MO_USAGE_FILE:-}" "${MO_TURNS_FILE:-}" "${MO_COST_FILE:-}" <<'PY' || true
 import json, os, sys
 usage_path, turns_path, cost_path = sys.argv[1:4]
 in_tok = out_tok = cached_tok = 0
 turns = []
 thread_id = None
-for line in os.environ.get("RAW_OUT", "").splitlines():
+def _read_raw():
+    p = os.environ.get("MO_RAW_FILE", "")
+    if not p:
+        return ""
+    try:
+        with open(p, "r", errors="replace") as _f:
+            return _f.read()
+    except OSError:
+        return ""
+for line in _read_raw().splitlines():
     line = line.strip()
     if not line.startswith("{"):
         continue
@@ -276,10 +288,21 @@ else
   # --json mode: stdout is JSONL, not a transcript. Reconstruct the assistant
   # body from agent_message events so the marker-strip fallback below still
   # has plain text to work with.
-  _CODEX_MSG=$(RAW_OUT="$RAW_OUT" python3 - <<'PY' || true
+  # Pass the stream file path, not its content (ARG_MAX / E2BIG — see above).
+  # In this branch RAW_OUT is still the verbatim stream-file cat.
+  _CODEX_MSG=$(MO_RAW_FILE="$_CODEX_STREAM_FILE" python3 - <<'PY' || true
 import json, os
+def _read_raw():
+    p = os.environ.get("MO_RAW_FILE", "")
+    if not p:
+        return ""
+    try:
+        with open(p, "r", errors="replace") as _f:
+            return _f.read()
+    except OSError:
+        return ""
 msgs = []
-for line in os.environ.get("RAW_OUT", "").splitlines():
+for line in _read_raw().splitlines():
     line = line.strip()
     if not line.startswith("{"):
         continue
@@ -308,10 +331,24 @@ rm -f "$_CODEX_LAST_MESSAGE"
 # If we pass that whole transcript through, mini-ork-plan's balanced JSON
 # extractor sees the prompt's example JSON before the actual answer. Keep text
 # after the final bare `codex` marker when present, then remove status lines.
-CLEAN=$(RAW_OUT="$RAW_OUT" python3 - <<'PY'
+# RAW_OUT is transformed by now (last-message body / agent text), so it can't
+# reuse $_CODEX_STREAM_FILE — stage it to a fresh tempfile and pass the path
+# (ARG_MAX / E2BIG: never put a large value in env or argv for exec).
+_CODEX_CLEAN_IN="$(mktemp -t mini-ork-codex-clean.XXXXXX)"
+printf '%s' "$RAW_OUT" > "$_CODEX_CLEAN_IN"
+CLEAN=$(MO_RAW_FILE="$_CODEX_CLEAN_IN" python3 - <<'PY'
 import re, sys
 import os
-txt = os.environ.get("RAW_OUT", "")
+def _read_raw():
+    p = os.environ.get("MO_RAW_FILE", "")
+    if not p:
+        return ""
+    try:
+        with open(p, "r", errors="replace") as _f:
+            return _f.read()
+    except OSError:
+        return ""
+txt = _read_raw()
 lines = txt.splitlines()
 last_codex = -1
 for i, line in enumerate(lines):
@@ -337,6 +374,7 @@ for line in lines:
 print("\n".join(kept).strip())
 PY
 )
+rm -f "$_CODEX_CLEAN_IN"
 [ -z "$CLEAN" ] && CLEAN="$RAW_OUT"
 
 if [ "$FORMAT" = "json" ]; then
@@ -346,14 +384,16 @@ if [ "$FORMAT" = "json" ]; then
   # to us via this CLI surface, so total_cost_usd is 0; caller's
   # _d022_charge_node_cost falls back to $0.01 placeholder which is
   # the documented behavior for executable-wrapper lanes.
-  python3 -c "
+  # Feed CLEAN via stdin, not argv — a large assistant body as a command-line
+  # argument would hit ARG_MAX / E2BIG just like the env-var sites above.
+  printf '%s' "$CLEAN" | python3 -c "
 import json, sys
 print(json.dumps({
-    'result': sys.argv[1],
+    'result': sys.stdin.read(),
     'total_cost_usd': 0.0,
     'model': 'codex',
 }))
-" "$CLEAN"
+"
 else
   printf '%s\n' "$CLEAN"
 fi

--- a/tests/unit/test_cl_codex_e2big.sh
+++ b/tests/unit/test_cl_codex_e2big.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression: cl_codex.sh must never pass the (multi-MB) codex JSONL stream or
+# the assistant body through exec's env/argv — that hits ARG_MAX and dies with
+# E2BIG "Argument list too long" (observed fleet-wide 2026-06-30: every codex
+# dispatch failed at the usage-harvest python3 call). The wrapper now passes a
+# FILE PATH (short) and reads it in python / via stdin. We stub `codex` to emit
+# a ~1.5MB agent_message + several turn.completed events, then assert the
+# wrapper produces clean output + usage/turns/cost sidecars without dying.
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+PASS=0; FAIL=0
+ok(){ echo "  [OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+echo "── unit: cl_codex.sh ARG_MAX/E2BIG regression ──"
+
+# --- stub codex CLI --------------------------------------------------------
+# Honors --output-last-message <path>. Emits thread.started + 2 turn.completed
+# (usage) + one big agent_message on stdout (→ stream file). Writes the big
+# assistant body to the last-message file UNLESS STUB_NO_LASTMSG=1, which forces
+# cl_codex's else-branch that reconstructs the body from the stream (site 279).
+cat > "$TMP/codex" <<'STUB'
+#!/usr/bin/env bash
+last_msg=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output-last-message) last_msg="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+big="$(head -c 1500000 /dev/zero | tr '\0' 'x')"
+printf '{"type":"thread.started","thread_id":"th-1"}\n'
+printf '{"type":"turn.completed","usage":{"input_tokens":1000,"output_tokens":500,"cached_input_tokens":200}}\n'
+printf '{"type":"turn.completed","usage":{"input_tokens":2000,"output_tokens":700,"cached_input_tokens":100}}\n'
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"FINAL_ANSWER %s"}}\n' "$big"
+if [ -z "${STUB_NO_LASTMSG:-}" ] && [ -n "$last_msg" ]; then
+  printf 'FINAL_ANSWER %s' "$big" > "$last_msg"
+fi
+exit 0
+STUB
+chmod +x "$TMP/codex"
+
+run_wrapper(){ # $1=format ; rest via env already set by caller
+  PATH="$TMP:$PATH" bash "$ROOT/lib/providers/cl_codex.sh" --print --output-format "$1" "do the thing"
+}
+
+# ── Scenario A: last-message present (sites 187 harvest + 311 clean + 356) ──
+USAGE="$TMP/a.tokens"; TURNS="$TMP/a.turns.jsonl"; COST="$TMP/a.cost"
+OUT="$(MO_USAGE_FILE="$USAGE" MO_TURNS_FILE="$TURNS" MO_COST_FILE="$COST" run_wrapper text 2>"$TMP/a.err")"
+RC=$?
+grep -qi "argument list too long" "$TMP/a.err" && bad "E2BIG triggered (scenario A)" || ok "no ARG_MAX/E2BIG with 1.5MB stream (A)"
+[ "$RC" -eq 0 ] && ok "wrapper exit 0 (A)" || bad "wrapper rc=$RC (A): $(tail -1 "$TMP/a.err")"
+grep -q "$(printf '3000\t1200')" "$USAGE" 2>/dev/null && ok "usage totals harvested (in=3000 out=1200)" || bad "usage wrong: $(cat "$USAGE" 2>/dev/null)"
+[ -s "$TURNS" ] && ok "turns sidecar written ($(wc -l <"$TURNS" | tr -d ' ') turns)" || bad "turns sidecar empty"
+[ -s "$COST" ] && ok "cost sidecar written ($(cat "$COST"))" || bad "cost sidecar empty"
+printf '%s' "$OUT" | grep -q "FINAL_ANSWER" && ok "clean text output carries assistant body (A)" || bad "clean output missing body (A)"
+
+# ── Scenario B: empty last-message → reconstruct from stream (site 279) ──────
+OUTB="$(STUB_NO_LASTMSG=1 run_wrapper text 2>"$TMP/b.err")"
+RCB=$?
+grep -qi "argument list too long" "$TMP/b.err" && bad "E2BIG triggered (scenario B / site 279)" || ok "no E2BIG reconstructing body from stream (B)"
+[ "$RCB" -eq 0 ] && ok "wrapper exit 0 (B)" || bad "wrapper rc=$RCB (B): $(tail -1 "$TMP/b.err")"
+printf '%s' "$OUTB" | grep -q "FINAL_ANSWER" && ok "reconstructed body carries assistant text (B)" || bad "reconstructed body missing (B)"
+
+# ── Scenario C: json envelope (site 356 — CLEAN via stdin, not argv) ─────────
+OUTJ="$(run_wrapper json 2>"$TMP/c.err")"
+grep -qi "argument list too long" "$TMP/c.err" && bad "E2BIG in json envelope (site 356)" || ok "no E2BIG in json envelope path (C)"
+printf '%s' "$OUTJ" | python3 -c 'import json,sys; d=json.load(sys.stdin); assert d.get("model")=="codex" and "FINAL_ANSWER" in d.get("result",""); print("ok")' >/dev/null 2>&1 \
+  && ok "json envelope valid + carries body (C)" || bad "json envelope invalid (C)"
+
+echo "── Results: $PASS OK  $FAIL FAIL ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

The **codex lane died fleet-wide** with `Argument list too long` (E2BIG). `cl_codex.sh` passed the entire codex JSONL stream (tens of KB–MB for a long implementer turn) as the **`RAW_OUT` environment variable** to `python3`. `execve()` counts env **and** argv against one `ARG_MAX` budget (1 MB on macOS), so a large `RAW_OUT` aborts the exec before python starts — every codex dispatch produced **zero edits**.

## Fix

Pass a short **file path** instead of the content, at all four sites:

| Site | What | Fix |
|---|---|---|
| 187 | usage/turns/cost harvest | read `$_CODEX_STREAM_FILE` directly |
| 279 | reconstruct `agent_message` | read `$_CODEX_STREAM_FILE` directly |
| 311 | strip transcript envelope | stage transformed `RAW_OUT` to a tempfile |
| 356 | json envelope | feed `CLEAN` via **stdin** instead of argv |

## Test

`tests/unit/test_cl_codex_e2big.sh` stubs `codex` with a **1.5 MB stream** (> ARG_MAX) across all three branches (last-message harvest / stream reconstruction / json envelope). Old code crashes with E2BIG; new code passes — **11 OK**. Verified locally that the old `RAW_OUT="$(1.5MB)" python3` pattern reproduces `Argument list too long` at this system's `kern.argmax=1048576`.