### PR TITLE
feat(dispatch): Python port of llm-dispatch core — Phase 0 / P0.2

### DIFF
--- a/mini_ork/dispatch/__init__.py
+++ b/mini_ork/dispatch/__init__.py
@@ -1,0 +1,35 @@
+"""mini_ork.dispatch — typed Python dispatch layer (Phase-0 migration, ADR-001).
+
+The first ported slice of lib/llm-dispatch.sh. Delivers prompts to providers
+over stdin (no E2BIG) and returns typed results with faithful exit codes —
+structurally retiring the two bash failure classes (ARG_MAX, rc-masking).
+Coexists with the bash dispatch (strangler-fig); not yet wired as the default.
+"""
+
+from __future__ import annotations
+
+from .core import dispatch
+from .models import DispatchRequest, DispatchResult, TokenUsage
+from .providers import (
+    KNOWN_MODELS,
+    ProviderSpec,
+    codex_cost,
+    dispatch_model,
+    dispatch_with_command,
+    parse_codex_usage,
+    resolve_provider,
+)
+
+__all__ = [
+    "dispatch",
+    "dispatch_model",
+    "dispatch_with_command",
+    "DispatchRequest",
+    "DispatchResult",
+    "TokenUsage",
+    "ProviderSpec",
+    "resolve_provider",
+    "parse_codex_usage",
+    "codex_cost",
+    "KNOWN_MODELS",
+]

