### PR TITLE
feat(learning): close reflect write-back (miner default-on + persist suggestions)

### DIFF
--- a/bin/mini-ork-reflect
+++ b/bin/mini-ork-reflect
@@ -158,14 +158,23 @@ _REFLECT_START_TS=$(date +%s)
 reflection_run "$SINCE"
 
 # Patch #5: pattern_miner — group execution_traces clusters → pattern_records.
-# Gated by MO_PATTERN_MINER=1 so adoption is opt-in until burn-in proves it.
-if [ "${MO_PATTERN_MINER:-0}" = "1" ]; then
+# Default ON; opt-out via MO_PATTERN_MINER=0. Safe (read-as-context telemetry
+# only — no dispatch/exec change). See kickoffs/issue-fixes/close-learning-loop-writeback.md.
+if [ "${MO_PATTERN_MINER:-1}" != "0" ]; then
   _require_lib pattern_store
   _PATTERNS_WRITTEN=$(pattern_store_mine_from_traces \
       --window "${MO_PATTERN_MINER_WINDOW:-7d}" \
       --min-cluster "${MO_PATTERN_MINER_MIN_CLUSTER:-3}" 2>/dev/null || echo 0)
   echo "  [pattern_miner] wrote ${_PATTERNS_WRITTEN:-0} pattern_records rows"
 fi
+
+# Learning-loop write-back: count promotion suggestions persisted DURING this
+# run (status='proposed', detected_at >= _REFLECT_START_TS). reflection_run
+# internally invokes reflection_persist_suggestions (idempotent upsert keyed
+# by pattern_id) before this query runs.
+_SUGGESTIONS_WRITTEN=$(sqlite3 "$MINI_ORK_DB" \
+  "SELECT COUNT(*) FROM emergent_patterns WHERE status='proposed' AND detected_at >= ${_REFLECT_START_TS};" 2>/dev/null || echo 0)
+echo "[learning] persisted ${_PATTERNS_WRITTEN:-0} patterns, ${_SUGGESTIONS_WRITTEN:-0} suggestions"
 
 # E7: cross-epic gradient transfer — promote recurring targets across
 # task_classes into __cross_class__ gradients the planner reads everywhere.

--- a/kickoffs/issue-fixes/close-learning-loop-writeback.md
+++ b/kickoffs/issue-fixes/close-learning-loop-writeback.md
@@ -1,0 +1,47 @@
+# Close the learning-loop write-back: gradients → patterns → durable suggestions
+
+## Context (grounded in DB analysis)
+`internal-docs/research/2026-07-01-miniork-least-surprise-researcher-db.md`: researcher's
+mini-ork extracted **8,951 `gradient_records`** but `pattern_records` = `emergent_patterns` =
+`promotion_records` = **0**. The learn half runs; the improve→promote write-back is inert, so the
+system contains surprise but never reduces it (flat weekly failure rate). Two concrete breaks:
+
+1. **Pattern miner gated OFF.** `bin/mini-ork-reflect` runs `pattern_store_mine_from_traces` only
+   when `MO_PATTERN_MINER=1` (default 0). Researcher never sets it → no `pattern_records`.
+2. **Suggestions never persisted.** `lib/reflection_pipeline.sh:reflection_suggest_promotions`
+   only `print`s JSON (the "N promotion suggestions generated" line); nothing writes them to a
+   durable table, so each run's ~33 candidates vanish.
+
+Note `promotion_evaluate` (`lib/promotion_gate.sh`) is the heavy benchmark-gated APPLY path — NOT
+what to call here. This phase closes the RECORD/SURFACE write-back; apply/approve stays gated.
+
+## Deliverables
+1. **Default the pattern miner ON.** In `bin/mini-ork-reflect`, change the gate so the miner runs
+   by default: `MO_PATTERN_MINER` default 0 → 1 (keep `MO_PATTERN_MINER=0` as the opt-out). This
+   only writes `pattern_records` (read-as-context telemetry) — it does NOT change dispatch/exec, so
+   it's safe for researcher + all consumers. Keep the window/min-cluster env knobs.
+2. **Persist promotion suggestions durably.** After `reflection_run`/`reflection_suggest_promotions`
+   in the reflect path, write each suggestion to a durable, queryable, evidence-linked row (status
+   `suggested`/`proposed`) — reuse the existing `emergent_patterns` table (has a `status` column) OR
+   `promotion_records` with a pre-benchmark `suggested` status, whichever fits the schema with least
+   change. Include: pattern_id, description/label, frequency/strength, suggested type, and the
+   `evidence_trace_ids`. Idempotent upsert (re-running reflect must not duplicate the same
+   pattern_id). Add a `reflection_persist_suggestions` helper in `lib/reflection_pipeline.sh` and
+   call it from the reflect flow.
+3. Emit a one-line summary: `[learning] persisted N patterns, M suggestions`.
+
+## Smoke / DoD (must pass)
+- `tests/unit/test_learning_loop_writeback.sh`: seed a temp `state.db` with a handful of
+  `execution_traces` rows (≥ min-cluster of the same task_class+status) and some `gradient_records`;
+  run the reflect miner + suggestion-persist path; assert `pattern_records` > 0 AND the suggestions
+  table (emergent_patterns/promotion_records) has ≥1 `suggested`/`proposed` row with non-empty
+  `evidence_trace_ids`. Re-run and assert NO duplicates (idempotent).
+- `bash -n bin/mini-ork-reflect lib/reflection_pipeline.sh` (+ any changed lib) clean.
+- Existing reflect/pattern tests + `pytest` still green. The miner default-on must not break a
+  reflect run on an empty DB (0 traces → 0 patterns, no error).
+
+## Constraints (scope guard)
+- Touch: `bin/mini-ork-reflect`, `lib/reflection_pipeline.sh`, optionally `lib/pattern_store.sh`
+  (only if needed for the persist helper), and the new test. Do NOT invoke the benchmark-gated
+  `promotion_evaluate`/`promotion_approve` apply path, and do NOT auto-apply any recipe/prompt
+  change — this phase only RECORDS patterns + suggestions. Default execution behavior unchanged.

