### PR TITLE
feat(dispatch): claude-family lanes in the Python dispatch registry (P0)

### DIFF
--- a/mini_ork/dispatch/__init__.py
+++ b/mini_ork/dispatch/__init__.py
@@ -11,11 +11,16 @@ from __future__ import annotations
 from .core import dispatch
 from .models import DispatchRequest, DispatchResult, TokenUsage
 from .providers import (
+    EXECUTABLE_MODELS,
     KNOWN_MODELS,
     ProviderSpec,
+    claude_cost,
+    claude_env_for,
+    claude_result_text,
     codex_cost,
     dispatch_model,
     dispatch_with_command,
+    parse_claude_usage,
     parse_codex_usage,
     resolve_provider,
 )
@@ -31,5 +36,10 @@ __all__ = [
     "resolve_provider",
     "parse_codex_usage",
     "codex_cost",
+    "parse_claude_usage",
+    "claude_cost",
+    "claude_result_text",
+    "claude_env_for",
     "KNOWN_MODELS",
+    "EXECUTABLE_MODELS",
 ]

--- a/mini_ork/dispatch/core.py
+++ b/mini_ork/dispatch/core.py
@@ -29,6 +29,7 @@ from .models import DispatchRequest, DispatchResult, TokenUsage
 # with a stub provider.
 UsageParser = Callable[[str], TokenUsage]
 CostParser = Callable[[str, TokenUsage], float]
