### PR TITLE
feat(dispatch): CLI entrypoint + cl_codex stdin mode — Phase 0 bridge

### DIFF
--- a/lib/providers/cl_codex.sh
+++ b/lib/providers/cl_codex.sh
@@ -55,8 +55,17 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Stdin prompt mode (Phase-0 wiring): when no positional prompt was given and
+# stdin is a pipe/file (not a tty), read the prompt from stdin. This lets the
+# Python dispatch layer (mini_ork.dispatch) drive the wrapper without ever
+# putting the prompt on argv — E2BIG-proof from the caller all the way in.
+# Backward-compatible: existing argv callers are unaffected.
+if [ -z "$PROMPT" ] && [ ! -t 0 ]; then
+  PROMPT="$(cat)"
+fi
+
 if [ -z "$PROMPT" ]; then
-  echo "[cl_codex] no prompt provided" >&2
+  echo "[cl_codex] no prompt provided (positional arg or stdin)" >&2
   exit 2
 fi
 

--- a/mini_ork/dispatch/__main__.py
+++ b/mini_ork/dispatch/__main__.py
@@ -1,0 +1,81 @@
+"""CLI entrypoint for the Python dispatch layer (Phase-0 wiring, ADR-001).
+
+    printf '%s' "$prompt" | python3 -m mini_ork.dispatch <model> --out <file>
+
+Reads the prompt from STDIN (never argv — E2BIG-proof), dispatches via
+mini_ork.dispatch.dispatch_model, writes the assistant text to --out (or
+stdout), persists an llm_calls row when MINI_ORK_DB is set, and exits with the
+provider's exit code so a bash caller (lib/llm-dispatch.sh MO_DISPATCH_BACKEND)
+sees a faithful rc.
+
+Usable standalone today; it is also the bridge a future MO_DISPATCH_BACKEND=
+python switch in lib/llm-dispatch.sh will delegate to (that live-path flip,
+with its sidecar-contract integration, is a separate slice).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from .models import DispatchRequest
+from .providers import dispatch_model, provider_for_model
+from .telemetry import persist_call
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="mini_ork.dispatch", add_help=True)
+    parser.add_argument("model", help="lane name, e.g. codex / opus / glm")
+    parser.add_argument("--out", default="", help="write assistant text here (default: stdout)")
+    parser.add_argument("--feature", default=os.environ.get("MO_LANE_FEATURE", "mini-ork:dispatch"))
+    parser.add_argument("--tier", default=os.environ.get("MO_LANE_TIER", "default"))
+    parser.add_argument("--actor", default=os.environ.get("MO_LANE_ACTOR", ""))
+    parser.add_argument("--timeout", type=float, default=float(os.environ.get("MO_NODE_TIMEOUT_S", "1500")))
+    args = parser.parse_args(argv)
+
+    prompt = sys.stdin.read()
+    request = DispatchRequest(model=args.model, prompt=prompt, timeout_s=args.timeout)
+    result = dispatch_model(request)
+
+    # Emit the assistant body to the caller (out-file or stdout).
+    if args.out:
+        try:
+            with open(args.out, "w", encoding="utf-8") as fh:
+                fh.write(result.text)
+        except OSError as exc:
+            sys.stderr.write(f"[mini_ork.dispatch] could not write {args.out}: {exc}\n")
+            return 127
+    else:
+        sys.stdout.write(result.text)
+
+    # Persist telemetry (best-effort; never changes the exit code).
+    db = os.environ.get("MINI_ORK_DB", "")
+    if db:
+        try:
+            persist_call(
+                db,
+                result,
+                provider=provider_for_model(args.model),
+                feature_name=args.feature,
+                tier=args.tier,
+                actor=args.actor or None,
+                run_id=os.environ.get("MINI_ORK_RUN_ID") or None,
+                traceparent=os.environ.get("MO_TRACEPARENT") or None,
+            )
+        except Exception as exc:  # telemetry must never break dispatch
+            sys.stderr.write(f"[mini_ork.dispatch] telemetry write failed: {exc}\n")
+
+    status = "ok" if result.ok else f"FAIL rc={result.rc}"
+    sys.stderr.write(
+        f"[mini_ork.dispatch] {args.model} {status} "
+        f"in={result.usage.input_tokens} out={result.usage.output_tokens} "
+        f"cost=${result.cost_usd:.6f} {result.duration_ms}ms\n"
+    )
+    if not result.ok and result.error:
+        sys.stderr.write(result.error.rstrip() + "\n")
+    return result.rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -153,6 +153,24 @@ class ProviderSpec:
     env: Mapping[str, str] = field(default_factory=dict)
 
 
+# Provider family recorded in llm_calls.provider, per built-in lane.
+_PROVIDER_FAMILY = {
+    "opus": "anthropic",
+    "sonnet": "anthropic",
+    "codex": "openai",
+    "gemini": "google",
+    "glm": "zai",
+    "kimi": "moonshot",
+    "minimax": "minimax",
+    "deepseek": "deepseek",
+}
+
+
+def provider_for_model(model: str) -> str:
+    """Telemetry provider family for a lane (falls back to the lane name)."""
+    return _PROVIDER_FAMILY.get(model, model)
+
+
 def mini_ork_root(root: str | os.PathLike[str] | None = None) -> Path:
     """Repo root: explicit arg → $MINI_ORK_ROOT → package parent."""
     if root is not None:
@@ -179,9 +197,10 @@ def resolve_provider(
 
     if model in EXECUTABLE_MODELS:
         # Run the wrapper as a command; prompt arrives over stdin (core.dispatch).
+        # stdout is the CLEANED assistant text — cl_codex.sh redirects the codex
+        # JSONL to a stream file and writes usage/cost to MO_*_FILE sidecars, so
+        # there are no stdout parsers here; dispatch_model reads the sidecars.
         command: tuple[str, ...] = (str(wrapper), "--print", "--output-format", "text")
-        if model == "codex":
-            return ProviderSpec(model, command, parse_codex_usage, codex_cost)
         return ProviderSpec(model, command)
 
     # Claude family: env-pin from the wrapper, then run claude with JSON output.
@@ -217,6 +236,8 @@ def dispatch_model(
             env=merged_env,
         )
     )
+    if request.model == "codex":
+        return _dispatch_codex_via_wrapper(effective, spec)
     return dispatch(
         effective,
         spec.command,
@@ -224,6 +245,62 @@ def dispatch_model(
         parse_cost=spec.parse_cost,  # type: ignore[arg-type]
         parse_text=spec.parse_text,  # type: ignore[arg-type]
     )
+
+
+def _read_codex_sidecars(usage_path: str, cost_path: str) -> tuple[TokenUsage, float]:
+    """Read cl_codex.sh's sidecars: MO_USAGE_FILE is a TSV ``in<TAB>out`` line;
+    MO_COST_FILE is a single float. Missing/garbled → zeros."""
+    in_tok = out_tok = 0
+    cost = 0.0
+    try:
+        with open(usage_path, encoding="utf-8") as fh:
+            parts = fh.read().strip().split("\t")
+            if len(parts) >= 2:
+                in_tok, out_tok = int(parts[0] or 0), int(parts[1] or 0)
+    except (OSError, ValueError):
+        pass
+    try:
+        with open(cost_path, encoding="utf-8") as fh:
+            cost = float(fh.read().strip() or 0.0)
+    except (OSError, ValueError):
+        pass
+    return TokenUsage(input_tokens=in_tok, output_tokens=out_tok), cost
+
+
+def _dispatch_codex_via_wrapper(
+    request: DispatchRequest, spec: ProviderSpec
+) -> DispatchResult:
+    """codex telemetry lives in sidecar files the wrapper writes (stdout is the
+    cleaned text). Point MO_USAGE_FILE/MO_COST_FILE at temp files, dispatch, then
+    fold the sidecar usage/cost into the result. MO_USAGE_FILE MUST end in
+    ``.tokens`` — cl_codex.sh derives its stream-file path from it."""
+    import tempfile
+
+    fd_u, usage_path = tempfile.mkstemp(suffix=".tokens")
+    os.close(fd_u)
+    fd_c, cost_path = tempfile.mkstemp(suffix=".cost")
+    os.close(fd_c)
+    try:
+        env = {**request.env, "MO_USAGE_FILE": usage_path, "MO_COST_FILE": cost_path}
+        req = DispatchRequest(
+            model=request.model,
+            prompt=request.prompt,
+            timeout_s=request.timeout_s,
+            max_turns=request.max_turns,
+            env=env,
+        )
+        result = dispatch(req, spec.command)
+        if result.ok:
+            usage, cost = _read_codex_sidecars(usage_path, cost_path)
+            result.usage = usage
+            result.cost_usd = cost
+        return result
+    finally:
+        for path in (usage_path, cost_path, f"{usage_path[:-7]}.stream.jsonl"):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
 
 def dispatch_with_command(

--- a/tests/test_dispatch_cli_py.py
+++ b/tests/test_dispatch_cli_py.py
@@ -1,0 +1,100 @@
+"""End-to-end test for the Python dispatch CLI entrypoint (mini_ork.dispatch
+__main__) — driven entirely offline through a fixture codex wrapper. Proves the
+full chain: stdin prompt → dispatch_model → wrapper-over-stdin → codex sidecar
+usage/cost → write out-file → persist llm_calls → faithful exit code.
+"""
+
+from __future__ import annotations
+
+import io
+import sqlite3
+import stat
+
+import pytest
+
+from mini_ork.dispatch.__main__ import main
+
+LLM_CALLS_SCHEMA = """
+CREATE TABLE llm_calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider TEXT NOT NULL, model_id TEXT NOT NULL, tier TEXT NOT NULL,
+  feature_name TEXT NOT NULL, actor TEXT, run_id INTEGER,
+  input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0, cost_usd REAL NOT NULL DEFAULT 0,
+  duration_ms INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('success','failed')),
+  error_message TEXT, metadata_json TEXT NOT NULL DEFAULT '{}',
+  cached_input_tokens INTEGER DEFAULT 0
+);
+"""
+
+# Fake cl_codex.sh: reads the prompt from stdin (the wrapper-stdin contract),
+# writes the usage/cost sidecars cl_codex.sh would, and emits cleaned text on
+# stdout. Exits MO_TEST_RC (default 0) so we can test rc propagation.
+FIXTURE_WRAPPER = r"""#!/usr/bin/env bash
+prompt="$(cat)"
+[ -n "${MO_USAGE_FILE:-}" ] && printf '%s\t%s\n' 100 40 > "$MO_USAGE_FILE"
+[ -n "${MO_COST_FILE:-}" ]  && printf '0.001234\n' > "$MO_COST_FILE"
+printf 'ECHO:%s\n' "$prompt"
+exit "${MO_TEST_RC:-0}"
+"""
+
+
+def _fixture_root(tmp_path):
+    root = tmp_path / "root"
+    prov = root / "lib" / "providers"
+    prov.mkdir(parents=True)
+    wrapper = prov / "cl_codex.sh"
+    wrapper.write_text(FIXTURE_WRAPPER)
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return root
+
+
+def _db(tmp_path):
+    p = tmp_path / "state.db"
+    con = sqlite3.connect(p)
+    con.executescript(LLM_CALLS_SCHEMA)
+    con.commit()
+    con.close()
+    return p
+
+
+def test_cli_dispatch_writes_text_persists_and_exits_ok(tmp_path, monkeypatch):
+    root = _fixture_root(tmp_path)
+    db = _db(tmp_path)
+    out = tmp_path / "out.txt"
+    monkeypatch.setenv("MINI_ORK_ROOT", str(root))
+    monkeypatch.setenv("MINI_ORK_DB", str(db))
+    monkeypatch.setenv("MINI_ORK_RUN_ID", "run-cli-1")
+    monkeypatch.setattr("sys.stdin", io.StringIO("hello world"))
+
+    rc = main(["codex", "--out", str(out), "--feature", "mini-ork:implementer"])
+
+    assert rc == 0
+    assert out.read_text() == "ECHO:hello world\n"  # cleaned text written
+    row = sqlite3.connect(db).execute(
+        "SELECT provider, model_id, status, input_tokens, output_tokens, cost_usd "
+        "FROM llm_calls ORDER BY id DESC LIMIT 1"
+    ).fetchone()
+    assert row[0] == "openai"  # provider_for_model('codex')
+    assert row[1] == "codex"
+    assert row[2] == "success"
+    assert row[3] == 100 and row[4] == 40  # usage from the sidecar
+    assert row[5] == pytest.approx(0.001234)  # cost from the sidecar
+
+
+def test_cli_propagates_nonzero_exit_code(tmp_path, monkeypatch):
+    root = _fixture_root(tmp_path)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(root))
+    monkeypatch.setenv("MO_TEST_RC", "5")  # wrapper exits 5
+    monkeypatch.delenv("MINI_ORK_DB", raising=False)
+    monkeypatch.setattr("sys.stdin", io.StringIO("q"))
+
+    rc = main(["codex"])  # stdout path (no --out)
+    assert rc == 5  # the provider's exit code is propagated to the CLI exit
+
+
+def test_cli_unknown_lane_exits_two(tmp_path, monkeypatch):
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))  # no wrappers here
+    monkeypatch.setattr("sys.stdin", io.StringIO("q"))
+    assert main(["not-a-lane"]) == 2

--- a/tests/test_dispatch_py.py
+++ b/tests/test_dispatch_py.py
@@ -126,7 +126,8 @@ def test_unknown_lane_is_structured_not_raised():
 def test_resolve_known_lane_points_at_wrapper():
     spec = resolve_provider("codex")
     assert spec.command[0].endswith("lib/providers/cl_codex.sh")
-    assert spec.parse_usage is parse_codex_usage
+    # codex telemetry comes from sidecars (dispatch_model), not stdout parsers.
+    assert spec.parse_usage is None
 
 
 # ── claude-family lanes ─────────────────────────────────────────────────────

--- a/tests/unit/test_cl_codex_stdin.sh
+++ b/tests/unit/test_cl_codex_stdin.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression: cl_codex.sh must accept the prompt from STDIN when no positional
+# prompt is given (the wrapper-stdin contract the Python dispatch layer drives —
+# prompt never on argv ⇒ E2BIG-proof from the caller all the way in). Existing
+# argv callers must still work unchanged.
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+PASS=0; FAIL=0
+ok(){ echo "  [OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+echo "── unit: cl_codex.sh stdin prompt mode ──"
+
+# Stub codex: capture the prompt it receives (the final positional arg, after
+# `--`) so we can assert what flowed through the wrapper.
+cat > "$TMP/codex" <<'STUB'
+#!/usr/bin/env bash
+last_msg=""; prev=""
+for a in "$@"; do
+  [ "$prev" = "--output-last-message" ] && last_msg="$a"
+  prev="$a"
+done
+printf '%s' "${@: -1}" > "$CODEX_PROMPT_CAPTURE"
+printf '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}\n'
+[ -n "$last_msg" ] && printf 'ANSWER' > "$last_msg"
+exit 0
+STUB
+chmod +x "$TMP/codex"
+
+run_codex(){ PATH="$TMP:$PATH" CODEX_PROMPT_CAPTURE="$TMP/cap" bash "$ROOT/lib/providers/cl_codex.sh" "$@"; }
+
+# 1. prompt via stdin, NO positional prompt → wrapper reads stdin
+: > "$TMP/cap"
+printf '%s' "HELLO-VIA-STDIN" | run_codex --print --output-format text >/dev/null 2>&1
+[ "$(cat "$TMP/cap")" = "HELLO-VIA-STDIN" ] && ok "prompt read from stdin reached codex" || bad "stdin prompt lost (got '$(cat "$TMP/cap")')"
+
+# 2. positional prompt still works (backward compat) — argv wins over stdin
+: > "$TMP/cap"
+printf '%s' "IGNORED-STDIN" | run_codex --print --output-format text "ARGV-PROMPT" >/dev/null 2>&1
+[ "$(cat "$TMP/cap")" = "ARGV-PROMPT" ] && ok "positional prompt still honored (argv wins)" || bad "argv prompt regressed (got '$(cat "$TMP/cap")')"
+
+# 3. no prompt at all (no argv, stdin is empty/closed) → clean exit 2, not a hang
+run_codex --print --output-format text </dev/null >/dev/null 2>&1
+[ "$?" -eq 2 ] && ok "no prompt anywhere → exit 2 (no hang)" || bad "expected exit 2 with no prompt"
+
+echo "── Results: $PASS OK  $FAIL FAIL ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Builds the bridge for routing live dispatch through `mini_ork.dispatch`. **Safe + offline-tested — nothing in the live path changes** (the `MO_DISPATCH_BACKEND=python` flag flip in `lib/llm-dispatch.sh` is a separate, deliberate slice, because the bash shim's sidecar/llm_calls contract needs faithful integration + a live codex smoke).

- **`lib/providers/cl_codex.sh`** — reads the prompt from **stdin** when no positional prompt is given (and stdin is a pipe). Lets the Python layer drive the wrapper with the prompt **never on argv** — E2BIG-proof caller-to-codex. Backward-compatible (argv still wins).
- **`mini_ork/dispatch/__main__.py`** — `python3 -m mini_ork.dispatch <model> --out F`: prompt on stdin → `dispatch_model` → write text → persist `llm_calls` (when `MINI_ORK_DB` set) → exit the provider's rc. **Usable standalone now.**
- **`providers.py`** — codex dispatch reads usage/cost from the wrapper's `MO_USAGE_FILE`/`MO_COST_FILE` **sidecars** (cl_codex.sh emits cleaned text on stdout, not JSONL) via `_dispatch_codex_via_wrapper`; `provider_for_model` maps a lane to its telemetry family.

## Tests
- `tests/unit/test_cl_codex_stdin.sh` (**3 OK**) — stdin prompt reaches codex; argv still wins; no-prompt → exit 2.
- `tests/test_dispatch_cli_py.py` (**3**) — full CLI chain end-to-end through a fixture wrapper, incl. codex sidecar usage/cost + faithful rc propagation.
- Python dispatch suite now **25 passing**; the E2BIG regression test is unaffected (11).