### PR TITLE
docs+fix(execute): document node-type dispatch semantics, diagnose reviewer verdict-gate failures

### DIFF
--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -2373,7 +2373,11 @@ PY
       # (D-011/D-016 class) — strict json.load gave verdict=unknown and
       # cascaded a passing run into rollback (run-1781105320-64712).
       VERDICT=$(python3 "$MINI_ORK_ROOT/lib/extract_verdict.py" "$REVIEW_FILE" 2>/dev/null || echo "unknown")
-      echo "  [ok] reviewer verdict=${VERDICT} → $REVIEW_FILE"
+      # [info], not [ok] — extraction succeeding says nothing about whether the
+      # verdict itself will pass the gate below. A prior "[ok] verdict=fail"
+      # log line read as a benign status update immediately ahead of a hard
+      # node failure, which is confusing to debug from logs alone.
+      echo "  [info] reviewer verdict=${VERDICT} → $REVIEW_FILE"
       # D-042 rich trace payload — reviewer/synthesizer node
       local _verdict_norm
       _verdict_norm=$(printf '%s' "$VERDICT" | tr '[:upper:]' '[:lower:]')
@@ -2396,6 +2400,9 @@ PY
             return 1
             ;;
           *)
+            echo "  [fail] reviewer node '${node_id}' verdict='${VERDICT}' is not one of pass|approve|approved|revise|needs_revision|request_changes|fail|failed|escalate — treating as a failed node." >&2
+            echo "         extract_verdict.py could not find a recognized 'verdict' key in $REVIEW_FILE." >&2
+            echo "         If this reviewer's output is informational only (no recipe edge/loop branches on its verdict), use type: researcher instead — it captures the same response without the pass/fail gate. See docs/EXTENSION.md § Node type dispatch semantics." >&2
             MO_NODE_FINISH_REASON="verdict_fail"
             _trace_write_node_rich "$NODE_TRACE_ID" "failure" "reviewer" "$REVIEW_FILE" "$VERDICT" "$MO_NODE_FINISH_REASON"
             _d022_charge_node_cost "${MINI_ORK_RUN_DIR}/.last-llm-cost"

--- a/docs/EXTENSION.md
+++ b/docs/EXTENSION.md
@@ -96,6 +96,50 @@ There is no top-level `mini-ork validate` command yet. Until recipe validation i
 MINI_ORK_DRY_RUN=1 bin/mini-ork run my-recipe kickoff.md
 ```
 
+### Node type dispatch semantics
+
+The `workflow.yaml` fields above describe the *shape* of a node. They don't
+describe what `bin/mini-ork-execute` actually *does* with each `type` at
+dispatch time — and the difference matters: two node types that look
+interchangeable have very different guarantees about whether your LLM
+call's output actually becomes a usable artifact.
+
+| Type | Write-target injected into prompt? | Response captured if the model doesn't write a file itself? | Gated on a `verdict`? |
+|---|---|---|---|
+| `researcher` | Yes — `"Write your output to: $RUN_DIR/context-<node_id>.json"` (a real resolved path, not a variable the model has to expand) | Yes — raw response text is saved to that path as a fallback | No |
+| `reviewer` | Yes — same as `researcher`, saved to `$RUN_DIR/review-<node_id>.json` | Yes — same fallback | **Yes**, see below |
+| `implementer` | No | **No.** `IMPL_LOG` only stores raw stdout for forensics; it is never treated as a data artifact | No |
+| `verifier` | N/A (runs `verifier_ref` script, no LLM call) | N/A | N/A (exit code is the verdict) |
+| `publisher` / `rollback` | N/A (`prompt_ref: null`, deterministic) | N/A | N/A |
+
+**Use `researcher` for any stage whose job is "generate content and hand it
+to the next node."** This is the default choice — it's what every shipped
+lens/synthesis-style recipe (`chapter-review`, `dsp-planning-burst`) uses.
+The model doesn't need a file-write tool at all: tell it in the prompt to
+emit exactly one JSON value as its final response, and mini-ork saves it.
+
+**Use `implementer` only for actual code-editing tasks against a git
+checkout.** It's the only node type where `MO_TARGET_CWD` gets pinned to a
+worktree, matching `code-fix` / `recursive-validate-impl`'s pattern of
+having the model edit real files in a real repo. If you route a
+"generate JSON, write it to the run dir" task through `implementer`, the
+LLM call will report `[ok] implementer output` — success! — while
+producing zero usable artifact, because nothing captures its response.
+This failure mode is silent: the dispatch itself doesn't error.
+
+**The `reviewer` verdict gate.** After capturing the response,
+`lib/extract_verdict.py` looks for a `verdict` key and requires its value
+to be one of `pass`/`approve`/`approved` to succeed. `revise`/
+`needs_revision`/`request_changes`/`fail`/`failed`/`escalate` — and
+critically, *anything else, including a missing `verdict` key entirely* —
+fails the node (`return 1`) and is counted toward `FAIL_COUNT`. This gate
+exists for recipes whose edges/loop genuinely branch on the verdict
+(escalate-to-reflector patterns). If your reviewer node is informational
+only — its prompt's real output contract has no `verdict` field, e.g.
+`{"passed": bool, "notes": "..."}`  — this gate will unconditionally fail
+that node regardless of how valid the content is. Use `type: researcher`
+instead; it captures identical content without the gate.
+
 ---
 
 ## 2. AgentRegistry


### PR DESCRIPTION
## Summary
- Discovered live while debugging a downstream recipe (researcher/libwit's `chapter-staged-compose`): `docs/EXTENSION.md` correctly documents `workflow.yaml`'s structural schema, but says nothing about what `mini-ork-execute` actually *does* with each node `type` at dispatch time. Two silent failure modes cost real debugging rounds:
  1. `implementer` nodes get NO auto-resolved write-target and NO fallback capture of their response — only `researcher`/`reviewer` do. Routing a "generate content, hand it downstream" task through `implementer` looks like success (`[ok] implementer output`) but produces zero usable artifact.
  2. `reviewer` nodes are hard-gated on a `verdict` key via `lib/extract_verdict.py` (only `pass`/`approve`/`approved` succeed). A reviewer whose real output contract has no `verdict` field always fails, regardless of content validity — and the log line right before the failure (`[ok] reviewer verdict=fail`) reads as a benign status update, not a precursor to a hard failure.
- Adds a "Node type dispatch semantics" table + writeup to `docs/EXTENSION.md` covering both.
- Improves `mini-ork-execute`'s own runtime diagnostics: the pre-gate log line is now `[info]` not `[ok]`, and the unrecognized-verdict failure now explains why the node failed and points at the `researcher`-type escape hatch, instead of a bare `return 1`.

## Test plan
- [x] `bash tests/smoke.sh` — 251 OK / 0 FAIL
- [x] `shellcheck -S error bin/mini-ork-execute` — clean
- [x] `bash -n bin/mini-ork-execute` — syntax OK
- [x] Confirmed no other file in the repo greps for the old `[ok] reviewer verdict=` log line format (safe to change)
- [x] Docs-only + log-message changes — no control-flow behavior changed (still `return 1` in the same cases)
