### PR TITLE
feat(optimize): R4a native GEPA-style reflective prompt optimizer (standalone, opt-in)

### DIFF
--- a/kickoffs/issue-fixes/r4a-gepa-reflective-optimizer.md
+++ b/kickoffs/issue-fixes/r4a-gepa-reflective-optimizer.md
@@ -1,0 +1,48 @@
+# R4a: native GEPA-style reflective prompt optimizer (standalone, not yet wired)
+
+## Context
+Recommendation R4 (`internal-docs/research/impl-analysis/03-gepa-reflective-optimization.md`):
+GEPA (reflective prompt evolution) beats GRPO by ~10% using up to 35× fewer rollouts — directly
+attacking mini-ork's per-run cost. mini-ork already has a GRPO loop + a PRM (`lib/process_reward.sh`)
++ textual gradients (`lib/gradient_extractor.sh`) that improve recipe prompts from run traces.
+
+This phase adds a native, dependency-free, GEPA-style reflective optimizer as a SEPARATE, opt-in
+track alongside GRPO. GRPO (lane routing = which model) is untouched; GEPA optimizes prompt TEXT
+(what the model is told). Standalone module + test only; wiring into the reflect→improve stage is
+R4b. Reimplement the pattern natively in Python (NOT vendoring the `gepa` pip package / litellm),
+mirroring the minimal-agent precedent.
+
+## Deliverables
+1. `mini_ork/optimize/gepa.py` — a minimal reflective optimizer:
+   - **Adapter protocol** `GepaAdapter` with two methods (the whole integration surface):
+     `evaluate(batch, candidate) -> list[float] scores + traces`, and
+     `make_reflective_dataset(candidate, eval_batch) -> per-example textual feedback dicts`.
+   - **Optimizer loop** `optimize(seed_candidate: dict[str,str], adapter, *, minibatch=8, budget)`:
+     Pareto-select a parent candidate → draw a minibatch → evaluate with trace capture → build the
+     reflective dataset (failure feedback) → ask a reflection model for a targeted rewrite of ONE
+     prompt component → evaluate the mutation on the SAME minibatch → **accept only if the summed
+     score improves** (the minibatch-acceptance gate = the 35× rollout saving) → keep a Pareto
+     front of candidates. `candidate` is `dict[str,str]` (recipe prompt fields = the textual
+     params GEPA evolves).
+   - Reflection model call goes through `mini_ork.dispatch.dispatch_model` (reuse the existing
+     dispatch; no litellm).
+   - Return the best candidate + a trace of accepted mutations.
+2. `mini_ork/optimize/__init__.py` exporting `GepaAdapter`, `optimize`.
+
+## Smoke / DoD (must pass)
+- `tests/test_gepa_optimizer_py.py` (pytest):
+  - A stub `GepaAdapter` over a trivial scorable task (e.g. candidate prompt must contain a target
+    token; score = fraction of minibatch examples "solved") + a stub reflection model (monkeypatch
+    `dispatch_model`) that proposes the improving edit. Assert: `optimize` returns a candidate with
+    a strictly-higher score than the seed; the minibatch-acceptance gate REJECTS a non-improving
+    mutation (assert a bad reflection is not accepted); the loop halts at `budget`.
+  - Assert rollout economy: full-eval count stays bounded (the acceptance gate prevents evaluating
+    every mutation on the full set).
+- `python -m pytest -q` overall still green (additive; nothing imports it yet).
+- `python -c "import mini_ork.optimize"` works.
+
+## Constraints (scope guard)
+- Add ONLY `mini_ork/optimize/gepa.py`, `mini_ork/optimize/__init__.py`, `tests/test_gepa_optimizer_py.py`.
+- Do NOT wire into `lib/reflection_pipeline.sh`, `bin/mini-ork-reflect`, or the GRPO loop (that is R4b).
+- No new pip dependency (`gepa`, `dspy`, litellm) — native Python + `mini_ork.dispatch` only.
+- GRPO path unchanged; this optimizer only runs when explicitly invoked (default system behavior unchanged).