--- a/mini_ork/dispatch/core.py
+++ b/mini_ork/dispatch/core.py
@@ -1,0 +1,103 @@
+"""The dispatch primitive — run a provider command and return a typed result.
+
+This is the Python replacement for the part of lib/llm-dispatch.sh that kept
+breaking. Two structural guarantees the bash version could not make:
+
+  1. **No E2BIG.** The prompt is delivered on STDIN (`input=`), never as an argv
+     element or environment variable. `execve()` counts argv + env against one
+     ARG_MAX budget (~1 MB on macOS); the bash lanes passed the prompt/stream
+     through env vars and died with "Argument list too long" on long turns.
+     Over stdin there is no size limit.
+
+  2. **Faithful rc.** The provider's exit code is read directly off the process
+     object and returned. There is no `if cmd; then …; fi` (which, with no
+     `else`, returns 0 even when the condition failed) to mask a hard failure as
+     success.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from collections.abc import Callable, Sequence
+
+from .models import DispatchRequest, DispatchResult, TokenUsage
+
+# Parser callables turn a provider's stdout into structured telemetry. They are
+# injected (not hard-wired) so the core stays provider-agnostic and unit-testable
+# with a stub provider.
+UsageParser = Callable[[str], TokenUsage]
+CostParser = Callable[[str, TokenUsage], float]
+
+
+def dispatch(
+    request: DispatchRequest,
+    command: Sequence[str],
+    *,
+    parse_usage: UsageParser | None = None,
+    parse_cost: CostParser | None = None,
+) -> DispatchResult:
+    """Run ``command`` (an argv list — no shell), feeding ``request.prompt`` on
+    stdin, and return a :class:`DispatchResult`.
+
+    A non-zero exit, a timeout, or a spawn failure each yield ``ok=False`` with a
+    distinct ``rc`` (the provider's code, ``124`` for timeout, ``127`` for spawn
+    failure) and the captured stderr in ``error`` — the caller always gets a
+    structured result, never an exception to wrangle.
+    """
+    proc_env = dict(os.environ)
+    if request.env:
+        proc_env.update({str(k): str(v) for k, v in request.env.items()})
+
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(
+            list(command),
+            input=request.prompt,  # ← prompt over stdin: structurally E2BIG-proof
+            capture_output=True,
+            text=True,
+            env=proc_env,
+            timeout=request.timeout_s,
+        )
+    except subprocess.TimeoutExpired:
+        return DispatchResult(
+            ok=False,
+            rc=124,
+            error=f"timeout after {request.timeout_s}s",
+            model=request.model,
+            duration_ms=int((time.monotonic() - start) * 1000),
+        )
+    except OSError as exc:
+        return DispatchResult(
+            ok=False,
+            rc=127,
+            error=f"spawn failed: {exc}",
+            model=request.model,
+            duration_ms=int((time.monotonic() - start) * 1000),
+        )
+
+    duration_ms = int((time.monotonic() - start) * 1000)
+    rc = proc.returncode
+    stdout = proc.stdout or ""
+    if rc != 0:
+        return DispatchResult(
+            ok=False,
+            rc=rc,
+            text=stdout,
+            error=(proc.stderr or "")[-2000:],
+            model=request.model,
+            duration_ms=duration_ms,
+        )
+
+    usage = parse_usage(stdout) if parse_usage else TokenUsage()
+    cost = parse_cost(stdout, usage) if parse_cost else 0.0
+    return DispatchResult(
+        ok=True,
+        rc=0,
+        text=stdout,
+        model=request.model,
+        usage=usage,
+        cost_usd=cost,
+        duration_ms=duration_ms,
+    )

--- a/mini_ork/dispatch/models.py
+++ b/mini_ork/dispatch/models.py
@@ -1,0 +1,51 @@
+"""Typed data contracts for the Python dispatch layer (Phase-0 migration, ADR-001).
+
+Stdlib dataclasses (not pydantic) so the dispatch core stays dependency-free —
+it must be importable without the web stack. These replace the untyped
+jq/heredoc JSON shuffling of lib/llm-dispatch.sh: the LLM envelope becomes a
+typed return value instead of env-var side-channels.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Per-call token totals harvested from a provider's output stream."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input_tokens: int = 0
+    cache_creation_tokens: int = 0
+
+
+@dataclass(frozen=True)
+class DispatchRequest:
+    """A single model call. The prompt is delivered to the provider over STDIN
+    (see core.dispatch), never argv/env — so a multi-MB prompt can never hit
+    ARG_MAX/E2BIG, the failure that killed the bash codex lane fleet-wide."""
+
+    model: str
+    prompt: str
+    timeout_s: float = 1500.0
+    max_turns: int = 60
+    # Extra environment for the provider process. The prompt is NEVER put here.
+    env: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DispatchResult:
+    """The outcome of a dispatch. `rc` is propagated faithfully from the
+    provider process — there is no `if cmd; then…; fi` construct that can mask a
+    non-zero exit as success (the bash D-013/D-014 regression)."""
+
+    ok: bool
+    rc: int
+    text: str = ""
+    error: str = ""
+    model: str = ""
+    usage: TokenUsage = field(default_factory=TokenUsage)
+    cost_usd: float = 0.0
+    duration_ms: int = 0

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -1,0 +1,135 @@
+"""Provider registry + telemetry parsers for the Python dispatch layer.
+
+Maps a model lane to the command that runs it and the parsers that turn its
+output into typed telemetry. Faithful port of the harvest logic in
+lib/providers/cl_codex.sh (the codex JSONL usage/cost parse). The lane wrappers
+are reused as the command for now; making them read the prompt from stdin (so
+the whole chain is E2BIG-proof end-to-end, not just the Python boundary) is the
+next migration slice.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from .core import dispatch
+from .models import DispatchRequest, DispatchResult, TokenUsage
+
+# Lanes mini-ork knows about. codex/gemini are executable wrappers; the rest are
+# Anthropic-compatible (claude CLI behind an env-pinned gateway).
+KNOWN_MODELS = frozenset(
+    {"opus", "sonnet", "kimi", "glm", "minimax", "codex", "gemini", "deepseek"}
+)
+
+# Codex list-price defaults (USD per million tokens), matching cl_codex.sh.
+_CODEX_USD_PER_MTOK_IN = 1.25
+_CODEX_USD_PER_MTOK_CACHED = 0.125
+_CODEX_USD_PER_MTOK_OUT = 10.0
+
+
+def parse_codex_usage(stdout: str) -> TokenUsage:
+    """Sum token usage from codex's ``--json`` JSONL event stream.
+
+    Faithful port of cl_codex.sh: accumulate ``turn.completed`` usage across all
+    turns. Non-JSON / malformed lines are skipped, never fatal.
+    """
+    in_tok = out_tok = cached_tok = 0
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            ev = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if ev.get("type") == "turn.completed":
+            u = ev.get("usage") or {}
+            in_tok += int(u.get("input_tokens") or 0)
+            out_tok += int(u.get("output_tokens") or 0)
+            cached_tok += int(u.get("cached_input_tokens") or 0)
+    return TokenUsage(
+        input_tokens=in_tok, output_tokens=out_tok, cached_input_tokens=cached_tok
+    )
+
+
+def codex_cost(_stdout: str, usage: TokenUsage) -> float:
+    """Estimate codex cost from token usage at list price. ``input_tokens``
+    already INCLUDES the cached tokens (which bill at the discounted rate), so
+    subtract them before applying the full input rate — same as cl_codex.sh."""
+    fresh_in = max(usage.input_tokens - usage.cached_input_tokens, 0)
+    return (
+        fresh_in * _CODEX_USD_PER_MTOK_IN
+        + usage.cached_input_tokens * _CODEX_USD_PER_MTOK_CACHED
+        + usage.output_tokens * _CODEX_USD_PER_MTOK_OUT
+    ) / 1e6
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """How to run one model lane and read its telemetry."""
+
+    model: str
+    command: tuple[str, ...]
+    parse_usage: object | None = None  # UsageParser | None
+    parse_cost: object | None = None  # CostParser | None
+
+
+def mini_ork_root(root: str | os.PathLike[str] | None = None) -> Path:
+    """Repo root: explicit arg → $MINI_ORK_ROOT → package parent."""
+    if root is not None:
+        return Path(root).resolve()
+    env = os.environ.get("MINI_ORK_ROOT")
+    if env:
+        return Path(env).resolve()
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_provider(
+    model: str, root: str | os.PathLike[str] | None = None
+) -> ProviderSpec:
+    """Resolve a model lane to its :class:`ProviderSpec`.
+
+    Raises ``ValueError`` for an unknown lane (we never invent a provider) and
+    ``FileNotFoundError`` if the wrapper script is missing.
+    """
+    if model not in KNOWN_MODELS:
+        raise ValueError(f"unknown model lane: {model!r}")
+    wrapper = mini_ork_root(root) / "lib" / "providers" / f"cl_{model}.sh"
+    if not wrapper.is_file():
+        raise FileNotFoundError(f"provider wrapper not found: {wrapper}")
+    command: tuple[str, ...] = (str(wrapper), "--print", "--output-format", "text")
+    if model == "codex":
+        return ProviderSpec(model, command, parse_codex_usage, codex_cost)
+    return ProviderSpec(model, command)
+
+
+def dispatch_model(
+    request: DispatchRequest, root: str | os.PathLike[str] | None = None
+) -> DispatchResult:
+    """Resolve ``request.model`` to a provider and dispatch it. Unknown lane /
+    missing wrapper come back as a structured ``ok=False`` result, not a raise."""
+    try:
+        spec = resolve_provider(request.model, root)
+    except (ValueError, FileNotFoundError) as exc:
+        return DispatchResult(ok=False, rc=2, error=str(exc), model=request.model)
+    return dispatch(
+        request,
+        spec.command,
+        parse_usage=spec.parse_usage,  # type: ignore[arg-type]
+        parse_cost=spec.parse_cost,  # type: ignore[arg-type]
+    )
+
+
+def dispatch_with_command(
+    request: DispatchRequest,
+    command: Sequence[str],
+    *,
+    parse_usage: object | None = None,
+    parse_cost: object | None = None,
+) -> DispatchResult:
+    """Escape hatch for tests / custom commands: dispatch an explicit argv."""
+    return dispatch(request, command, parse_usage=parse_usage, parse_cost=parse_cost)  # type: ignore[arg-type]

--- a/tests/test_dispatch_py.py
+++ b/tests/test_dispatch_py.py
@@ -1,0 +1,124 @@
+"""Tests for mini_ork.dispatch — the Phase-0 Python port of llm-dispatch.
+
+Asserts the two bash failure classes are structurally impossible in the Python
+layer (E2BIG over stdin, faithful rc) and that the codex telemetry parser is a
+faithful port of cl_codex.sh.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from mini_ork.dispatch import (
+    DispatchRequest,
+    TokenUsage,
+    codex_cost,
+    dispatch_model,
+    dispatch_with_command,
+    parse_codex_usage,
+    resolve_provider,
+)
+
+PY = sys.executable
+
+
+def _req(prompt: str, **kw) -> DispatchRequest:
+    return DispatchRequest(model="stub", prompt=prompt, **kw)
+
+
+def test_no_e2big_with_multi_mb_prompt():
+    # 1.5 MB prompt — well over macOS ARG_MAX (~1 MB). Passing this as an argv
+    # element or env var (what the bash lanes did) aborts execve() with E2BIG.
+    # Over stdin there is no limit: the stub reads it and reports its length.
+    big = "x" * 1_500_000
+    cmd = [PY, "-c", "import sys; sys.stdout.write(str(len(sys.stdin.read())))"]
+    res = dispatch_with_command(_req(big), cmd)
+    assert res.ok is True
+    assert res.rc == 0
+    assert res.text.strip() == str(len(big))
+
+
+def test_rc_is_propagated_faithfully_on_failure():
+    # A non-zero exit must surface as ok=False with the real rc — the bash shim
+    # `if cmd; then…; fi` (no else) returned 0 here (D-013/D-014 regression).
+    cmd = [PY, "-c", "import sys; sys.stderr.write('boom\\n'); sys.exit(7)"]
+    res = dispatch_with_command(_req("hello"), cmd)
+    assert res.ok is False
+    assert res.rc == 7
+    assert "boom" in res.error
+
+
+def test_stdout_captured_on_success():
+    cmd = [PY, "-c", "print('ANSWER-42')"]
+    res = dispatch_with_command(_req("q"), cmd)
+    assert res.ok is True
+    assert "ANSWER-42" in res.text
+
+
+def test_timeout_yields_rc_124():
+    cmd = [PY, "-c", "import time; time.sleep(5)"]
+    res = dispatch_with_command(_req("q", timeout_s=0.4), cmd)
+    assert res.ok is False
+    assert res.rc == 124
+    assert "timeout" in res.error
+
+
+def test_spawn_failure_yields_rc_127():
+    res = dispatch_with_command(_req("q"), ["/nonexistent/binary-xyz"])
+    assert res.ok is False
+    assert res.rc == 127
+
+
+def test_codex_usage_parser_sums_turns():
+    stream = "\n".join(
+        [
+            '{"type":"thread.started","thread_id":"t1"}',
+            '{"type":"turn.completed","usage":{"input_tokens":1000,"output_tokens":500,"cached_input_tokens":200}}',
+            "not-json-noise",
+            '{"type":"turn.completed","usage":{"input_tokens":2000,"output_tokens":700,"cached_input_tokens":100}}',
+        ]
+    )
+    u = parse_codex_usage(stream)
+    assert u.input_tokens == 3000
+    assert u.output_tokens == 1200
+    assert u.cached_input_tokens == 300
+
+
+def test_codex_cost_subtracts_cached_before_full_rate():
+    u = TokenUsage(input_tokens=3000, output_tokens=1200, cached_input_tokens=300)
+    # fresh_in=2700 -> (2700*1.25 + 300*0.125 + 1200*10.0)/1e6
+    expected = (2700 * 1.25 + 300 * 0.125 + 1200 * 10.0) / 1e6
+    assert codex_cost("", u) == pytest.approx(expected)
+
+
+def test_dispatch_through_a_codex_style_stub():
+    # End-to-end: a stub that emits codex JSONL on stdout, parsed via the codex
+    # parsers — proves the parser wiring path returns typed telemetry.
+    emit = (
+        "import sys; "
+        "sys.stdout.write('"
+        '{"type":"turn.completed","usage":{"input_tokens":10,"output_tokens":5,"cached_input_tokens":2}}'
+        "')"
+    )
+    res = dispatch_with_command(
+        _req("q"), [PY, "-c", emit], parse_usage=parse_codex_usage, parse_cost=codex_cost
+    )
+    assert res.ok is True
+    assert res.usage.input_tokens == 10
+    assert res.usage.output_tokens == 5
+    assert res.cost_usd == pytest.approx((8 * 1.25 + 2 * 0.125 + 5 * 10.0) / 1e6)
+
+
+def test_unknown_lane_is_structured_not_raised():
+    res = dispatch_model(DispatchRequest(model="not-a-real-lane", prompt="q"))
+    assert res.ok is False
+    assert res.rc == 2
+    assert "unknown model lane" in res.error
+
+
+def test_resolve_known_lane_points_at_wrapper():
+    spec = resolve_provider("codex")
+    assert spec.command[0].endswith("lib/providers/cl_codex.sh")
+    assert spec.parse_usage is parse_codex_usage


