### PR TITLE
feat(dispatch): pre-dispatch lane-health gate — fail fast, no silent stall

### DIFF
--- a/mini_ork/dispatch/__init__.py
+++ b/mini_ork/dispatch/__init__.py
@@ -13,6 +13,7 @@ from .models import DispatchRequest, DispatchResult, TokenUsage
 from .providers import (
     EXECUTABLE_MODELS,
     KNOWN_MODELS,
+    LaneHealth,
     ProviderSpec,
     claude_cost,
     claude_env_for,
@@ -20,8 +21,11 @@ from .providers import (
     codex_cost,
     dispatch_model,
     dispatch_with_command,
+    lane_health,
     parse_claude_usage,
     parse_codex_usage,
+    preflight,
+    provider_for_model,
     resolve_provider,
 )
 from .telemetry import cache_aware_cost, persist_call
@@ -45,4 +49,8 @@ __all__ = [
     "EXECUTABLE_MODELS",
     "persist_call",
     "cache_aware_cost",
+    "lane_health",
+    "preflight",
+    "LaneHealth",
+    "provider_for_model",
 ]

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 from collections.abc import Mapping, Sequence
@@ -214,11 +215,66 @@ def resolve_provider(
     )
 
 
+# A wrapper's `${SOME_API_KEY:?}` guard declares the key it requires. If that
+# var is unset the bash wrapper aborts and the lane produces nothing — the exact
+# "minimax died silently, 19-min stall" failure from prod sessions. We read that
+# declaration to fail FAST with a clear reason instead of stalling.
+_REQUIRED_KEY_RE = re.compile(r"\$\{([A-Z][A-Z0-9_]*_API_KEY)\s*:[?]")
+
+
+@dataclass(frozen=True)
+class LaneHealth:
+    ok: bool
+    reason: str
+
+
+def lane_health(model: str, root: str | os.PathLike[str] | None = None) -> LaneHealth:
+    """Cheap pre-dispatch check: is this lane runnable right now? Catches the
+    common silent-death cause — a wrapper that requires an API key env var which
+    isn't set. Does NOT make a network call. Lanes with no declared key (ambient
+    auth, e.g. opus) are healthy as long as the wrapper exists."""
+    if model not in KNOWN_MODELS:
+        return LaneHealth(False, f"unknown lane: {model!r}")
+    wrapper = mini_ork_root(root) / "lib" / "providers" / f"cl_{model}.sh"
+    if not wrapper.is_file():
+        return LaneHealth(False, f"wrapper missing: {wrapper}")
+    try:
+        text = wrapper.read_text(encoding="utf-8")
+    except OSError as exc:
+        return LaneHealth(False, f"wrapper unreadable: {exc}")
+    for match in _REQUIRED_KEY_RE.finditer(text):
+        key = match.group(1)
+        if not os.environ.get(key):
+            return LaneHealth(
+                False, f"{model}: ${key} is not set — lane would die silently"
+            )
+    return LaneHealth(True, "ok")
+
+
+def preflight(
+    models: Sequence[str], root: str | os.PathLike[str] | None = None
+) -> dict[str, LaneHealth]:
+    """Health-check several lanes at once (e.g. every lane a recipe will use).
+    Returns {model: LaneHealth}; callers abort the run if any are unhealthy."""
+    return {m: lane_health(m, root) for m in dict.fromkeys(models)}
+
+
 def dispatch_model(
-    request: DispatchRequest, root: str | os.PathLike[str] | None = None
+    request: DispatchRequest,
+    root: str | os.PathLike[str] | None = None,
+    *,
+    preflight_check: bool = True,
 ) -> DispatchResult:
     """Resolve ``request.model`` to a provider and dispatch it. Unknown lane /
-    missing wrapper come back as a structured ``ok=False`` result, not a raise."""
+    missing wrapper / a lane whose required API key is unset come back as a
+    structured ``ok=False`` result (fail-fast), not a raise or a silent stall."""
+    if preflight_check:
+        health = lane_health(request.model, root)
+        if not health.ok:
+            return DispatchResult(
+                ok=False, rc=2, error=f"lane preflight failed: {health.reason}",
+                model=request.model,
+            )
     try:
         spec = resolve_provider(request.model, root)
     except (ValueError, FileNotFoundError) as exc:

--- a/tests/test_dispatch_health_py.py
+++ b/tests/test_dispatch_health_py.py
@@ -1,0 +1,94 @@
+"""Tests for the pre-dispatch lane-health gate (mini_ork.dispatch).
+
+Targets the most-repeated prod failure: a lane whose API key is missing dies
+SILENTLY and the run stalls for ~19 minutes. lane_health turns that into an
+instant, clear failure; dispatch_model fails fast instead of dispatching.
+"""
+
+from __future__ import annotations
+
+import stat
+
+from mini_ork.dispatch import (
+    DispatchRequest,
+    dispatch_model,
+    lane_health,
+    preflight,
+)
+
+# A gateway wrapper that REQUIRES a key (the `${KEY:?}` guard), like cl_glm.sh.
+KEYED_WRAPPER = '#!/usr/bin/env bash\nexport ANTHROPIC_AUTH_TOKEN="${GLM_API_KEY:?GLM_API_KEY required}"\n'
+# An ambient wrapper with NO required key, like opus (uses the claude login).
+AMBIENT_WRAPPER = '#!/usr/bin/env bash\nexport CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1\n'
+
+
+def _wrapper(tmp_path, model, body):
+    prov = tmp_path / "lib" / "providers"
+    prov.mkdir(parents=True, exist_ok=True)
+    w = prov / f"cl_{model}.sh"
+    w.write_text(body)
+    w.chmod(w.stat().st_mode | stat.S_IXUSR)
+    return tmp_path
+
+
+def test_missing_key_is_unhealthy_with_clear_reason(tmp_path, monkeypatch):
+    _wrapper(tmp_path, "glm", KEYED_WRAPPER)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))
+    monkeypatch.delenv("GLM_API_KEY", raising=False)
+    h = lane_health("glm")
+    assert h.ok is False
+    assert "GLM_API_KEY" in h.reason and "silently" in h.reason
+
+
+def test_present_key_is_healthy(tmp_path, monkeypatch):
+    _wrapper(tmp_path, "glm", KEYED_WRAPPER)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))
+    monkeypatch.setenv("GLM_API_KEY", "set")
+    assert lane_health("glm").ok is True
+
+
+def test_ambient_lane_with_no_key_is_healthy(tmp_path, monkeypatch):
+    _wrapper(tmp_path, "opus", AMBIENT_WRAPPER)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))
+    assert lane_health("opus").ok is True  # no ${KEY:?} declared → fine
+
+
+def test_unknown_lane_and_missing_wrapper_unhealthy(tmp_path, monkeypatch):
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))  # empty: no wrappers
+    assert lane_health("not-a-lane").ok is False
+    assert lane_health("glm").ok is False  # known lane but wrapper absent
+
+
+def test_dispatch_model_fails_fast_on_missing_key(tmp_path, monkeypatch):
+    _wrapper(tmp_path, "glm", KEYED_WRAPPER)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))
+    monkeypatch.delenv("GLM_API_KEY", raising=False)
+    res = dispatch_model(DispatchRequest(model="glm", prompt="hi"))
+    assert res.ok is False
+    assert res.rc == 2
+    assert "preflight failed" in res.error and "GLM_API_KEY" in res.error
+
+
+def test_preflight_check_can_be_disabled(tmp_path, monkeypatch):
+    # Use a lane with NO wrapper so neither path makes a live call. Gate ON →
+    # the preflight catches the missing wrapper; gate OFF → it skips the gate and
+    # fails later at resolve (a different message). Proves the gate is opt-out.
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))  # empty: no wrappers
+    on = dispatch_model(DispatchRequest(model="glm", prompt="hi"))
+    assert "preflight failed" in on.error
+    off = dispatch_model(
+        DispatchRequest(model="glm", prompt="hi"), preflight_check=False
+    )
+    assert off.ok is False
+    assert "preflight failed" not in off.error  # gate skipped; failed at resolve
+
+
+def test_preflight_reports_all_lanes(tmp_path, monkeypatch):
+    _wrapper(tmp_path, "glm", KEYED_WRAPPER)
+    _wrapper(tmp_path, "opus", AMBIENT_WRAPPER)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))
+    monkeypatch.delenv("GLM_API_KEY", raising=False)
+    report = preflight(["glm", "opus", "glm"])  # dup deduped
+    assert set(report) == {"glm", "opus"}
+    assert report["glm"].ok is False
+    assert report["opus"].ok is True

--- a/tests/test_dispatch_py.py
+++ b/tests/test_dispatch_py.py
@@ -120,7 +120,7 @@ def test_unknown_lane_is_structured_not_raised():
     res = dispatch_model(DispatchRequest(model="not-a-real-lane", prompt="q"))
     assert res.ok is False
     assert res.rc == 2
-    assert "unknown model lane" in res.error
+    assert "unknown lane" in res.error  # caught by the preflight gate, fail-fast
 
 
 def test_resolve_known_lane_points_at_wrapper():


### PR DESCRIPTION
Fixes the **most-repeated prod failure** (session ee467ab7): a lane whose API key is missing **dies silently** and the run stalls ~19 min before the timeout notices (`MINIMAX_API_KEY not in the bare-shell env — and it died in the verify run`).

- **`lane_health(model)`** — cheap, no network. A wrapper's `${SOME_API_KEY:?}` guard *declares* the key it needs; if that var is unset the lane would abort silently, so we report it instantly with a clear reason. Ambient lanes (no declared key, e.g. opus) stay healthy on wrapper presence alone.
- **`preflight(models)`** — health-check every lane a recipe will use in one call.
- **`dispatch_model` fails FAST** on an unhealthy lane (`ok=False/rc=2`, `lane preflight failed: glm: $GLM_API_KEY is not set …`) instead of dispatching into a stall. Opt-out via `preflight_check=False`.

Architectural home is the Python dispatch layer (rides into the live path with the `MO_DISPATCH_BACKEND` flip); the bash dispatch is untouched. Test: `tests/test_dispatch_health_py.py` (7) — missing/present key, ambient lane, unknown lane, missing wrapper, dispatch_model fail-fast, opt-out, multi-lane preflight. Dispatch suite **32 passing**.