### PR TITLE
docs: Rivet-parity roadmap + ADR-001 (Bash→Python migration)

### DIFF
--- a/docs/_meta/adr-001-python-migration.md
+++ b/docs/_meta/adr-001-python-migration.md
@@ -1,0 +1,127 @@
+# ADR-001 — Migrate mini-ork's core from Bash to Python
+
+- **Status:** Proposed
+- **Date:** 2026-06-30
+- **Deciders:** maintainers
+- **Related:** [Rivet-parity roadmap](./rivet-parity-roadmap.md) (Phase 0)
+
+## Context
+
+mini-ork's core — the universal loop (classify→plan→execute→verify→reflect→
+improve→eval→promote), the recipe runner, `lib/llm-dispatch.sh`, the lane
+lenses, and the GRPO learning loop — is implemented in Bash with SQLite state
+and `jq`/heredoc JSON handling. The newest and hardest subsystems are *already*
+Python: the FastAPI control plane (`mini_ork/web`, PR #34), `mini_ork/client.py`,
+and traceotter (~888 LOC). The repo is therefore already bilingual, with Python
+owning the parts that needed real data structures.
+
+Bash has hit a structural ceiling. Nearly every defect fixed in the 2026-06-30
+working session was a Bash/`exec`/process-fragility bug, not a logic bug:
+
+| Defect | Bash root cause |
+|---|---|
+| codex lane dead fleet-wide (E2BIG) | `RAW_OUT="$big" python3` — `execve()` counts env+argv against `ARG_MAX` |
+| shim reported `rc=0` on hard failure | `if cmd; then…; fi` with no `else` returns 0; `$?` after `fi` masks the rc |
+| pre-push/post-commit hook clobbered HEAD | hand-rolled hooks `git reset` the worktree and don't restore on failure |
+| orphaned runs, dangling `node_start` events | `.pid` / `.stop-requested` / `.cost-pause` sentinel-file coordination |
+| framework-edit capture unreliable | diff-vs-implementer-worktree heredoc harvesting |
+
+These are not isolated; they are the cost of orchestrating subprocesses, parsing
+JSON, and coordinating concurrency in a language with no types, no exceptions,
+no structured concurrency, and a `set -uo pipefail` minefield.
+
+## Decision
+
+**Migrate the mini-ork core to Python, incrementally (strangler-fig), starting
+with `llm-dispatch`. Do not rewrite big-bang. Do not migrate to Rust/Go/TS.**
+
+Python is chosen because:
+
+1. **Ecosystem fit.** mini-ork is LLM-agent *orchestration logic*. That world —
+   Anthropic/OpenAI SDKs, pydantic, FastAPI, the ML tooling universe — is
+   Python-first. (Rivet chose Rust because Rivet is *infrastructure*, where
+   cold-start/CPU/memory dominate. mini-ork's bottleneck is LLM **network
+   latency**, so a systems language buys nothing.)
+2. **Consolidation, not a third language.** ~40% of the value already lives in
+   Python; this migrates the rest *onto* it.
+3. **It deletes the bug classes above.** No shell `exec` layer (no `ARG_MAX`),
+   real exceptions/return values (no `rc=0` masking), structured subprocess +
+   DB-transaction coordination (no sentinel files), structured return values
+   (no heredoc capture).
+4. **Concurrency fits.** Parallel lenses are I/O-bound; `asyncio` is built for
+   "fan out N model calls, await all." The GIL is irrelevant for
+   network/subprocess-bound work; Bash's `&`/`wait`/FIFO juggling (which the
+   `cl_codex.sh` comments admit wedges on macOS) disappears.
+
+## Alternatives considered
+
+| Option | Verdict | Why |
+|---|---|---|
+| **Python** | **Chosen** | Ecosystem-native, reuses existing code, kills the bug classes, lowest migration cost |
+| TypeScript / Node | Rejected | Viable + strong async, but discards the Python investment and is less ML-native |
+| Go | Rejected | Great concurrency + single-binary, but discards Python and is weak in the AI ecosystem; only wins if single-binary distribution were goal #1 (it isn't for a dev tool) |
+| Rust | Rejected | Right for Rivet's runtime layer, wrong for an I/O-bound orchestrator; ~6-month rewrite to optimize the 2% that isn't network wait; small AI-logic contributor pool |
+| Stay on Bash | Rejected | Structural ceiling demonstrated; blocks the actor/durable-execution roadmap |
+
+## Consequences
+
+**Positive**
+- Eliminates the `ARG_MAX`, rc-masking, hook-clobber, sentinel-file, and
+  capture-unreliability defect classes.
+- `pydantic` models replace `jq`/heredoc JSON parsing — the LLM envelopes become
+  typed contracts.
+- `pytest` replaces fragile Bash test harnesses; CI gets faster and more honest.
+- **Unlocks the Rivet roadmap.** Actor-per-run (T3.1) and durable-execution
+  (T3.2) are natural in `asyncio` (or via a durable-execution lib like Temporal's
+  Python SDK) and effectively impossible to do cleanly in Bash. This migration is
+  the **prerequisite** for that work, not a parallel effort.
+
+**Negative / risks**
+- Migration effort across a large surface; mitigated by the strangler-fig phasing
+  (ship value each phase, never a frozen rewrite).
+- Python packaging/deps friction; mitigated by `uv` + a locked environment.
+- Two languages coexist during transition; mitigated by a hard rule: new code is
+  Python, Bash is only *called*, never *extended*.
+
+## What we keep (do NOT rewrite)
+- The SQLite schema + `db/migrations/` (the data model is sound).
+- Recipes-as-data (`recipes/**/*.yaml`) — the orchestration *content*.
+- The GRPO reward / PRM math and the `MO_*` / `MINI_ORK_*` env-knob surface
+  (port the semantics 1:1; validate with the existing learning-loop tests).
+- The FastAPI control plane (already Python — it becomes the spine).
+
+## Migration plan (phased, strangler-fig)
+
+**Phase 0 — Scaffold (no behavior change).**
+- `uv`-managed package; `typer` CLI skeleton; `pydantic` models for the run,
+  node, lane-result, and LLM-envelope shapes; a thin `subprocess`/`asyncio`
+  dispatch primitive. New `bin/mini-ork` is Python and *shells out* to every
+  unported subsystem. Parity test: Python entrypoint reproduces current CLI
+  surface.
+
+**Phase 1 — `llm-dispatch` (the part that keeps breaking).**
+- Port `lib/llm-dispatch.sh` + the lane wrappers (`cl_*.sh`) to a Python
+  `dispatch` module: typed provider adapters, prompt/stream via files/stdin (no
+  env-var payloads → no E2BIG), real rc/exception propagation, token+cost
+  sidecars as return values. Retire `test_d013_d014` / `test_cl_codex_e2big` once
+  their conditions are structurally impossible.
+
+**Phase 2 — The universal loop.**
+- Port classify→plan→execute→verify→reflect as an `asyncio` workflow with a
+  per-node journal (this is also roadmap T3.2's seed). Lenses fan out with
+  `asyncio.gather`. State writes go through DB transactions, not sentinel files.
+
+**Phase 3 — Recipes + epics/scheduler.**
+- Recipe runner reads the existing YAML; the epics/scheduler queue becomes
+  async tasks. Auto-merge + review gates wired through the control plane.
+
+**Phase 4 — Retire Bash + the sentinel/hook machinery.**
+- Replace `.pid`/`.stop-requested` coordination with the actor model (roadmap
+  T3.1); replace hand-rolled git hooks with `lefthook` (roadmap T1.1). Delete the
+  Bash core once every phase has a Python equivalent under test.
+
+## Acceptance / done-ness
+- Each phase ships behind tests with the Bash path still callable until the
+  Python path reaches parity; no phase regresses the learning-loop validation.
+- The migration is "done" when `lib/*.sh` core modules are deleted and CI runs
+  only `pytest` + the control-plane smoke suite.

--- a/docs/_meta/rivet-parity-roadmap.md
+++ b/docs/_meta/rivet-parity-roadmap.md
@@ -1,0 +1,211 @@
+# Rivet-parity roadmap — best practices to adopt into mini-ork
+
+> Source: comparison of `rivet-dev/rivet` (Apache-2.0 Rust actor runtime, 5.6k★)
+> against mini-ork (Bash + SQLite LLM orchestration framework). Written 2026-06-30.
+
+Rivet and mini-ork sit at **different layers** — Rivet is *infrastructure you build
+agents on*; mini-ork is an *orchestration harness that drives LLMs to do work*. They
+are not competitors. The value is in borrowing Rivet's **programming model** (actors,
+durable workflows, co-located state, observability) and its **repo hygiene**
+(declarative hooks, schema-first SDKs, dependency/format gates, benchmarks-with-
+methodology) — **not** its planetary-scale infra (global edge, infinite horizontal
+scale, multi-region placement), which is out of scope for a single-machine dev
+orchestrator.
+
+Each item: **what Rivet does → what mini-ork does today → target → acceptance →
+effort → autonomous-safe?** "Autonomous-safe" means it can be applied by a mini-ork
+dispatch and mechanically verified without risking the review/safety gates.
+
+---
+
+## Phase 0 — Language migration (Bash → Python) ⭐⭐⭐ — gates everything below
+
+> Full rationale + phased plan: **[ADR-001](./adr-001-python-migration.md)**.
+
+The single highest-leverage change, and a prerequisite for the Tier-3 epics.
+mini-ork is LLM-agent *orchestration logic*; that ecosystem is Python-first, ~40%
+of the value is already Python (FastAPI control plane, client, traceotter), and
+nearly every defect this session was a Bash/`exec`/process-fragility bug (E2BIG
+`ARG_MAX`, `if`-no-`else` rc masking, hook worktree clobber, sentinel-file
+coordination, heredoc capture). **Not** Rust (right for Rivet's runtime layer,
+wrong for an I/O-bound orchestrator) — see ADR-001 alternatives.
+
+- **P0.1** Scaffold: `uv` package, `typer` CLI, `pydantic` models, async dispatch
+  primitive; Python `bin/mini-ork` shells out to unported subsystems.
+- **P0.2** Port `llm-dispatch` + lane wrappers (prompt/stream via files/stdin →
+  no E2BIG; real rc/exceptions). **Start here.**
+- **P0.3** Port the universal loop as an `asyncio` workflow with a per-node
+  journal (also seeds T3.2).
+- **P0.4** Port recipes + epics/scheduler; retire Bash + sentinel/hook machinery
+  (folds in T1.1 lefthook + T3.1 actor model).
+- **Keep:** SQLite schema/migrations, recipes-as-data YAML, GRPO/PRM math, the
+  `MO_*` env surface, the FastAPI control plane.
+- **Effort:** XL (phased, strangler-fig — ships value each phase). **Autonomous-safe:**
+  ❌ human-led; individual phase slices may be dispatched once Python scaffolding exists.
+
+Tiers 1–3 below assume Phase 0 is underway: prefer landing each item in **Python**
+where the surface has already been ported, rather than extending Bash.
+
+---
+
+## Tier 1 — Quick wins (autonomous-safe, low architectural risk)
+
+### T1.1 — Declarative git hooks (lefthook) ⭐
+- **Rivet:** `lefthook.yml` declaratively wires git hooks.
+- **mini-ork today:** hand-written `.githooks/pre-push` + `post-commit`. The
+  post-commit watchdog and an external process have clobbered HEAD this session
+  (reset to a foreign `refs/codex/curated-sync`). Hand-rolled hooks are the bug
+  surface.
+- **Target:** adopt `lefthook.yml` as the hook manager; keep the existing checks
+  (readme-claim-check, pre_push_review, reversion-guard) as *commands lefthook
+  invokes*, not as bespoke scripts that mutate the worktree.
+- **Acceptance:** `lefthook install` wires pre-push + post-commit; Layer-1 claim
+  check and Layer-3 reviewer still fire on push; no hook performs `git reset`/
+  `checkout` of the user's branch; `tests/unit/test_post_commit_head_guard.sh`
+  still passes.
+- **Effort:** M. **Autonomous-safe:** ⚠️ partial — porting the Layer-3 reviewer
+  gate is delicate; do the scaffolding autonomously, gate the reviewer wiring on
+  human review.
+
+### T1.2 — Schema-first API + generated client ⭐ (control-plane, PR #34)
+- **Rivet:** defines its API once (`rivetkit-json-schema` / `-openapi` /
+  `-asyncapi`) and generates TS/Python/Rust/Swift clients.
+- **mini-ork today:** `mini_ork/client.py` and the `mini_ork/web/routes/*`
+  handlers (launch/steer/stop/kill/profile/answers from PR #34) are hand-written
+  and drift independently.
+- **Target:** author a single OpenAPI 3.1 spec (`schemas/control-plane.openapi.yaml`)
+  describing every PR #34 endpoint + request/response shape; add a CI check that
+  the spec matches the live FastAPI routes; (stretch) generate the Python client
+  from the spec so server + SDK never drift.
+- **Acceptance:** spec validates (`openapi-spec-validator`); a test asserts each
+  documented path/method exists in the FastAPI app and vice-versa (no
+  undocumented or phantom routes); client smoke test still green.
+- **Effort:** M. **Autonomous-safe:** ✅ (spec + drift test). Client codegen:
+  stretch.
+
+### T1.3 — `AGENTS.md` + publishable coding-agent skill
+- **Rivet:** ships `AGENTS.md` and `npx skills add rivet-dev/skills`.
+- **mini-ork today:** has a `CLAUDE.md` + an internal `mini-ork` skill.
+- **Target:** add a tool-agnostic `AGENTS.md` (mirrors CLAUDE.md guidance for
+  Cursor/Windsurf/etc.); document how to install the `mini-ork` skill.
+- **Acceptance:** `AGENTS.md` exists, links the recipe catalogue + lane policy;
+  README references it.
+- **Effort:** S. **Autonomous-safe:** ✅
+
+### T1.4 — Format + dependency/policy gates
+- **Rivet:** `biome.json`, `rustfmt.toml`, `deny.toml` (cargo-deny), `.editorconfig`.
+- **mini-ork today:** shellcheck + GitGuardian + readme-claim-check; no formatter,
+  no editorconfig, OSS-vet rules enforced by hand.
+- **Target:** add `.editorconfig`; add `shfmt` config + a `make fmt`/CI format
+  check for bash; add a `deny`-style policy file encoding the OSS-vet rules (no
+  absolute `/Users`/`/Volumes` paths, no API keys, no foreign-repo paths) as a
+  scriptable gate.
+- **Acceptance:** `.editorconfig` present; `shfmt -d` clean on `lib/ bin/ tests/`;
+  the OSS-vet policy gate runs in CI and passes on a clean tree, fails on a
+  planted violation.
+- **Effort:** S–M. **Autonomous-safe:** ✅
+
+### T1.5 — `justfile` + `examples/`
+- **Rivet:** `justfile` for canonical dev commands; `examples/` per use case.
+- **mini-ork today:** commands scattered across `bin/` + `scripts/` + `make`.
+- **Target:** a `justfile` aliasing the canonical flows (init, run, scheduler,
+  test layers, fmt, serve); an `examples/` dir with 2–3 runnable kickoff+recipe
+  pairs.
+- **Acceptance:** `just --list` shows the canonical commands; each example has a
+  README and a one-command invocation.
+- **Effort:** S. **Autonomous-safe:** ✅
+
+### T1.6 — Benchmarks-with-methodology ⭐
+- **Rivet:** README publishes hard numbers *with* a reproducible methodology block.
+- **mini-ork today:** "self-improving, no reward model" is asserted, not measured.
+- **Target:** a `bench/` script that measures learning-loop value — routing-regret
+  reduction over N runs, cost saved vs the static map, lane-win convergence — and
+  emits a methodology block for the README/blog.
+- **Acceptance:** `bench/learning-loop.sh` runs offline (`MINI_ORK_DRY_RUN=1` with
+  synthetic traces) and prints reproducible numbers + methodology; README gains a
+  "Benchmarks" section.
+- **Effort:** M. **Autonomous-safe:** ✅ (offline/synthetic).
+
+---
+
+## Tier 2 — Moderate (mostly the observability/web surface)
+
+### T2.1 — Built-in inspector ⭐
+- **Rivet:** live SQLite viewer, workflow-state stepper (steps + retries), event
+  monitor, REPL.
+- **mini-ork today:** `mini_ork/web` obs surface + the PR #34 SSE stream (≈60% there).
+- **Target:** a live `state.db` viewer; a run-stepper showing each node's
+  retries/verdicts; an event tail over `run_events`; a REPL to invoke a
+  lane/recipe interactively.
+- **Effort:** L. **Autonomous-safe:** ⚠️ (frontend — human-reviewed).
+
+### T2.2 — Three deployment tiers, one engine
+- **Rivet:** *just a library* (in-process) → *self-host* (single binary/Docker) →
+  *managed cloud*.
+- **Target:** make the ladder explicit — local CLI (today) → `docker run mini-ork
+  serve` (the control plane, packaged) → multi-tenant. Document the progression.
+- **Effort:** M. **Autonomous-safe:** ⚠️ (Dockerfile + docs autonomous; multi-tenant later).
+
+---
+
+## Tier 3 — Architectural epics (human-gated; design-first, NOT one-shot)
+
+### T3.1 — Actor-per-run ⭐⭐
+- **Rivet:** one durable, addressable, long-lived process per unit of work; state
+  co-located in-memory + auto-persisted.
+- **mini-ork today:** a run is a detached bash PID tracked by sentinel files
+  (`.pid`, `.stop-requested`, `.cost-pause`) with a `pgrep`-by-run-id fallback in
+  `kill_run` — the source of orphan processes + dangling `node_start` events on
+  SIGKILL.
+- **Target:** model each `task_run` as a supervised actor — one owner process,
+  co-located run-dir state, a steering queue, a scheduler, an SSE channel; a
+  single addressable handle replaces sentinel-file coordination.
+- **Effort:** XL. **Autonomous-safe:** ❌ design + staged delivery.
+
+### T3.2 — Durable execution / replayable loop ⭐⭐
+- **Rivet:** workflows checkpoint each step, auto-retry, deterministically replay
+  after a crash.
+- **mini-ork today:** the universal loop runs in one bash process; a host crash
+  loses it. State is in `state.db` but there is no step-replay journal.
+- **Target:** a per-node journal so a crashed run resumes from the last completed
+  node; makes the framework-edit publisher/rollback chain crash-safe.
+- **Effort:** XL. **Autonomous-safe:** ❌
+
+### T3.3 — Hibernation / scale-to-zero
+- **Rivet:** runs when active, sleeps when idle, $0 idle.
+- **mini-ork today:** a slow lane holds a live process and burns the
+  `MO_NODE_TIMEOUT_S` budget while merely *waiting on the provider*.
+- **Target:** checkpoint-and-sleep a run blocked on an LLM call; wake on
+  completion/next poll, so many runs coexist without N live processes.
+- **Effort:** L–XL. **Autonomous-safe:** ❌ (depends on T3.1).
+
+### T3.4 — Durable per-run queue (generalize operator_steering)
+- **Rivet:** `for await (const msg of c.queue.iter())`.
+- **mini-ork today:** `operator_steering` rows + HTTP `steer_run` are a poor-man's
+  per-run queue.
+- **Target:** a real durable queue per run carrying steering, HITL approvals, and
+  tool requests with iterate-and-ack semantics.
+- **Effort:** L. **Autonomous-safe:** ❌ (couples to T3.1).
+
+---
+
+## Dispatch plan
+
+- **Now:** kick off **Phase 0** (ADR-001) — P0.1 scaffold, then P0.2
+  `llm-dispatch` port. This is the gating work; everything else lands cleaner once
+  it's underway.
+- **Cheap parallel wins (language-agnostic, safe to do in Bash today):** T1.3
+  (AGENTS.md), T1.4 (.editorconfig + OSS-vet policy gate), T1.5 (justfile) — these
+  are repo-hygiene files that don't extend the Bash core, so they don't fight the
+  migration.
+- **Do in Python as P0 reaches the relevant surface:** T1.2 (OpenAPI schema +
+  drift test — the control plane is already Python), T1.6 (benchmarks).
+- **Human-gated:** T1.1 (lefthook — folds into P0.4), Tier 2.
+- **Design-first epics (require Phase 0):** T3.1 → T3.2 → T3.3/T3.4 (actor model
+  is the prerequisite for the durable-execution + hibernation + queue work, and is
+  natural in `asyncio`, impractical in Bash).
+
+## What NOT to copy
+Global edge network, infinite horizontal scale, multi-region placement, managed-
+cloud control plane. mini-ork is a single-machine dev orchestrator; chasing
+distributed-infra parity is scope creep. Borrow the model, not the datacenter.

--- a/docs/_meta/rivet-parity-roadmap.md
+++ b/docs/_meta/rivet-parity-roadmap.md
@@ -50,6 +50,32 @@ where the surface has already been ported, rather than extending Bash.
 
 ## Tier 1 — Quick wins (autonomous-safe, low architectural risk)
 
+### T1.0 — Parallel-run safety via per-run config isolation ⭐⭐ (active blocker)
+- **Rivet:** each actor owns co-located, per-instance state; instances never
+  contend on shared mutable config.
+- **mini-ork today:** **cannot run two dispatches in parallel safely.**
+  `agents.yaml` (the lane policy) is read *live, per-dispatch* by
+  `lib/decision_service.sh` + `lib/lane-helpers.sh` — there is **no per-run config
+  snapshot**. Editing the global `agents.yaml` while a run is in flight mutates
+  that run's lane routing on its next node. The scheduler is serial by design; the
+  `config/` dir and `state.db` are single-tenant globals.
+- **Target (interim, Bash-implementable, forward-compatible):** snapshot the
+  *effective* config at launch into the run-dir
+  (`runs/<run_id>/config/agents.yaml` + a resolved lane/knob manifest); make the
+  dispatch resolvers read **run-dir-first** (run-dir → `MINI_ORK_HOME` →
+  `MINI_ORK_ROOT`). Result: editing global `agents.yaml` never touches in-flight
+  runs; concurrent runs hold independent frozen policies; runs become reproducible
+  (config captured with the run).
+- **Acceptance:** two concurrent `mini-ork run`s with different launch-time lane
+  policies each keep their own lanes; mutating global `agents.yaml` mid-run does
+  not change a live run's resolved lane (asserted by a test that snapshots, mutates
+  the global, dispatches, and checks the lane); a broader shared-state audit
+  (config dir, `state.db` run-keying, `version_registry`, `coord_gate` locks)
+  documents anything else that needs run-scoping.
+- **Effort:** M. **Autonomous-safe:** ⚠️ touches the dispatch resolver — gate on
+  review. **This is the first concrete slice of T3.1 (actor-per-run) and survives
+  the Phase-0 Python migration unchanged (it's a design pattern, not a band-aid).**
+
 ### T1.1 — Declarative git hooks (lefthook) ⭐
 - **Rivet:** `lefthook.yml` declaratively wires git hooks.
 - **mini-ork today:** hand-written `.githooks/pre-push` + `post-commit`. The


### PR DESCRIPTION
Two docs, no code:

- **`docs/_meta/rivet-parity-roadmap.md`** — the `rivet-dev/rivet` best-practices comparison turned into an actionable roadmap. **Phase 0** (Bash→Python migration, gates everything) + **Tier 1** quick wins (lefthook, schema-first OpenAPI for the PR #34 control plane, AGENTS.md, format/policy gates, justfile, benchmarks-with-methodology) + **Tier 2** (inspector, deploy tiers) + **Tier 3** architectural epics (actor-per-run, durable execution, hibernation, durable queues). Marks what NOT to copy (global edge / infinite scale).
- **`docs/_meta/adr-001-python-migration.md`** — the decision record. Grounds **Python** (not Rust) in this session's defect pattern (E2BIG ARG_MAX, if-no-else rc masking, hook worktree clobber, sentinel-file coordination, heredoc capture — all Bash/exec fragility). Phased strangler-fig plan: scaffold → `llm-dispatch` → loop → recipes → retire Bash. Keeps SQLite schema, recipes-as-data, GRPO math, FastAPI control plane.