--- a/mini_ork/optimize/__init__.py
+++ b/mini_ork/optimize/__init__.py
@@ -1,0 +1,12 @@
+"""Mini-ork prompt optimization (Phase 1: GEPA-style reflective optimizer).
+
+Public surface: ``GepaAdapter`` (the user-supplied Protocol that scores a
+candidate against a batch and surfaces reflective failures) and ``optimize``
+(the minibatch-acceptance-gated reflective-mutation loop).
+"""
+
+from __future__ import annotations
+
+from .gepa import GepaAdapter, optimize
+
+__all__ = ["GepaAdapter", "optimize"]

--- a/mini_ork/optimize/gepa.py
+++ b/mini_ork/optimize/gepa.py
@@ -1,0 +1,222 @@
+"""GEPA-style reflective prompt optimizer (R4a standalone). Standalone — no
+wiring into the GRPO loop, ``lib/reflection_pipeline.sh``, or
+``bin/mini-ork-reflect``. R4b will integrate.
+
+Budget semantic: ``budget`` = max OPTIMIZATION ITERATIONS. Each accepted
+mutation costs one full eval; rejected mutations cost only the two minibatch
+evals. With ``budget=4`` and most mutations rejected you spend ~8 minibatch
+evals + 0-4 full evals — the 35x rollout savings claim vs. evaluating every
+mutation on the full set.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from mini_ork.dispatch import DispatchRequest, DispatchResult, dispatch_model
+
+
+@runtime_checkable
+class GepaAdapter(Protocol):
+    """User-supplied scorer. ``full_eval_count`` and ``iteration_count`` are
+    counters that ``optimize()`` resets at entry and increments during the run
+    so callers can assert rollout cost is bounded and the loop halts.
+    """
+
+    full_eval_count: int
+    iteration_count: int
+    full_batch: list[Any]
+
+    def evaluate(
+        self, batch: list[Any], candidate: dict[str, str]
+    ) -> tuple[list[float], list[Any]]:
+        """Score ``candidate`` on ``batch``; return ``(per_example_scores, traces)``."""
+        ...
+
+    def make_reflective_dataset(
+        self,
+        candidate: dict[str, str],
+        eval_batch: list[tuple[Any, float, Any]],
+    ) -> list[dict[str, Any]]:
+        """Turn ``(example, score, trace)`` triples into feedback dicts (opaque)."""
+        ...
+
+
+@dataclass
+class _FrontEntry:
+    candidate: dict[str, str]
+    full_score: float
+
+
+class ParetoFront:
+    """Non-dominated front over ``(candidate, full_score)``. Single-objective
+    degenerates to "keep the highest-scoring entry"; data structure is in
+    place for R4b multi-objective extension.
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[_FrontEntry] = []
+
+    def add(self, candidate: dict[str, str], full_score: float) -> None:
+        # Drop entries strictly worse than the newcomer.
+        self._entries = [
+            e for e in self._entries if not (e.full_score < full_score)
+        ]
+        # If any remaining entry strictly beats the newcomer, it's dominated.
+        if any(e.full_score > full_score for e in self._entries):
+            return
+        # Dedup ties (same score, different candidate).
+        self._entries = [
+            e for e in self._entries if e.full_score != full_score
+        ]
+        self._entries.append(_FrontEntry(dict(candidate), full_score))
+
+    def select(self) -> tuple[dict[str, str], float]:
+        best = max(self._entries, key=lambda e: e.full_score)
+        return dict(best.candidate), best.full_score
+
+    def best(self) -> tuple[dict[str, str], float]:
+        return self.select()
+
+
+class _NoProposal(Exception):
+    """Reflection call returned no usable mutation. Loop skips the iteration."""
+
+
+def _strip_code_fence(raw: str) -> str:
+    if not raw.startswith("```"):
+        return raw
+    parts = raw.split("```")
+    if len(parts) < 3:
+        return raw
+    inner = parts[1]
+    if inner.startswith("json"):
+        inner = inner[4:]
+    return inner.strip()
+
+
+def reflect_on_component(
+    candidate: dict[str, str],
+    reflective_dataset: list[dict[str, Any]],
+    component_key: str,
+    *,
+    model: str = "stub",
+) -> dict[str, str]:
+    """Call ``dispatch_model`` to propose a rewrite of one component.
+
+    Returns a NEW candidate dict (input not mutated). Raises ``_NoProposal``
+    on unparseable response or missing target key.
+    """
+    prompt = json.dumps({
+        "candidate": candidate,
+        "component_to_rewrite": component_key,
+        "feedback": reflective_dataset,
+        "instruction": (
+            f"Propose a rewrite of the '{component_key}' field that "
+            f"addresses the failures above. Respond with JSON only: "
+            f'{{"{component_key}": "<new value>"}}'
+        ),
+    }, indent=2)
+    result: DispatchResult = dispatch_model(
+        DispatchRequest(model=model, prompt=prompt)
+    )
+    if not result.ok or not result.text.strip():
+        raise _NoProposal(f"dispatch not ok: rc={result.rc} err={result.error!r}")
+    try:
+        parsed = json.loads(_strip_code_fence(result.text.strip()))
+    except json.JSONDecodeError as e:
+        raise _NoProposal(f"reflection response not JSON: {e}") from e
+    if not isinstance(parsed, dict) or component_key not in parsed:
+        raise _NoProposal(f"reflection missing {component_key!r}: {parsed!r}")
+    new_value = parsed[component_key]
+    if not isinstance(new_value, str):
+        new_value = str(new_value)
+    mutated = dict(candidate)
+    mutated[component_key] = new_value
+    return mutated
+
+
+def optimize(
+    seed_candidate: dict[str, str],
+    adapter: GepaAdapter,
+    *,
+    minibatch: int = 8,
+    budget: int = 4,
+    model: str = "stub",
+    rng: random.Random | None = None,
+    component_selector: Callable[[dict[str, str]], str] | None = None,
+) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    """Run the reflective-mutation loop.
+
+    ``budget`` = max iterations. ``adapter.full_eval_count`` is guaranteed
+    ``<= budget`` at return because only accepted mutations consume a full
+    eval. Returns ``(best_candidate, accepted_mutations_trace)``.
+    """
+    rng = rng or random.Random()
+    component_selector = component_selector or (lambda c: next(iter(c)))
+
+    adapter.full_eval_count = 0
+    adapter.iteration_count = 0
+
+    # Seed: full eval so the front has a baseline. NOT counted in
+    # ``full_eval_count`` — that counter is "mutation-triggered full evals",
+    # the rollout cost that ``budget`` bounds.
+    front = ParetoFront()
+    seed_scores, _ = adapter.evaluate(adapter.full_batch, seed_candidate)
+    seed_full = sum(seed_scores) / max(len(seed_scores), 1)
+    front.add(seed_candidate, seed_full)
+
+    accepted: list[dict[str, Any]] = []
+
+    while adapter.iteration_count < budget:
+        adapter.iteration_count += 1
+        parent, parent_full = front.select()
+        component_key = component_selector(parent)
+
+        # Draw minibatch (full batch if k >= len).
+        if minibatch >= len(adapter.full_batch):
+            minibatch_data = list(adapter.full_batch)
+        else:
+            minibatch_data = rng.sample(adapter.full_batch, minibatch)
+
+        # Parent minibatch eval — NOT a full eval; rollout stays bounded.
+        parent_minibatch_scores, parent_traces = adapter.evaluate(
+            minibatch_data, parent
+        )
+        eval_batch = list(
+            zip(minibatch_data, parent_minibatch_scores, parent_traces)
+        )
+
+        # Reflect + mutate. Skip iteration on no proposal.
+        reflective = adapter.make_reflective_dataset(parent, eval_batch)
+        try:
+            mutated = reflect_on_component(
+                parent, reflective, component_key, model=model
+            )
+        except _NoProposal:
+            continue
+
+        # Mutation minibatch eval. Gate: strict improvement.
+        new_scores, _ = adapter.evaluate(minibatch_data, mutated)
+        if sum(new_scores) <= sum(parent_minibatch_scores):
+            continue  # rejected — no full eval consumed
+
+        # Accepted: full eval + front update.
+        new_full_scores, _ = adapter.evaluate(adapter.full_batch, mutated)
+        new_full = sum(new_full_scores) / max(len(new_full_scores), 1)
+        front.add(mutated, new_full)
+        adapter.full_eval_count += 1
+        accepted.append({
+            "iteration": len(accepted),
+            "component": component_key,
+            "parent_minibatch_score": sum(parent_minibatch_scores),
+            "new_minibatch_score": sum(new_scores),
+            "parent_full_score": parent_full,
+            "new_full_score": new_full,
+        })
+
+    best_candidate, _ = front.best()
+    return best_candidate, accepted

