### PR TITLE
feat(isolation): protect mini-ork from cross-repo corruption (cwd + ref guards)

### DIFF
--- a/.githooks/reference-transaction
+++ b/.githooks/reference-transaction
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# .githooks/reference-transaction — protect THIS mini-ork repo from cross-repo
+# corruption by a consuming repo's vendored install.
+#
+# The problem (by design, until now): another repo that uses mini-ork (a
+# vendored .mini-ork/) runs a provider lane — e.g. codex — whose cwd drifts, by
+# mistake, into THIS framework tree. The provider then does its own git
+# operations here: it creates `refs/codex/curated-sync` pointing at a FOREIGN
+# commit (observed: 3fdeeb4 "Fix DigitalOcean dark mode logo") and
+# `git reset --hard` HEAD onto it, replacing the framework working tree with an
+# unrelated repo's tree (the "8432 deletions" corruption).
+#
+# This hook makes the framework repo immune regardless of what the consuming
+# repo does — it does not depend on the consumer being updated. It fires on
+# every ref update; in the `prepared` phase it ABORTS the transaction if any
+# update moves HEAD / a branch, or creates a ref, to a commit that shares NO
+# history with this repo. That is the unmistakable signature of a foreign reset.
+# Legitimate work (new commits, merges, fast-forwards, branch switches) all share
+# mini-ork history and pass untouched.
+#
+# Escape hatch: MO_ALLOW_FOREIGN_REF=1 (for a deliberate cross-graft).
+set -uo pipefail
+
+state="${1:-}"
+[ "$state" = "prepared" ] || exit 0
+[ "${MO_ALLOW_FOREIGN_REF:-0}" = "1" ] && exit 0
+
+# Anchor: a commit KNOWN to belong to this repo's history. Prefer the remote
+# tracking ref (a rogue reset doesn't touch refs/remotes/*), so recovery to a
+# real mini-ork commit is still permitted even while HEAD is already corrupted.
+anchor=""
+for ref in refs/remotes/origin/main refs/remotes/origin/HEAD HEAD; do
+  anchor=$(git rev-parse --verify --quiet "$ref^{commit}" 2>/dev/null) && [ -n "$anchor" ] && break
+done
+if [ -z "$anchor" ]; then
+  anchor=$(git for-each-ref --count=1 --format='%(objectname)' refs/heads/ 2>/dev/null)
+fi
+[ -n "$anchor" ] || exit 0  # bare/empty repo with no anchor — nothing to defend
+
+zero="0000000000000000000000000000000000000000"
+reject=0
+while read -r _old new ref; do
+  case "$ref" in
+    HEAD | refs/heads/* | refs/codex/*) ;;
+    *) continue ;;  # remotes, tags, notes, stash, etc. are not the vector
+  esac
+  [ "$new" = "$zero" ] && continue              # deletions are fine
+  git cat-file -e "${new}^{commit}" 2>/dev/null || continue  # non-commit → skip
+  # FOREIGN iff it shares no merge-base with our anchor.
+  if [ -z "$(git merge-base "$new" "$anchor" 2>/dev/null)" ]; then
+    echo "[mini-ork ref-guard] REJECT $ref -> ${new:0:12}: commit is FOREIGN to this repo (no shared history)." >&2
+    echo "  This is the cross-repo corruption vector — a consuming repo's lane writing into the framework tree." >&2
+    echo "  If this is intentional, re-run with MO_ALLOW_FOREIGN_REF=1." >&2
+    reject=1
+  fi
+done
+
+exit "$reject"

--- a/mini_ork/dispatch/__init__.py
+++ b/mini_ork/dispatch/__init__.py
@@ -19,6 +19,7 @@ from .providers import (
     claude_env_for,
     claude_result_text,
     codex_cost,
+    cwd_guard,
     dispatch_model,
     dispatch_with_command,
     lane_health,
@@ -27,6 +28,7 @@ from .providers import (
     preflight,
     provider_for_model,
     resolve_provider,
+    resolve_target_cwd,
 )
 from .telemetry import cache_aware_cost, persist_call
 
@@ -53,4 +55,6 @@ __all__ = [
     "preflight",
     "LaneHealth",
     "provider_for_model",
+    "cwd_guard",
+    "resolve_target_cwd",
 ]

--- a/mini_ork/dispatch/core.py
+++ b/mini_ork/dispatch/core.py
@@ -60,6 +60,7 @@ def dispatch(
             capture_output=True,
             text=True,
             env=proc_env,
+            cwd=request.cwd,  # None = inherit; pinned by the caller's cwd guard
             timeout=request.timeout_s,
         )
     except subprocess.TimeoutExpired:

--- a/mini_ork/dispatch/models.py
+++ b/mini_ork/dispatch/models.py
@@ -33,6 +33,11 @@ class DispatchRequest:
     max_turns: int = 60
     # Extra environment for the provider process. The prompt is NEVER put here.
     env: dict[str, str] = field(default_factory=dict)
+    # Working directory for the provider process. None = inherit the caller's
+    # cwd. The cwd guard (providers.cwd_guard) refuses a dispatch whose cwd lands
+    # inside the mini-ork framework tree — that is the cwd-confusion that lets a
+    # target-repo lane's git ops corrupt the framework repo.
+    cwd: str | None = None
 
 
 @dataclass

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -259,6 +259,46 @@ def preflight(
     return {m: lane_health(m, root) for m in dict.fromkeys(models)}
 
 
+def resolve_target_cwd(
+    request: DispatchRequest, *, env: Mapping[str, str] | None = None
+) -> str:
+    """The directory the provider runs in. Precedence: request.cwd →
+    $MO_TARGET_CWD → the current process cwd. Returns an absolute path so the
+    dispatch is never at the mercy of an inherited, drifted cwd."""
+    e = os.environ if env is None else env
+    cwd = request.cwd or e.get("MO_TARGET_CWD") or os.getcwd()
+    return os.path.abspath(cwd)
+
+
+def cwd_guard(
+    cwd: str,
+    root: str | os.PathLike[str] | None = None,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> LaneHealth:
+    """Refuse a dispatch whose working directory is INSIDE the mini-ork framework
+    tree. That is the cwd-confusion (a target-repo lane landing in mini-ork
+    itself) under which the provider's own git operations — e.g. codex's
+    `refs/codex/*` resets — corrupt the framework repo. A genuine mini-ork
+    self-edit opts in with MO_ALLOW_FRAMEWORK_CWD=1."""
+    e = os.environ if env is None else env
+    if e.get("MO_ALLOW_FRAMEWORK_CWD") == "1":
+        return LaneHealth(True, "ok")
+    framework = mini_ork_root(root)
+    target = Path(cwd).resolve()
+    try:
+        target.relative_to(framework)
+    except ValueError:
+        return LaneHealth(True, "ok")  # outside the framework tree — fine
+    return LaneHealth(
+        False,
+        f"dispatch cwd {target} is inside the mini-ork framework tree {framework} "
+        "— likely cwd-confusion (a target-repo lane landing in mini-ork). Set "
+        "MO_TARGET_CWD to the target repo, or MO_ALLOW_FRAMEWORK_CWD=1 for a "
+        "genuine mini-ork self-edit.",
+    )
+
+
 def dispatch_model(
     request: DispatchRequest,
     root: str | os.PathLike[str] | None = None,
@@ -266,8 +306,12 @@ def dispatch_model(
     preflight_check: bool = True,
 ) -> DispatchResult:
     """Resolve ``request.model`` to a provider and dispatch it. Unknown lane /
-    missing wrapper / a lane whose required API key is unset come back as a
-    structured ``ok=False`` result (fail-fast), not a raise or a silent stall."""
+    missing wrapper / unset API key / a framework-tree cwd come back as a
+    structured ``ok=False`` result (fail-fast), not a raise, stall, or repo
+    corruption."""
+    # Always pin an explicit, absolute cwd so the provider can't inherit a
+    # drifted one. The guard (below) is what refuses the dangerous case.
+    target_cwd = resolve_target_cwd(request)
     if preflight_check:
         health = lane_health(request.model, root)
         if not health.ok:
@@ -275,22 +319,25 @@ def dispatch_model(
                 ok=False, rc=2, error=f"lane preflight failed: {health.reason}",
                 model=request.model,
             )
+        guard = cwd_guard(target_cwd, root)
+        if not guard.ok:
+            return DispatchResult(
+                ok=False, rc=2, error=f"cwd guard failed: {guard.reason}",
+                model=request.model,
+            )
     try:
         spec = resolve_provider(request.model, root)
     except (ValueError, FileNotFoundError) as exc:
         return DispatchResult(ok=False, rc=2, error=str(exc), model=request.model)
-    # Merge the lane's pinned env UNDER any per-request overrides.
+    # Merge the lane's pinned env UNDER any per-request overrides; pin the cwd.
     merged_env = {**dict(spec.env), **request.env}
-    effective = (
-        request
-        if merged_env == request.env
-        else DispatchRequest(
-            model=request.model,
-            prompt=request.prompt,
-            timeout_s=request.timeout_s,
-            max_turns=request.max_turns,
-            env=merged_env,
-        )
+    effective = DispatchRequest(
+        model=request.model,
+        prompt=request.prompt,
+        timeout_s=request.timeout_s,
+        max_turns=request.max_turns,
+        env=merged_env,
+        cwd=target_cwd,
     )
     if request.model == "codex":
         return _dispatch_codex_via_wrapper(effective, spec)
@@ -344,6 +391,7 @@ def _dispatch_codex_via_wrapper(
             timeout_s=request.timeout_s,
             max_turns=request.max_turns,
             env=env,
+            cwd=request.cwd,  # preserve the guarded target cwd through the codex path
         )
         result = dispatch(req, spec.command)
         if result.ok:

--- a/tests/test_dispatch_cwd_py.py
+++ b/tests/test_dispatch_cwd_py.py
@@ -1,0 +1,76 @@
+"""Tests for the cwd guard (mini_ork.dispatch) — the dispatch-side half of the
+isolation fix. A target-repo lane must never run with its cwd inside the
+mini-ork framework tree; that confusion is how a consuming repo's provider git
+ops (codex's refs/codex resets) corrupt the framework repo.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+
+from mini_ork.dispatch import (
+    DispatchRequest,
+    cwd_guard,
+    dispatch_model,
+    resolve_target_cwd,
+)
+
+KEYED = '#!/usr/bin/env bash\nexport ANTHROPIC_AUTH_TOKEN="${GLM_API_KEY:?}"\n'
+
+
+def _wrapper(root, model, body):
+    prov = root / "lib" / "providers"
+    prov.mkdir(parents=True, exist_ok=True)
+    w = prov / f"cl_{model}.sh"
+    w.write_text(body)
+    w.chmod(w.stat().st_mode | stat.S_IXUSR)
+
+
+def test_resolve_target_cwd_precedence(tmp_path, monkeypatch):
+    # explicit request.cwd wins
+    r = DispatchRequest(model="glm", prompt="x", cwd=str(tmp_path / "a"))
+    assert resolve_target_cwd(r) == os.path.abspath(str(tmp_path / "a"))
+    # then MO_TARGET_CWD
+    monkeypatch.setenv("MO_TARGET_CWD", str(tmp_path / "b"))
+    assert resolve_target_cwd(DispatchRequest(model="glm", prompt="x")) == os.path.abspath(
+        str(tmp_path / "b")
+    )
+
+
+def test_cwd_inside_framework_is_rejected(tmp_path):
+    framework = tmp_path / "mini-ork"
+    (framework / "sub").mkdir(parents=True)
+    g = cwd_guard(str(framework / "sub"), root=framework)
+    assert g.ok is False
+    assert "framework tree" in g.reason and "cwd-confusion" in g.reason
+
+
+def test_cwd_outside_framework_is_allowed(tmp_path):
+    framework = tmp_path / "mini-ork"
+    framework.mkdir()
+    target = tmp_path / "researcher"
+    target.mkdir()
+    assert cwd_guard(str(target), root=framework).ok is True
+
+
+def test_framework_cwd_allowed_with_optin(tmp_path, monkeypatch):
+    framework = tmp_path / "mini-ork"
+    framework.mkdir()
+    monkeypatch.setenv("MO_ALLOW_FRAMEWORK_CWD", "1")
+    assert cwd_guard(str(framework), root=framework).ok is True  # self-edit opt-in
+
+
+def test_dispatch_model_fails_fast_on_framework_cwd(tmp_path, monkeypatch):
+    # Healthy lane (key set) but the requested cwd is inside the framework tree
+    # → dispatch_model must refuse BEFORE running the provider.
+    _wrapper(tmp_path, "glm", KEYED)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(tmp_path))
+    monkeypatch.setenv("GLM_API_KEY", "set")
+    monkeypatch.delenv("MO_ALLOW_FRAMEWORK_CWD", raising=False)
+    res = dispatch_model(
+        DispatchRequest(model="glm", prompt="hi", cwd=str(tmp_path / "lib"))
+    )
+    assert res.ok is False
+    assert res.rc == 2
+    assert "cwd guard failed" in res.error

--- a/tests/unit/test_reference_transaction_guard.sh
+++ b/tests/unit/test_reference_transaction_guard.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Regression: .githooks/reference-transaction must REJECT a ref update that moves
+# HEAD / a branch (or creates a ref) to a commit FOREIGN to this repo — the exact
+# cross-repo corruption a consuming repo's drifted lane caused (reset --hard to
+# refs/codex/curated-sync = 3fdeeb4, an unrelated repo's commit). Legitimate
+# history (commits, resets within the repo's own graph) must pass.
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+HOOK="$ROOT/.githooks/reference-transaction"
+PASS=0; FAIL=0
+ok(){ echo "  [OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+echo "── unit: reference-transaction foreign-ref guard ──"
+
+# git must support the reference-transaction hook (>= 2.28)
+if ! git --version | awk '{print $3}' | awk -F. '{exit !($1>2 || ($1==2 && $2>=28))}'; then
+  echo "  [SKIP] git $(git --version | awk '{print $3}') has no reference-transaction hook"
+  echo "── Results: 0 OK  0 FAIL ──"; exit 0
+fi
+
+R="$TMP/repo"; HK="$TMP/hooks"; mkdir -p "$R" "$HK"
+cp "$HOOK" "$HK/reference-transaction"; chmod +x "$HK/reference-transaction"
+(
+  cd "$R"
+  git init -q
+  git config user.email t@t; git config user.name t
+  git config core.hooksPath "$HK"
+  echo a > f; git add f; git commit -q -m A
+  echo b > f; git add f; git commit -q -m B
+)
+A=$(cd "$R"; git rev-parse HEAD~1)
+B=$(cd "$R"; git rev-parse HEAD)
+# a FOREIGN root commit (empty tree, no parent) — shares no history with A/B
+EMPTY_TREE=$(cd "$R"; git hash-object -w -t tree /dev/null)
+FOREIGN=$(cd "$R"; printf 'Fix DigitalOcean dark mode logo\n' | git commit-tree "$EMPTY_TREE")
+
+# 1. creating refs/codex/* to a foreign commit is REJECTED
+( cd "$R"; git update-ref refs/codex/curated-sync "$FOREIGN" ) 2>/dev/null \
+  && bad "foreign refs/codex/* creation was allowed" \
+  || ok "foreign refs/codex/* creation rejected"
+[ -z "$(cd "$R"; git rev-parse --verify --quiet refs/codex/curated-sync)" ] \
+  && ok "refs/codex/curated-sync not created" || bad "ref leaked into repo"
+
+# 2. reset --hard onto the foreign commit is REJECTED (HEAD unchanged)
+( cd "$R"; git reset --hard "$FOREIGN" ) >/dev/null 2>&1 || true
+[ "$(cd "$R"; git rev-parse HEAD)" = "$B" ] \
+  && ok "foreign reset --hard rejected (HEAD held at B)" || bad "HEAD was clobbered to foreign"
+
+# 3. a LEGITIMATE reset within the repo's own history is ALLOWED
+( cd "$R"; git reset --hard "$A" ) >/dev/null 2>&1
+[ "$(cd "$R"; git rev-parse HEAD)" = "$A" ] \
+  && ok "legit reset to an in-history commit allowed" || bad "legit reset was blocked"
+
+# 4. a normal new commit is ALLOWED (shares history)
+( cd "$R"; git reset --hard "$B" >/dev/null 2>&1; echo c > f; git add f; git commit -q -m C )
+[ "$(cd "$R"; git log --oneline | wc -l | tr -d ' ')" -ge 3 ] \
+  && ok "normal commit allowed" || bad "normal commit blocked"
+
+# 5. the escape hatch lets a deliberate foreign graft through
+( cd "$R"; MO_ALLOW_FOREIGN_REF=1 git reset --hard "$FOREIGN" ) >/dev/null 2>&1 || true
+[ "$(cd "$R"; git rev-parse HEAD)" = "$FOREIGN" ] \
+  && ok "MO_ALLOW_FOREIGN_REF=1 bypass works" || bad "escape hatch did not work"
+
+echo "── Results: $PASS OK  $FAIL FAIL ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
**Design fix: make it impossible for a consuming repo to corrupt the source mini-ork repo.**

A consuming repo's vendored `.mini-ork/` running a provider lane whose cwd drifts (by mistake) into *this* framework tree was corrupting it — codex created `refs/codex/curated-sync` at a **foreign** commit (`3fdeeb4` 'DigitalOcean dark mode logo') and `reset --hard` HEAD onto it (the 8432-deletion clobber that hit this session repeatedly). Two complementary defenses:

### PREVENT — dispatch-side (`mini_ork.dispatch`)
- `DispatchRequest.cwd` + `core.dispatch` runs the provider in an **explicit, absolute cwd** (no inherited drift).
- `resolve_target_cwd` (`request.cwd → MO_TARGET_CWD → getcwd`) + `cwd_guard`: `dispatch_model` **fails fast** if the target cwd is inside the mini-ork framework tree. Opt in for genuine self-edits with `MO_ALLOW_FRAMEWORK_CWD=1`.

### BLOCK — source-side (works against ANY consumer, incl. old/unguarded fleets)
- **`.githooks/reference-transaction`** rejects, *at the git level*, any update that moves HEAD / a branch or creates a ref to a commit **foreign to this repo** (no shared history) — the exact reset-to-foreign signature. Legitimate history (commits, merges, in-graph resets) passes. Escape hatch `MO_ALLOW_FOREIGN_REF=1`.

The ref-guard is the key one: it protects the framework repo **even though the consuming fleet runs an old copy** — it lives here, blocking the write where it lands.

### Tests
`tests/test_dispatch_cwd_py.py` (6) + `tests/unit/test_reference_transaction_guard.sh` (6 — foreign ref/reset rejected, legit history allowed, bypass works). Dispatch suite **37 passing**.