+TextParser = Callable[[str], str]
 
 
 def dispatch(
@@ -37,6 +38,7 @@ def dispatch(
     *,
     parse_usage: UsageParser | None = None,
     parse_cost: CostParser | None = None,
+    parse_text: TextParser | None = None,
 ) -> DispatchResult:
     """Run ``command`` (an argv list — no shell), feeding ``request.prompt`` on
     stdin, and return a :class:`DispatchResult`.
@@ -92,10 +94,13 @@ def dispatch(
 
     usage = parse_usage(stdout) if parse_usage else TokenUsage()
     cost = parse_cost(stdout, usage) if parse_cost else 0.0
+    # parse_text extracts the assistant body from a structured envelope (e.g.
+    # claude --output-format json puts it in .result); default is raw stdout.
+    text = parse_text(stdout) if parse_text else stdout
     return DispatchResult(
         ok=True,
         rc=0,
-        text=stdout,
+        text=text,
         model=request.model,
         usage=usage,
         cost_usd=cost,

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -12,15 +12,19 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Sequence
-from dataclasses import dataclass
+import shlex
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from .core import dispatch
 from .models import DispatchRequest, DispatchResult, TokenUsage
 
-# Lanes mini-ork knows about. codex/gemini are executable wrappers; the rest are
-# Anthropic-compatible (claude CLI behind an env-pinned gateway).
+# Lanes mini-ork knows about. codex/gemini are EXECUTABLE wrappers (run the
+# cl_*.sh as a command); the rest are the CLAUDE family (source the cl_*.sh to
+# pin ANTHROPIC_* env, then run `claude --print --output-format json`).
+EXECUTABLE_MODELS = frozenset({"codex", "gemini"})
 KNOWN_MODELS = frozenset(
     {"opus", "sonnet", "kimi", "glm", "minimax", "codex", "gemini", "deepseek"}
 )
@@ -68,6 +72,75 @@ def codex_cost(_stdout: str, usage: TokenUsage) -> float:
     ) / 1e6
 
 
+# ── claude family (anthropic-compatible lanes) ──────────────────────────────
+# `claude --print --output-format json` emits {"result", "total_cost_usd",
+# "usage": {...}}. The body is .result (NOT raw stdout), cost is reported
+# directly, and usage carries the cache-aware token split.
+
+
+def _claude_envelope(stdout: str) -> dict:
+    try:
+        obj = json.loads(stdout)
+        return obj if isinstance(obj, dict) else {}
+    except (ValueError, TypeError):
+        return {}
+
+
+def claude_result_text(stdout: str) -> str:
+    """Extract the assistant body from claude's JSON envelope (.result)."""
+    env = _claude_envelope(stdout)
+    return str(env.get("result") or "") if env else stdout
+
+
+def parse_claude_usage(stdout: str) -> TokenUsage:
+    u = (_claude_envelope(stdout).get("usage")) or {}
+    return TokenUsage(
+        input_tokens=int(u.get("input_tokens") or 0),
+        output_tokens=int(u.get("output_tokens") or 0),
+        cached_input_tokens=int(u.get("cache_read_input_tokens") or 0),
+        cache_creation_tokens=int(u.get("cache_creation_input_tokens") or 0),
+    )
+
+
+def claude_cost(stdout: str, _usage: TokenUsage) -> float:
+    """Claude reports real billed cost in the envelope — trust it over an
+    estimate."""
+    try:
+        return float(_claude_envelope(stdout).get("total_cost_usd") or 0.0)
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def claude_env_for(
+    model: str, root: str | os.PathLike[str] | None = None
+) -> dict[str, str]:
+    """Capture the ANTHROPIC_*/CLAUDE_* env a claude-family wrapper exports, by
+    sourcing it in a subshell. This reuses the committed cl_*.sh as the single
+    source of truth for each lane's base_url/model/key-env — no duplication in
+    Python. Returns {} if the wrapper's required API key env var is unset (its
+    `${KEY:?}` guard aborts the source before any export runs)."""
+    wrapper = mini_ork_root(root) / "lib" / "providers" / f"cl_{model}.sh"
+    if not wrapper.is_file():
+        raise FileNotFoundError(f"provider wrapper not found: {wrapper}")
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f"source {shlex.quote(str(wrapper))} >/dev/null 2>&1; "
+            'env | grep -E "^(ANTHROPIC_|CLAUDE_CODE_)" || true',
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    env: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            env[key] = value
+    return env
+
+
 @dataclass(frozen=True)
 class ProviderSpec:
     """How to run one model lane and read its telemetry."""
@@ -76,6 +149,8 @@ class ProviderSpec:
     command: tuple[str, ...]
     parse_usage: object | None = None  # UsageParser | None
     parse_cost: object | None = None  # CostParser | None
+    parse_text: object | None = None  # TextParser | None
+    env: Mapping[str, str] = field(default_factory=dict)
 
 
 def mini_ork_root(root: str | os.PathLike[str] | None = None) -> Path:
@@ -101,10 +176,23 @@ def resolve_provider(
     wrapper = mini_ork_root(root) / "lib" / "providers" / f"cl_{model}.sh"
     if not wrapper.is_file():
         raise FileNotFoundError(f"provider wrapper not found: {wrapper}")
-    command: tuple[str, ...] = (str(wrapper), "--print", "--output-format", "text")
-    if model == "codex":
-        return ProviderSpec(model, command, parse_codex_usage, codex_cost)
-    return ProviderSpec(model, command)
+
+    if model in EXECUTABLE_MODELS:
+        # Run the wrapper as a command; prompt arrives over stdin (core.dispatch).
+        command: tuple[str, ...] = (str(wrapper), "--print", "--output-format", "text")
+        if model == "codex":
+            return ProviderSpec(model, command, parse_codex_usage, codex_cost)
+        return ProviderSpec(model, command)
+
+    # Claude family: env-pin from the wrapper, then run claude with JSON output.
+    return ProviderSpec(
+        model=model,
+        command=("claude", "--print", "--output-format", "json"),
+        parse_usage=parse_claude_usage,
+        parse_cost=claude_cost,
+        parse_text=claude_result_text,
+        env=claude_env_for(model, root),
+    )
 
 
 def dispatch_model(
@@ -116,11 +204,25 @@ def dispatch_model(
         spec = resolve_provider(request.model, root)
     except (ValueError, FileNotFoundError) as exc:
         return DispatchResult(ok=False, rc=2, error=str(exc), model=request.model)
+    # Merge the lane's pinned env UNDER any per-request overrides.
+    merged_env = {**dict(spec.env), **request.env}
+    effective = (
+        request
+        if merged_env == request.env
+        else DispatchRequest(
+            model=request.model,
+            prompt=request.prompt,
+            timeout_s=request.timeout_s,
+            max_turns=request.max_turns,
+            env=merged_env,
+        )
+    )
     return dispatch(
-        request,
+        effective,
         spec.command,
         parse_usage=spec.parse_usage,  # type: ignore[arg-type]
         parse_cost=spec.parse_cost,  # type: ignore[arg-type]
+        parse_text=spec.parse_text,  # type: ignore[arg-type]
     )
 
 
@@ -130,6 +232,13 @@ def dispatch_with_command(
     *,
     parse_usage: object | None = None,
     parse_cost: object | None = None,
+    parse_text: object | None = None,
 ) -> DispatchResult:
     """Escape hatch for tests / custom commands: dispatch an explicit argv."""
-    return dispatch(request, command, parse_usage=parse_usage, parse_cost=parse_cost)  # type: ignore[arg-type]
+    return dispatch(
+        request,
+        command,
+        parse_usage=parse_usage,  # type: ignore[arg-type]
+        parse_cost=parse_cost,  # type: ignore[arg-type]
+        parse_text=parse_text,  # type: ignore[arg-type]
+    )

--- a/tests/test_dispatch_py.py
+++ b/tests/test_dispatch_py.py
@@ -7,6 +7,7 @@ faithful port of cl_codex.sh.
 
 from __future__ import annotations
 
+import json
 import sys
 
 import pytest
@@ -14,9 +15,13 @@ import pytest
 from mini_ork.dispatch import (
     DispatchRequest,
     TokenUsage,
+    claude_cost,
+    claude_env_for,
+    claude_result_text,
     codex_cost,
     dispatch_model,
     dispatch_with_command,
+    parse_claude_usage,
     parse_codex_usage,
     resolve_provider,
 )
@@ -122,3 +127,72 @@ def test_resolve_known_lane_points_at_wrapper():
     spec = resolve_provider("codex")
     assert spec.command[0].endswith("lib/providers/cl_codex.sh")
     assert spec.parse_usage is parse_codex_usage
+
+
+# ── claude-family lanes ─────────────────────────────────────────────────────
+
+_CLAUDE_ENVELOPE = json.dumps(
+    {
+        "result": "the answer is 42",
+        "total_cost_usd": 0.0123,
+        "usage": {
+            "input_tokens": 800,
+            "output_tokens": 120,
+            "cache_read_input_tokens": 200,
+            "cache_creation_input_tokens": 50,
+        },
+    }
+)
+
+
+def test_claude_result_text_extracts_result_field():
+    assert claude_result_text(_CLAUDE_ENVELOPE) == "the answer is 42"
+
+
+def test_claude_usage_and_cost_from_envelope():
+    u = parse_claude_usage(_CLAUDE_ENVELOPE)
+    assert u.input_tokens == 800
+    assert u.output_tokens == 120
+    assert u.cached_input_tokens == 200
+    assert u.cache_creation_tokens == 50
+    # claude reports real billed cost — trust the envelope, don't estimate
+    assert claude_cost(_CLAUDE_ENVELOPE, u) == pytest.approx(0.0123)
+
+
+def test_dispatch_through_a_claude_style_stub():
+    emit = "import sys; sys.stdout.write(sys.stdin.read())"  # echo the envelope
+    cmd = [PY, "-c", emit]
+    res = dispatch_with_command(
+        _req(_CLAUDE_ENVELOPE),
+        cmd,
+        parse_text=claude_result_text,
+        parse_usage=parse_claude_usage,
+        parse_cost=claude_cost,
+    )
+    assert res.ok is True
+    assert res.text == "the answer is 42"  # body is .result, not the raw JSON
+    assert res.usage.output_tokens == 120
+    assert res.cost_usd == pytest.approx(0.0123)
+
+
+def test_claude_env_for_reuses_wrapper_as_source_of_truth(monkeypatch):
+    # With the lane's API key present, sourcing cl_glm.sh yields the z.ai pins.
+    monkeypatch.setenv("GLM_API_KEY", "dummy-key-for-test")
+    env = claude_env_for("glm")
+    assert env.get("ANTHROPIC_BASE_URL") == "https://api.z.ai/api/anthropic"
+    assert env.get("ANTHROPIC_MODEL") == "GLM-5.1"
+
+
+def test_claude_env_for_empty_without_key(monkeypatch):
+    # Missing key → the wrapper's `${GLM_API_KEY:?}` guard aborts the source
+    # before any export, so we get nothing rather than a half-pinned env.
+    monkeypatch.delenv("GLM_API_KEY", raising=False)
+    env = claude_env_for("glm")
+    assert "ANTHROPIC_AUTH_TOKEN" not in env
+
+
+def test_resolve_claude_lane_uses_claude_command():
+    spec = resolve_provider("glm")
+    assert spec.command[0] == "claude"
+    assert spec.parse_text is claude_result_text
+    assert spec.parse_usage is parse_claude_usage


### PR DESCRIPTION
Extends `mini_ork.dispatch` from codex-only to **all 8 lanes**. The claude family (opus/sonnet/kimi/glm/minimax/deepseek) is driven by **reusing each committed `cl_*.sh` wrapper as the single source of truth** for its env pins — zero config duplicated into Python.

- `claude_env_for(model)` — sources the wrapper in a subshell, captures the `ANTHROPIC_*`/`CLAUDE_CODE_*` env it exports (empty if the lane's API key is unset; the wrapper's `${KEY:?}` guard aborts before any export).
- `parse_claude_usage` / `claude_cost` / `claude_result_text` — parse the `claude --print --output-format json` envelope (cache-aware `.usage` split, **real** `.total_cost_usd`, body in `.result`).
- `core.dispatch` gains a `parse_text` hook (envelope body extraction).
- `resolve_provider` branches **executable** (codex/gemini → wrapper command) vs **claude-family** (claude command + pinned env); `dispatch_model` merges the lane env under per-request overrides.

Test: **16 passing** (+6 claude cases) — envelope result/usage/cost; dispatch through a claude-style stub returns `.result` as the body; `claude_env_for("glm")` yields the z.ai pins with a key and `{}` without. Still stdlib-only, coexists with the bash.