### PR TITLE
feat(dispatch): persist DispatchResult to llm_calls (Phase 0 / telemetry)

### DIFF
--- a/mini_ork/dispatch/__init__.py
+++ b/mini_ork/dispatch/__init__.py
@@ -24,6 +24,7 @@ from .providers import (
     parse_codex_usage,
     resolve_provider,
 )
+from .telemetry import cache_aware_cost, persist_call
 
 __all__ = [
     "dispatch",
@@ -42,4 +43,6 @@ __all__ = [
     "claude_env_for",
     "KNOWN_MODELS",
     "EXECUTABLE_MODELS",
+    "persist_call",
+    "cache_aware_cost",
 ]

--- a/mini_ork/dispatch/telemetry.py
+++ b/mini_ork/dispatch/telemetry.py
@@ -1,0 +1,119 @@
+"""Persist a DispatchResult to the llm_calls table (Phase-0 migration, ADR-001).
+
+Python port of lib/llm-dispatch.sh's `_mo_llm_write_llm_calls_row`. Two faithful
+behaviours carried over:
+
+  - **Column introspection.** Only columns that actually exist in the target
+    `llm_calls` table are inserted, so the writer works against any schema
+    version (old DBs without the 0024 cache-aware columns still take the core
+    row) — exactly like the bash `PRAGMA table_info` gate.
+  - **Cache-aware cost split.** `cost_input_uncached/cached/cache_write` are
+    derived from the token split at the same default rates as the bash writer.
+
+Parameterized SQL throughout; a missing DB file is a no-op (returns None), never
+a crash — telemetry must never break a dispatch.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Mapping
+from pathlib import Path
+
+from .models import DispatchResult, TokenUsage
+
+# Per-Mtok USD rates for the cache-aware input cost split — same defaults as the
+# bash writer (lib/llm-dispatch.sh). Overridable per call for correct
+# per-provider pricing.
+DEFAULT_RATE_UNCACHED_IN = 15.0
+DEFAULT_RATE_CACHED_IN = 1.5
+DEFAULT_RATE_CACHE_WRITE = 18.75
+
+
+def cache_aware_cost(
+    usage: TokenUsage,
+    *,
+    rate_uncached_in: float = DEFAULT_RATE_UNCACHED_IN,
+    rate_cached_in: float = DEFAULT_RATE_CACHED_IN,
+    rate_cache_write: float = DEFAULT_RATE_CACHE_WRITE,
+) -> tuple[float, float, float]:
+    """(uncached_input, cached_input, cache_write) USD. input_tokens INCLUDES the
+    cached + cache-creation tokens, so subtract them before the uncached rate."""
+    uncached_in = max(
+        usage.input_tokens - usage.cached_input_tokens - usage.cache_creation_tokens, 0
+    )
+    return (
+        uncached_in * rate_uncached_in / 1_000_000,
+        usage.cached_input_tokens * rate_cached_in / 1_000_000,
+        usage.cache_creation_tokens * rate_cache_write / 1_000_000,
+    )
+
+
+def persist_call(
+    db_path: str | Path,
+    result: DispatchResult,
+    *,
+    provider: str,
+    feature_name: str,
+    tier: str = "default",
+    actor: str | None = None,
+    run_id: str | int | None = None,
+    iter_: int | None = None,
+    traceparent: str | None = None,
+    metadata: Mapping[str, object] | None = None,
+    session_id: str | None = None,
+) -> int | None:
+    """Write one llm_calls row for ``result``; return its rowid (or None if the
+    DB file is absent). ``status`` is derived from ``result.ok`` to satisfy the
+    table's CHECK(status IN ('success','failed')) constraint."""
+    db = Path(db_path)
+    if not db.is_file():
+        return None
+
+    usage = result.usage
+    uncached_cost, cached_cost, cache_write_cost = cache_aware_cost(usage)
+    md: dict[str, object] = dict(metadata or {})
+    if session_id and "session_id" not in md:
+        md["session_id"] = session_id
+
+    candidate: dict[str, object] = {
+        "provider": provider,
+        "model_id": result.model or "",
+        "tier": tier,
+        "feature_name": feature_name,
+        "actor": actor,
+        "status": "success" if result.ok else "failed",
+        "duration_ms": int(result.duration_ms),
+        "cost_usd": float(result.cost_usd),
+        "error_message": result.error or None,
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": usage.input_tokens + usage.output_tokens,
+        "metadata_json": json.dumps(md),
+        "run_id": run_id,
+        "iter": iter_,
+        "traceparent": traceparent,
+        "session_id": session_id,
+        "cached_input_tokens": usage.cached_input_tokens,
+        "cache_creation_input_tokens": usage.cache_creation_tokens,
+        "cost_input_uncached_usd": uncached_cost,
+        "cost_input_cached_usd": cached_cost,
+        "cost_cache_write_usd": cache_write_cost,
+    }
+
+    con = sqlite3.connect(str(db), timeout=5)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        existing = {row[1] for row in con.execute("PRAGMA table_info(llm_calls)")}
+        cols = [c for c in candidate if c in existing]
+        placeholders = ",".join("?" for _ in cols)
+        col_sql = ",".join(f'"{c}"' for c in cols)
+        cur = con.execute(
+            f"INSERT INTO llm_calls ({col_sql}) VALUES ({placeholders})",
+            [candidate[c] for c in cols],
+        )
+        con.commit()
+        return cur.lastrowid
+    finally:
+        con.close()

--- a/tests/test_dispatch_telemetry_py.py
+++ b/tests/test_dispatch_telemetry_py.py
@@ -1,0 +1,152 @@
+"""Tests for mini_ork.dispatch.telemetry — persisting a DispatchResult to
+llm_calls. Faithful-port checks: column introspection (works on old schemas),
+cache-aware cost split, success/failed status, and no-op on a missing DB.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from mini_ork.dispatch import (
+    DispatchResult,
+    TokenUsage,
+    cache_aware_cost,
+    persist_call,
+)
+
+# A faithful slice of the llm_calls schema (core + the 0024 cache-aware columns).
+FULL_SCHEMA = """
+CREATE TABLE llm_calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider TEXT NOT NULL, model_id TEXT NOT NULL, tier TEXT NOT NULL,
+  feature_name TEXT NOT NULL, actor TEXT, run_id INTEGER, iter INTEGER,
+  input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0, cost_usd REAL NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('success','failed')),
+  error_message TEXT, traceparent TEXT, session_id TEXT,
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  cached_input_tokens INTEGER DEFAULT 0, cache_creation_input_tokens INTEGER DEFAULT 0,
+  cost_input_uncached_usd REAL DEFAULT 0, cost_input_cached_usd REAL DEFAULT 0,
+  cost_cache_write_usd REAL DEFAULT 0,
+  ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+"""
+
+# An OLD schema missing every additive cache column — proves introspection.
+MINIMAL_SCHEMA = """
+CREATE TABLE llm_calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider TEXT NOT NULL, model_id TEXT NOT NULL, tier TEXT NOT NULL,
+  feature_name TEXT NOT NULL, cost_usd REAL NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('success','failed')),
+  metadata_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+
+def _db(tmp_path, schema):
+    p = tmp_path / "state.db"
+    con = sqlite3.connect(p)
+    con.executescript(schema)
+    con.commit()
+    con.close()
+    return p
+
+
+def _ok_result():
+    return DispatchResult(
+        ok=True,
+        rc=0,
+        text="hi",
+        model="glm",
+        usage=TokenUsage(input_tokens=1000, output_tokens=200, cached_input_tokens=300),
+        cost_usd=0.05,
+        duration_ms=1234,
+    )
+
+
+def test_persist_success_row(tmp_path):
+    db = _db(tmp_path, FULL_SCHEMA)
+    rowid = persist_call(
+        db, _ok_result(), provider="anthropic", feature_name="mini-ork:implementer",
+        tier="smart", actor="glm", run_id="run-1", session_id="sess-9",
+    )
+    assert rowid is not None
+    con = sqlite3.connect(db)
+    row = con.execute(
+        "SELECT provider, model_id, status, input_tokens, output_tokens, "
+        "total_tokens, cost_usd, cached_input_tokens, session_id, metadata_json "
+        "FROM llm_calls WHERE id=?",
+        (rowid,),
+    ).fetchone()
+    con.close()
+    assert row[0] == "anthropic"
+    assert row[1] == "glm"
+    assert row[2] == "success"
+    assert row[3] == 1000 and row[4] == 200
+    assert row[5] == 1200  # total = input + output
+    assert row[6] == pytest.approx(0.05)
+    assert row[7] == 300
+    assert row[8] == "sess-9"
+    assert '"session_id": "sess-9"' in row[9]  # folded into metadata too
+
+
+def test_persist_failed_row_records_error(tmp_path):
+    db = _db(tmp_path, FULL_SCHEMA)
+    res = DispatchResult(ok=False, rc=7, error="rate limit reached", model="codex")
+    rowid = persist_call(db, res, provider="openai", feature_name="mini-ork:planner")
+    con = sqlite3.connect(db)
+    status, err = con.execute(
+        "SELECT status, error_message FROM llm_calls WHERE id=?", (rowid,)
+    ).fetchone()
+    con.close()
+    assert status == "failed"
+    assert err == "rate limit reached"
+
+
+def test_cost_breakdown_persisted(tmp_path):
+    db = _db(tmp_path, FULL_SCHEMA)
+    res = DispatchResult(
+        ok=True, rc=0, model="glm",
+        usage=TokenUsage(input_tokens=1000, cached_input_tokens=200, cache_creation_tokens=100),
+    )
+    rowid = persist_call(db, res, provider="anthropic", feature_name="f")
+    con = sqlite3.connect(db)
+    uncached, cached, cw = con.execute(
+        "SELECT cost_input_uncached_usd, cost_input_cached_usd, cost_cache_write_usd "
+        "FROM llm_calls WHERE id=?",
+        (rowid,),
+    ).fetchone()
+    con.close()
+    # uncached_in = 1000-200-100 = 700
+    assert uncached == pytest.approx(700 * 15.0 / 1_000_000)
+    assert cached == pytest.approx(200 * 1.5 / 1_000_000)
+    assert cw == pytest.approx(100 * 18.75 / 1_000_000)
+
+
+def test_introspection_writes_only_existing_columns(tmp_path):
+    # Old schema with NO cache columns — must still insert the core row, not crash.
+    db = _db(tmp_path, MINIMAL_SCHEMA)
+    rowid = persist_call(db, _ok_result(), provider="anthropic", feature_name="f")
+    assert rowid is not None
+    con = sqlite3.connect(db)
+    provider, status = con.execute(
+        "SELECT provider, status FROM llm_calls WHERE id=?", (rowid,)
+    ).fetchone()
+    con.close()
+    assert provider == "anthropic" and status == "success"
+
+
+def test_missing_db_is_noop_not_crash(tmp_path):
+    assert persist_call(tmp_path / "nope.db", _ok_result(), provider="x", feature_name="f") is None
+
+
+def test_cache_aware_cost_subtracts_cached_and_creation():
+    u = TokenUsage(input_tokens=1000, cached_input_tokens=200, cache_creation_tokens=100)
+    uncached, cached, cw = cache_aware_cost(u)
+    assert uncached == pytest.approx(700 * 15.0 / 1_000_000)
+    assert cached == pytest.approx(200 * 1.5 / 1_000_000)
+    assert cw == pytest.approx(100 * 18.75 / 1_000_000)


### PR DESCRIPTION
Completes the **dispatch → result → persist** loop in `mini_ork.dispatch`. Python port of `_mo_llm_write_llm_calls_row`.

- **`persist_call(db, result, *, provider, feature_name, …)`** — writes one `llm_calls` row; `status` derived from `result.ok` (satisfies the `CHECK(status IN ('success','failed'))` constraint); parameterized SQL.
- **Faithful column introspection** (`PRAGMA table_info`) — only inserts columns that exist, so it works on old schemas (pre-0024, no cache columns) without crashing, exactly like the bash writer.
- **`cache_aware_cost(usage)`** — uncached/cached/cache-write USD split at the bash default rates (`input_tokens` includes cached+creation, so they're subtracted).
- **Missing DB file → no-op** (returns None); telemetry must never break a dispatch.

**Validated against the real `db/init.sh` schema** — all candidate columns are a subset of production `llm_calls`; extra prod columns left to their defaults.

Test: `tests/test_dispatch_telemetry_py.py` (**6 passing**) — success/failed rows, total/token/cost persisted, cache cost split, introspection on a minimal schema, missing-DB no-op. **Suite now 22 passing.** Still stdlib-only, coexists with the bash.