### PR DESCRIPTION
## Phase 0 begins (ADR-001)
First ported slice of `lib/llm-dispatch.sh` — the module that broke most this session. New `mini_ork.dispatch` package (stdlib dataclasses, **zero new deps**, **coexists with the bash** via strangler-fig; not yet wired as default).

| file | role |
|---|---|
| `models.py` | typed `DispatchRequest` / `DispatchResult` / `TokenUsage` |
| `core.py` | `dispatch()`: runs a provider argv (no shell), prompt over **stdin**, returns a typed result with the **faithful exit code** |
| `providers.py` | model registry + codex JSONL usage/cost parsers (faithful port of `cl_codex.sh`) + `dispatch_model` |

## The two bash failure classes — now structurally impossible
- **E2BIG** (killed the codex lane fleet-wide): the prompt goes over **stdin**, never argv/env, so a multi-MB prompt can't hit `ARG_MAX`.
- **rc-masking** (D-013/D-014): the exit code is read off the process object — no `if cmd; then…; fi` (no `else` ⇒ returns 0 on failure) to mask it.

## Test — `tests/test_dispatch_py.py` (10 passing)
1.5 MB prompt dispatches with **no E2BIG**; `rc=7` → `ok=False/rc=7`; timeout → 124; spawn-fail → 127; codex usage parser sums turns; codex cost subtracts cached before full rate; unknown lane returns a structured result (no raise).

## Scope / next
This is the **typed core**. Wiring it as the live dispatch path — and giving the `cl_*.sh` wrappers a stdin mode so the chain is E2BIG-proof end-to-end — is the next P0 slice. Keeps SQLite schema, recipes-as-data, GRPO math, FastAPI control plane untouched.