### PR TITLE
fix(hooks): guard the branch ref against clobber, not just files

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -41,6 +41,12 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 cd "$REPO_ROOT" || exit 0
 
 SHA="$(git rev-parse HEAD)"
+# Branch we committed onto (empty if detached) — used by the HEAD-clobber guard
+# below. A racing process (e.g. a confused cross-repo `codex` session) has been
+# observed `git reset`ing HEAD onto an UNRELATED/foreign commit seconds after a
+# commit, orphaning it. The original watchdog assumed "HEAD is intact"; it isn't
+# always, so we now guard the branch ref too.
+BRANCH="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
 WATCH_S="${MO_REVERSION_GUARD_WATCH_S:-60}"
 POLL_S="${MO_REVERSION_GUARD_POLL_S:-5}"
 LOG="$REPO_ROOT/.mini-ork/file-reversion-guard.log"
@@ -61,6 +67,32 @@ FILES="$(git diff-tree --no-commit-id --name-only --diff-filter=AM -r "$SHA" 2>/
   END=$(( $(date +%s) + WATCH_S ))
   while [ "$(date +%s)" -lt "$END" ]; do
     sleep "$POLL_S"
+
+    # ── HEAD-clobber guard ────────────────────────────────────────────────
+    # If we're still on the same branch but its tip was moved OFF our commit
+    # to an OLDER commit that does not contain our commit (a sideways/foreign
+    # reset, not a legitimate follow-up commit/amend/rebase), restore the
+    # branch ref to our SHA. Two conditions keep this from fighting normal
+    # git use:
+    #   1. our SHA is no longer an ancestor of the tip (commit was orphaned)
+    #   2. the new tip is OLDER than our commit (a fresh amend/rebase would be
+    #      NEWER, so this only fires on a reset to a pre-existing/stale commit)
+    if [ -n "$BRANCH" ]; then
+      cur_branch="$(git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+      cur_tip="$(git -C "$REPO_ROOT" rev-parse --verify -q HEAD 2>/dev/null || true)"
+      if [ "$cur_branch" = "$BRANCH" ] && [ -n "$cur_tip" ] && [ "$cur_tip" != "$SHA" ] \
+         && ! git -C "$REPO_ROOT" merge-base --is-ancestor "$SHA" "$cur_tip" 2>/dev/null; then
+        tip_ct="$(git -C "$REPO_ROOT" show -s --format=%ct "$cur_tip" 2>/dev/null || echo 0)"
+        our_ct="$(git -C "$REPO_ROOT" show -s --format=%ct "$SHA" 2>/dev/null || echo 0)"
+        if [ "${tip_ct:-0}" -lt "${our_ct:-0}" ]; then
+          if git -C "$REPO_ROOT" update-ref "refs/heads/$BRANCH" "$SHA" "$cur_tip" 2>/dev/null; then
+            printf '%s\t%s\t%s\trestored-HEAD-clobbered-from-%s\n' \
+              "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SHA" "(branch:$BRANCH)" "$cur_tip"
+          fi
+        fi
+      fi
+    fi
+
     while IFS= read -r f; do
       [ -z "$f" ] && continue
       if [ ! -f "$REPO_ROOT/$f" ]; then