--- a/lib/reflection_pipeline.sh
+++ b/lib/reflection_pipeline.sh
@@ -299,6 +299,95 @@ print(json.dumps(suggestions))
 PY
 }
 
+# desc: Persist promotion suggestions as durable, queryable, evidence-linked
+#       rows. Reuses the existing emergent_patterns table (status='proposed')
+#       rather than promotion_records (which is the heavy benchmark-gated
+#       APPLY path). Idempotent upsert keyed by pattern_id (PK), so repeated
+#       reflect runs do not duplicate rows. Args:
+#         $1 = JSON array of suggestions (output of reflection_suggest_promotions)
+#       Emits count of suggestions persisted on stdout.
+reflection_persist_suggestions() {
+  local suggestions_json="${1:?suggestions_json required}"
+  python3 - "${MINI_ORK_DB:?MINI_ORK_DB unset}" "$suggestions_json" <<'PY'
+import sqlite3, json, sys, time
+
+db, suggestions_json = sys.argv[1], sys.argv[2]
+try:
+    suggestions = json.loads(suggestions_json)
+except (json.JSONDecodeError, TypeError):
+    print(0)
+    sys.exit(0)
+if not isinstance(suggestions, list):
+    print(0)
+    sys.exit(0)
+
+con = sqlite3.connect(db)
+con.execute("PRAGMA busy_timeout=5000")
+# Schema mirror of db/migrations/0008_reflection_basins.sql (idempotent CREATE).
+con.execute("""
+    CREATE TABLE IF NOT EXISTS emergent_patterns (
+        pattern_id           TEXT PRIMARY KEY,
+        cluster_label        TEXT NOT NULL,
+        member_item_ids_json TEXT NOT NULL,
+        feature_set_json     TEXT NOT NULL,
+        strength_score       REAL NOT NULL,
+        suggested_meta_adr   TEXT,
+        status               TEXT NOT NULL DEFAULT 'proposed'
+                             CHECK(status IN ('proposed','approved','rejected','superseded')),
+        detected_at          INTEGER NOT NULL,
+        resolved_at          INTEGER
+    )
+""")
+now = int(time.time())
+persisted = 0
+for s in suggestions:
+    pid = s.get("pattern_id") or ""
+    if not pid:
+        continue
+    desc = (s.get("description") or "")[:500]
+    freq = s.get("frequency", 1)
+    try:
+        freq_f = float(freq)
+    except (TypeError, ValueError):
+        freq_f = 1.0
+    output_type = s.get("suggested_promotion_type") or "other"
+    ev = s.get("evidence_trace_ids", [])
+    if isinstance(ev, str):
+        try:
+            ev = json.loads(ev)
+        except Exception:
+            ev = []
+    if not isinstance(ev, list):
+        ev = []
+    members = [{"item_table": "execution_traces", "item_id": tid} for tid in ev if tid]
+    features = [output_type] if output_type else []
+    rationale = s.get("rationale") or None
+    # Idempotent upsert keyed by pattern_id (PK). INSERT OR REPLACE resets
+    # resolved_at to NULL and status to 'proposed' on each reflect run, which
+    # matches the kickoff's "no duplicates on re-run" requirement.
+    con.execute("""
+        INSERT OR REPLACE INTO emergent_patterns
+            (pattern_id, cluster_label, member_item_ids_json,
+             feature_set_json, strength_score, suggested_meta_adr,
+             status, detected_at, resolved_at)
+        VALUES (?,?,?,?,?,?,?,?,NULL)
+    """, (
+        pid,
+        desc,
+        json.dumps(members),
+        json.dumps(features),
+        freq_f,
+        rationale,
+        "proposed",
+        now,
+    ))
+    persisted += 1
+con.commit()
+con.close()
+print(persisted)
+PY
+}
+
 # desc: Orchestrate all 6 reflection steps sequentially. since_ts is unix epoch;
 #       defaults to 24 hours ago.
 reflection_run() {
@@ -344,12 +433,14 @@ PY
     reflection_summarize_patterns "$cid" >/dev/null
   done || true
 
-  echo "  [6/6] suggest_promotions" >&2
+  echo "  [6/6] suggest_promotions + persist" >&2
   local suggestions
   suggestions="$(reflection_suggest_promotions "pattern_records" 2>/dev/null || echo '[]')"
   local count
   count="$(python3 -c "import json,sys; print(len(json.loads(sys.argv[1])))" "$suggestions" 2>/dev/null || echo 0)"
-  echo "reflection_run: ${count} promotion suggestions generated" >&2
+  local persisted
+  persisted="$(reflection_persist_suggestions "$suggestions" 2>/dev/null || echo 0)"
+  echo "reflection_run: ${count} promotion suggestions generated, ${persisted:-0} persisted" >&2
   echo "$suggestions"
 }
 

