### PR TITLE
release: v0.6.0 — control plane, parallel-run safety, Phase-0 dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,54 @@ No unreleased changes yet.
 
 ---
 
+## [0.6.0] - 2026-06-30
+
+**Live control plane, parallel-run safety, and the start of the Python
+migration.** Adds an HTTP control plane for detached/steerable runs, makes
+concurrent runs safe by isolating per-run config, and lands the first coexisting
+slices of the Bash→Python dispatch migration (ADR-001). All additive — no
+breaking changes.
+
+### Added
+
+- **Live control plane** — detached run-launch (`POST /api/v1/runs`), HTTP
+  operator-steering (`POST /api/v1/task-runs/{id}/steer`), and a HITL steering
+  checkpoint (`plan_status=needs_steering`, pause/resume).
+- **Per-run config isolation (T1.0)** — a run snapshots its effective lane
+  policy (`config/agents.yaml`) into its run-dir at launch via
+  `lib/config_resolve.sh`, and the dispatch resolvers read run-dir-first. Editing
+  the global `agents.yaml` no longer perturbs an in-flight run; concurrent runs
+  hold independent frozen policies. **Parallel runs are now safe.**
+- **`mini_ork.dispatch`** — Phase-0 Python dispatch layer (coexists with the
+  bash path; nothing wired live yet): a typed dispatch core (prompt delivered
+  over stdin → no `ARG_MAX`/E2BIG, faithful exit codes), an all-lane provider
+  registry (codex via wrapper sidecars; claude-family via wrapper env reuse),
+  `llm_calls` telemetry persistence, and a `python3 -m mini_ork.dispatch <model>`
+  CLI entrypoint.
+- **`lib/providers/cl_codex.sh` stdin prompt mode** — reads the prompt from stdin
+  when none is on argv (E2BIG-proof caller-to-codex); argv still wins.
+- **Docs** — Rivet-parity roadmap and ADR-001 (Bash→Python migration) under
+  `docs/_meta/`.
+
+### Fixed
+
+- **codex lane E2BIG** — `cl_codex.sh` passed the codex output stream through the
+  environment, exceeding `ARG_MAX` and killing every codex dispatch; the stream
+  is now passed by file path.
+- **Post-commit watchdog** now restores the branch ref when a racing process
+  clobbers `HEAD` onto an unrelated commit, not just reverted working-tree files.
+- **Planner no longer dead-ends** on `profile_status=needs_answers` with zero
+  questions (`lib/profile_gate.sh`) — a self-sufficient planner dispatches
+  instead of blocking on answers that cannot exist. The confidence-floor gate is
+  unchanged.
+- **bug-audit planner** emits structured JSON rather than markdown.
+
+### Changed
+
+- UI dev-dependencies: `vite` 5 → 8, `@types/node` 20 → 25.
+
+---
+
 ## [0.4.1] - 2026-06-26
 
 **Verifier infra hardening patch.** Fixes infrastructure false-negatives in

--- a/bin/mini-ork
+++ b/bin/mini-ork
@@ -534,7 +534,7 @@ PY
     done
     ;;
 
-  version) echo "mini-ork 0.5.0 (universal task loop runtime)" ;;
+  version) echo "mini-ork 0.6.0 (universal task loop runtime)" ;;
 
   help|--help|-h)
     cat <<'EOF'


### PR DESCRIPTION
Bumps `bin/mini-ork version` 0.5.0 → **0.6.0** and adds the CHANGELOG entry. **Minor** bump — all additive, no breaking changes.

Highlights since v0.5.0 (36 commits):
- **Added:** live control plane (detached run-launch + HTTP steering + HITL checkpoint, #34); per-run config isolation → **safe parallel runs** (#38); the **Phase-0 `mini_ork.dispatch` layer** (typed core / all-lane registry / telemetry / CLI entrypoint, #40–43, coexisting); `cl_codex.sh` stdin mode; Rivet roadmap + ADR-001.
- **Fixed:** codex E2BIG (#35), post-commit HEAD-clobber guard (#36), planner zero-question dead-end (#39), bug-audit JSON (#25).
- **Changed:** UI dev-deps (vite 8, @types/node 25).

On merge I'll tag `v0.6.0` on the merge commit, which triggers the Release workflow.