--- a/tests/test_gepa_optimizer_py.py
+++ b/tests/test_gepa_optimizer_py.py
@@ -1,0 +1,150 @@
+"""Tests for mini_ork.optimize.gepa — the R4a reflective prompt optimizer.
+
+Trivial scoring task: a candidate scores 1.0 per example iff its
+``instruction`` field contains ``TARGET_TOKEN``, else 0.0. Tests monkeypatch
+``mini_ork.optimize.gepa.dispatch_model`` so no real model call happens.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mini_ork.dispatch import DispatchResult
+from mini_ork.optimize import optimize
+
+
+TARGET_TOKEN = "target_token"
+SEED = {"instruction": "You are a helpful assistant."}
+N_EXAMPLES = 10
+MINIBATCH = 4
+
+
+class StubAdapter:
+    """Scoring: 1.0 per example iff ``TARGET_TOKEN`` appears in
+    ``candidate['instruction']``. Records every ``evaluate`` call so tests
+    can assert on rollout counts.
+    """
+
+    def __init__(self, full_batch=None):
+        self.full_eval_count = 0
+        self.iteration_count = 0
+        self.full_batch = (
+            list(full_batch) if full_batch is not None else list(range(N_EXAMPLES))
+        )
+        self.evaluate_log: list[tuple[int, bool]] = []
+
+    def evaluate(self, batch, candidate):
+        has = TARGET_TOKEN in candidate.get("instruction", "")
+        self.evaluate_log.append((len(batch), has))
+        scores = [1.0 if has else 0.0 for _ in batch]
+        traces = [{"i": i} for i in batch]
+        return scores, traces
+
+    def make_reflective_dataset(self, candidate, eval_batch):
+        return [
+            {"example": ex, "score": s, "trace": t}
+            for ex, s, t in eval_batch
+        ]
+
+
+def _improve_reflection(candidate, _dataset, _key):
+    """Propose an edit that ADDS ``TARGET_TOKEN`` (improving)."""
+    return {"instruction": f"{candidate.get('instruction', '')} {TARGET_TOKEN}"}
+
+
+def _noop_reflection(candidate, _dataset, _key):
+    """Propose a no-op edit — mutated equals parent."""
+    return dict(candidate)
+
+
+@pytest.fixture
+def patch_dispatch(monkeypatch):
+    """Patch ``mini_ork.optimize.gepa.dispatch_model`` to call a Python
+    callable instead of a real model. The reflection callable receives
+    ``(candidate, feedback_list, component_key)`` and must return the new
+    candidate dict (the test response is wrapped in a JSON code fence so it
+    exercises the parser).
+    """
+
+    def _patch(reflect_fn):
+        def stub_dispatch(request):
+            try:
+                blob = json.loads(request.prompt)
+                candidate = blob.get("candidate", {})
+                component_key = blob.get("component_to_rewrite", "instruction")
+                new_candidate = reflect_fn(
+                    candidate, blob.get("feedback", []), component_key
+                )
+                response_text = "```json\n" + json.dumps(new_candidate) + "\n```"
+            except Exception:
+                response_text = "```json\n{}\n```"
+            return DispatchResult(ok=True, rc=0, text=response_text, model="stub")
+
+        monkeypatch.setattr(
+            "mini_ork.optimize.gepa.dispatch_model", stub_dispatch
+        )
+
+    return _patch
+
+
+def test_optimize_improves_seed(patch_dispatch):
+    """Reflective loop must return a candidate strictly better than seed."""
+    patch_dispatch(_improve_reflection)
+    adapter = StubAdapter()
+    best, accepted = optimize(SEED, adapter, minibatch=MINIBATCH, budget=4)
+    # The improving reflection was accepted at least once.
+    assert len(accepted) >= 1, f"expected ≥1 accept, got {accepted}"
+    # The best candidate now contains TARGET_TOKEN; seed did not.
+    assert TARGET_TOKEN in best["instruction"]
+    assert TARGET_TOKEN not in SEED["instruction"]
+    # At least one full eval was triggered by the accept.
+    assert adapter.full_eval_count >= 1
+
+
+def test_gate_rejects_non_improving_mutation(patch_dispatch):
+    """Minibatch acceptance gate REJECTS no-op edits; seed is preserved."""
+    patch_dispatch(_noop_reflection)
+    adapter = StubAdapter()
+    best, accepted = optimize(SEED, adapter, minibatch=MINIBATCH, budget=4)
+    # No acceptance — every mutation equalled the parent on the minibatch,
+    # so the strict `sum(new) > sum(parent)` gate failed.
+    assert accepted == [], f"expected no accepts, got {accepted}"
+    assert adapter.full_eval_count == 0
+    # Seed was kept (Pareto front never moved off it).
+    assert best == SEED
+    assert TARGET_TOKEN not in best["instruction"]
+
+
+def test_loop_halts_at_budget(patch_dispatch):
+    """Loop runs exactly ``budget`` iterations regardless of accept/reject."""
+    patch_dispatch(_improve_reflection)
+    adapter = StubAdapter()
+    budget = 3
+    optimize(SEED, adapter, minibatch=MINIBATCH, budget=budget)
+    assert adapter.iteration_count == budget
+
+
+def test_rollout_economy_bounded(patch_dispatch):
+    """Full-eval count stays bounded by budget even when many mutations
+    are attempted. The minibatch gate skips full eval on rejected mutations
+    — that's the rollout-economy claim.
+    """
+    patch_dispatch(_improve_reflection)
+    adapter = StubAdapter()
+    budget = 8
+    optimize(SEED, adapter, minibatch=MINIBATCH, budget=budget)
+    # All 8 iterations ran.
+    assert adapter.iteration_count == budget
+    # But full evals are bounded by budget (actually ≤ number of accepts).
+    assert adapter.full_eval_count <= budget
+    # And critically: rejects happened — otherwise rollout economy is unproven.
+    # After the first accept, the mutation has TARGET_TOKEN, so subsequent
+    # "improving" reflections produce candidates with the same substring →
+    # equal minibatch scores → strict `>` gate rejects them.
+    assert adapter.full_eval_count < adapter.iteration_count, (
+        f"expected rejections to bound rollout; "
+        f"got full_eval_count={adapter.full_eval_count}, "
+        f"iteration_count={adapter.iteration_count}"
+    )


### PR DESCRIPTION
## Summary
R4a: a native, dependency-free **GEPA-style reflective prompt optimizer** (`mini_ork/optimize/gepa.py`).
Standalone and opt-in — nothing wired into the GRPO loop / `bin/mini-ork-reflect` yet (that's R4b),
so system behavior is unchanged.

- Two-method adapter (`GepaAdapter.evaluate` + `make_reflective_dataset`) — the whole integration surface.
- `optimize()` loop: Pareto parent select → minibatch eval → reflect-on-failures via
  `mini_ork.dispatch.dispatch_model` → **minibatch-acceptance gate** (only an improving mutation pays
  a full eval — GEPA's ~35× rollout saving) → Pareto front update.
- `candidate = dict[str,str]` = recipe prompt fields (the textual params GEPA evolves).
- No `gepa`/`dspy`/litellm dependency. Test 4/4 (beats seed, rejects non-improving mutation, halts
  at budget, rollout-economy bounded); full pytest 138 passed.