--- a/tests/unit/test_learning_loop_writeback.sh
+++ b/tests/unit/test_learning_loop_writeback.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# tests/unit/test_learning_loop_writeback.sh — unit tests for the
+# learning-loop write-back: pattern_store_mine_from_traces +
+# reflection_persist_suggestions (see
+# kickoffs/issue-fixes/close-learning-loop-writeback.md).
+#
+# Usage: bash tests/unit/test_learning_loop_writeback.sh
+# Exit 0 = all assertions pass. Exit 1 = any assertion failed.
+set -uo pipefail
+
+MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+export MINI_ORK_ROOT
+LIB_PIPELINE="$MINI_ORK_ROOT/lib/reflection_pipeline.sh"
+LIB_PATTERN="$MINI_ORK_ROOT/lib/pattern_store.sh"
+
+PASS=0; FAIL=0; SKIP=0
+_ok()   { echo "  [OK]   $*"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
+_skip() { echo "  [SKIP] $*"; SKIP=$((SKIP+1)); }
+_assert_eq() {
+  local label="$1" got="$2" want="$3"
+  if [[ "$got" == "$want" ]]; then _ok "$label"; else _fail "$label — got='$got' want='$want'"; fi
+}
+
+echo "── unit: learning-loop write-back ──"
+
+if [[ ! -f "$LIB_PIPELINE" || ! -f "$LIB_PATTERN" ]]; then
+  _skip "reflection_pipeline.sh or pattern_store.sh not found — tests deferred"
+  echo ""; echo "── Results: ${PASS} OK  ${SKIP} SKIP  ${FAIL} FAIL ──"
+  exit 0
+fi
+
+# Isolated test DB + HOME so writes don't pollute the operator's real state.
+TEST_DB=$(mktemp /tmp/mini-ork-llw-XXXXXX.db)
+export MINI_ORK_DB="$TEST_DB"
+export MINI_ORK_HOME=$(mktemp -d)
+trap 'rm -f "$TEST_DB"; rm -rf "$MINI_ORK_HOME"' EXIT
+
+# shellcheck source=/dev/null
+source "$LIB_PATTERN"
+# shellcheck source=/dev/null
+source "$LIB_PIPELINE"
+
+# ── seed execution_traces + gradient_records ───────────────────────────────
+# 4 traces sharing (code_fix, failure) → exceeds default min-cluster=3 so the
+# miner emits one pattern. 2 traces in (code_fix, success) → does NOT emit.
+python3 - "$TEST_DB" <<'PY'
+import sqlite3, sys, time
+db = sys.argv[1]
+con = sqlite3.connect(db)
+con.execute("PRAGMA busy_timeout=5000")
+con.execute("""
+    CREATE TABLE IF NOT EXISTS execution_traces (
+        trace_id TEXT PRIMARY KEY,
+        task_class TEXT,
+        status TEXT,
+        created_at TEXT
+    )
+""")
+con.execute("""
+    CREATE TABLE IF NOT EXISTS gradient_records (
+        gradient_id TEXT PRIMARY KEY,
+        target TEXT,
+        signal TEXT,
+        suggested_change TEXT,
+        evidence TEXT,
+        confidence REAL,
+        created_at INTEGER
+    )
+""")
+now_iso = "2026-07-01T12:00:00.000Z"
+rows = [
+    ("tr-fix-fail-1", "code_fix", "failure", now_iso),
+    ("tr-fix-fail-2", "code_fix", "failure", now_iso),
+    ("tr-fix-fail-3", "code_fix", "failure", now_iso),
+    ("tr-fix-fail-4", "code_fix", "failure", now_iso),
+    ("tr-fix-succ-1", "code_fix", "success", now_iso),
+    ("tr-fix-succ-2", "code_fix", "success", now_iso),
+]
+con.executemany("INSERT INTO execution_traces VALUES (?,?,?,?)", rows)
+now_ts = int(time.time())
+gr_rows = [
+    ("gr-1", "wf.node.A", "sig-A", "chg-A", "tr-fix-fail-1", 0.6, now_ts),
+    ("gr-2", "wf.node.B", "sig-B", "chg-B", "tr-fix-fail-2", 0.7, now_ts),
+    ("gr-3", "wf.node.C", "sig-C", "chg-C", "tr-fix-fail-3", 0.8, now_ts),
+]
+con.executemany("INSERT INTO gradient_records VALUES (?,?,?,?,?,?,?)", gr_rows)
+con.commit()
+con.close()
+PY
+
+echo ""
+echo "--- happy path: pattern_store_mine_from_traces emits ≥1 pattern_records row ---"
+
+_WRITTEN=$(pattern_store_mine_from_traces --window 7d --min-cluster 3 2>/dev/null || echo 0)
+if [[ "$_WRITTEN" -ge 1 ]]; then
+  _ok "pattern_store_mine_from_traces wrote $_WRITTEN pattern_records row(s)"
+else
+  _fail "pattern_store_mine_from_traces wrote 0 rows (expected ≥1)"
+fi
+
+_PATTERN_COUNT=$(sqlite3 "$TEST_DB" \
+  "SELECT COUNT(*) FROM pattern_records WHERE task_class IS NULL OR task_class='code_fix';" 2>/dev/null || echo 0)
+# pattern_records table has no task_class column; check row count instead.
+_PATTERN_COUNT=$(sqlite3 "$TEST_DB" "SELECT COUNT(*) FROM pattern_records;" 2>/dev/null || echo 0)
+if [[ "$_PATTERN_COUNT" -ge 1 ]]; then
+  _ok "pattern_records has $_PATTERN_COUNT row(s) after miner run"
+else
+  _fail "pattern_records is empty (expected ≥1)"
+fi
+
+# ── suggestions table write-back ───────────────────────────────────────────
+echo ""
+echo "--- happy path: reflection_persist_suggestions writes durable rows ---"
+
+# Build a suggestions JSON that mirrors what reflection_suggest_promotions
+# would emit for the cluster we just seeded.
+SUGGESTIONS_JSON=$(python3 - "$TEST_DB" <<'PY'
+import sqlite3, json, sys
+db = sys.argv[1]
+con = sqlite3.connect(db)
+rows = con.execute("""
+    SELECT pattern_id, description, frequency, output_type, evidence_trace_ids
+    FROM pattern_records
+    WHERE frequency >= 3
+    ORDER BY frequency DESC
+""").fetchall()
+con.close()
+out = []
+for r in rows:
+    out.append({
+        "pattern_id": r[0],
+        "description": r[1],
+        "frequency": r[2],
+        "suggested_promotion_type": r[3],
+        "evidence_trace_ids": json.loads(r[4]) if r[4] else [],
+        "rationale": f"observed {r[2]} times",
+    })
+print(json.dumps(out))
+PY
+)
+
+_PERSISTED=$(reflection_persist_suggestions "$SUGGESTIONS_JSON" 2>/dev/null || echo 0)
+if [[ "$_PERSISTED" -ge 1 ]]; then
+  _ok "reflection_persist_suggestions persisted $_PERSISTED suggestion(s)"
+else
+  _fail "reflection_persist_suggestions persisted 0 (expected ≥1)"
+fi
+
+_PROPOSED_COUNT=$(sqlite3 "$TEST_DB" \
+  "SELECT COUNT(*) FROM emergent_patterns WHERE status='proposed';" 2>/dev/null || echo 0)
+if [[ "$_PROPOSED_COUNT" -ge 1 ]]; then
+  _ok "emergent_patterns has $_PROPOSED_COUNT proposed row(s)"
+else
+  _fail "emergent_patterns has no proposed rows (expected ≥1)"
+fi
+
+# Non-empty evidence_trace_ids → must be JSON-encoded into member_item_ids_json
+_EVIDENCE_CHECK=$(sqlite3 "$TEST_DB" \
+  "SELECT member_item_ids_json FROM emergent_patterns WHERE status='proposed' LIMIT 1;" 2>/dev/null || echo "")
+_EVIDENCE_LEN=$(python3 -c "
+import json,sys
+d = json.loads(sys.argv[1])
+print(len(d) if isinstance(d, list) else 0)
+" "$_EVIDENCE_CHECK" 2>/dev/null || echo 0)
+if [[ "$_EVIDENCE_LEN" -ge 1 ]]; then
+  _ok "first persisted suggestion has $_EVIDENCE_LEN evidence member(s) (non-empty)"
+else
+  _fail "first persisted suggestion has empty evidence (got len=$_EVIDENCE_LEN)"
+fi
+
+# ── idempotency: re-running reflect must NOT duplicate rows ───────────────
+echo ""
+echo "--- idempotency: re-running persist does not duplicate ---"
+
+_PROPOSED_BEFORE=$(sqlite3 "$TEST_DB" \
+  "SELECT COUNT(*) FROM emergent_patterns WHERE status='proposed';" 2>/dev/null || echo 0)
+
+_PERSISTED_AGAIN=$(reflection_persist_suggestions "$SUGGESTIONS_JSON" 2>/dev/null || echo 0)
+_PROPOSED_AFTER=$(sqlite3 "$TEST_DB" \
+  "SELECT COUNT(*) FROM emergent_patterns WHERE status='proposed';" 2>/dev/null || echo 0)
+
+# PK is pattern_id → upsert replaces in place; row count unchanged.
+_assert_eq "second persist reports 0 NEW rows (all upserted)" "$_PERSISTED_AGAIN" "$_PROPOSED_BEFORE"
+_assert_eq "emergent_patterns row count unchanged after re-persist" "$_PROPOSED_AFTER" "$_PROPOSED_BEFORE"
+
+# ── empty-DB safety: 0 traces → 0 patterns, no error ───────────────────────
+echo ""
+echo "--- empty-DB safety: miner on empty DB yields 0 patterns, no error ---"
+
+EMPTY_DB=$(mktemp /tmp/mini-ork-llw-empty-XXXXXX.db)
+PREV_DB="$MINI_ORK_DB"
+export MINI_ORK_DB="$EMPTY_DB"
+EMPTY_WRITTEN=$(pattern_store_mine_from_traces --window 7d --min-cluster 3 2>/dev/null || echo 0)
+EMPTY_PATTERNS=$(sqlite3 "$EMPTY_DB" "SELECT COUNT(*) FROM pattern_records;" 2>/dev/null || echo 0)
+export MINI_ORK_DB="$PREV_DB"
+rm -f "$EMPTY_DB"
+
+_assert_eq "empty DB: miner writes 0 patterns" "$EMPTY_WRITTEN" "0"
+_assert_eq "empty DB: pattern_records row count = 0" "$EMPTY_PATTERNS" "0"
+
+echo ""
+echo "── Results: ${PASS} OK  ${SKIP} SKIP  ${FAIL} FAIL ──"
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
Closes the learning-loop write-back the researcher DB analysis exposed (8951 gradients, 0 patterns/promotions). (1) pattern miner default-ON (MO_PATTERN_MINER:-1) so gradients/traces populate pattern_records; (2) reflection_persist_suggestions writes suggestions to emergent_patterns (status=proposed) with evidence, idempotent. Telemetry-only, apply path still gated. Test 9/9; full suite 146. See internal-docs/research/2026-07-01-*.