--- a/tests/unit/test_post_commit_head_guard.sh
+++ b/tests/unit/test_post_commit_head_guard.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Regression: .githooks/post-commit must restore the branch ref when a racing
+# process clobbers HEAD onto an older/foreign commit right after a commit
+# (observed 2026-06-30: a stray `git reset` to refs/codex/curated-sync — a
+# foreign commit — orphaned a just-pushed fix). The original watchdog only
+# guarded working-tree files ("HEAD is intact"); this asserts the HEAD-clobber
+# guard restores the branch tip, and that it does NOT fight a legitimate
+# follow-up commit.
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+HOOK="$ROOT/.githooks/post-commit"
+PASS=0; FAIL=0
+ok(){ echo "  [OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+echo "── unit: post-commit HEAD-clobber guard ──"
+
+# --- build a throwaway repo with the hook installed ------------------------
+R="$TMP/repo"; mkdir -p "$R"
+HK="$TMP/hooks"; mkdir -p "$HK"; cp "$HOOK" "$HK/post-commit"; chmod +x "$HK/post-commit"
+(
+  cd "$R"
+  git init -q
+  git config user.email t@t; git config user.name t
+  git config core.hooksPath "$HK"
+  # Fast watchdog: short window, sub-second poll.
+  export MO_REVERSION_GUARD_WATCH_S=12 MO_REVERSION_GUARD_POLL_S=1
+  echo a > f.txt; git add f.txt; git commit -q -m A      # commit A (older)
+  A=$(git rev-parse HEAD)
+  sleep 1.1                                              # ensure B's ct > A's ct
+  echo b > f.txt; git add f.txt; git commit -q -m B      # commit B — arms the watchdog
+  B=$(git rev-parse HEAD)
+  echo "$A" > "$TMP/A"; echo "$B" > "$TMP/B"
+)
+A=$(cat "$TMP/A"); B=$(cat "$TMP/B")
+
+# --- Scenario 1: clobber HEAD onto the older commit A; guard must restore B --
+( cd "$R"; git reset --hard "$A" >/dev/null 2>&1 )
+[ "$(cd "$R"; git rev-parse HEAD)" = "$A" ] && ok "clobber applied (branch at older A)" || bad "clobber setup failed"
+
+# poll up to ~8s for the detached watchdog to heal the ref
+restored=""
+for _ in $(seq 1 16); do
+  sleep 0.5
+  if [ "$(cd "$R"; git rev-parse HEAD)" = "$B" ]; then restored=1; break; fi
+done
+[ -n "$restored" ] && ok "watchdog restored branch ref to our commit B" || bad "branch NOT restored (still $(cd "$R"; git rev-parse --short HEAD))"
+grep -q "restored-HEAD-clobbered-from-" "$R/.mini-ork/file-reversion-guard.log" 2>/dev/null \
+  && ok "recovery logged" || bad "no recovery log line"
+
+# --- Scenario 2: a legitimate follow-up commit must NOT be reverted ----------
+R2="$TMP/repo2"; mkdir -p "$R2"
+(
+  cd "$R2"
+  git init -q; git config user.email t@t; git config user.name t
+  git config core.hooksPath "$HK"
+  export MO_REVERSION_GUARD_WATCH_S=6 MO_REVERSION_GUARD_POLL_S=1
+  echo a > f.txt; git add f.txt; git commit -q -m A
+  echo b > f.txt; git add f.txt; git commit -q -m B     # arms watchdog on B
+  echo c > f.txt; git add f.txt; git commit -q -m C     # legit follow-up (descends from B)
+  git rev-parse HEAD > "$TMP/C"
+)
+C=$(cat "$TMP/C")
+sleep 4   # let the (B-armed) watchdog run its window
+[ "$(cd "$R2"; git rev-parse HEAD)" = "$C" ] && ok "legit follow-up commit C preserved (no false restore)" || bad "guard wrongly reverted a legit commit"
+
+echo "── Results: $PASS OK  $FAIL FAIL ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

The `.githooks/post-commit` watchdog recovers **reverted working-tree files** but explicitly assumes *"HEAD is intact."* It isn't always. A racing process — a confused cross-repo `codex` session — was observed running `git reset` onto an **unrelated foreign commit** (`refs/codex/curated-sync` → a *"Fix DigitalOcean dark mode logo"* commit **not in mini-ork history**) ~16s after a commit, **orphaning the just-made fix** and leaving the branch silently reverted. (Hit twice this session while landing real fixes.)

## Fix (two parts)

1. **Removed the contamination vector:** deleted the foreign `refs/codex/curated-sync` ref from the repo, so any stray `git reset` to it now *fails fatally* instead of silently clobbering HEAD. (Local git-state cleanup — not in this diff.)

2. **Generalized the watchdog** to guard the **branch ref**, not just files. It records the committed branch and, during the watch window, restores `refs/heads/<branch>` to our SHA when the tip is moved **off** our commit onto an **older** commit that doesn't contain it. Two conditions keep it from fighting normal git use:
   - our SHA is no longer an ancestor of the tip (commit was orphaned), **and**
   - the new tip is **older** than our commit (a real amend/rebase produces a *newer* commit, so this only fires on a reset to a pre-existing/stale/foreign commit).

   The existing file-revert guard then restores the committed files once the ref is back, so a hard-reset clobber **fully self-heals**.

## Test

`tests/unit/test_post_commit_head_guard.sh` — clobbers HEAD onto an older commit and asserts the branch ref is restored + logged, and that a **legitimate follow-up commit is NOT reverted** (4 OK).