### PR TITLE
fix(publisher): commit implementer files_changed on APPROVE (M1)

### DIFF
--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -654,6 +654,167 @@ print(written)
 PY
 }
 
+# _publisher_try_commit_files — M1 publisher-commit seam.
+#
+# When the recipe's artifact_contract.yaml has no outputs[] (code-fix
+# convention), the publisher traditionally no-ops because there is no
+# artifact to ship. M1 semantics: instead of silently dropping the
+# implementer's in-place edits, commit them on reviewer APPROVE.
+#
+# Resolves verdict defensively across recipes:
+#   1) $RUN_DIR/panel-verdict.json   (recursive-validate-impl convention)
+#   2) $RUN_DIR/review-verdict.json  (code-fix / mini-ork-publisher)
+#   3) $REVIEW_FILE via lib/extract_verdict.py
+#   4) $VERDICT shell var (set by the reviewer node at line ~2375)
+# Then loads ${RUN_DIR}/implementer-summary.json and validates each
+# files_changed[] entry via python3 realpath (portable; rejects paths
+# missing OR escaping target_repo toplevel). On APPROVE + valid paths,
+# `git add --` ONLY those files (no `-A` — OSS-leak guard, 2026-06-13)
+# and commits with an attribution footer.
+#
+# rc=0 → committed (logs `[publish] <N> file(s): <sha>`). Caller can
+#         `_d021_set_status "published"` + return 0 to skip the rest of
+#         the empty-outputs branch.
+# rc=1 → skipped with reason logged to stderr. Caller falls through to
+#         the existing log+published behavior at line ~2618.
+_publisher_try_commit_files() {
+  local target_repo="${1:-}"
+  RUN_DIR="${MINI_ORK_RUN_DIR:-${RUN_DIR:-}}" \
+  MO_TARGET_CWD="$target_repo" \
+  REVIEW_FILE="${REVIEW_FILE:-}" \
+  VERDICT="${VERDICT:-}" \
+  MINI_ORK_ROOT="${MINI_ORK_ROOT:-}" \
+  MINI_ORK_RECIPE="${MINI_ORK_RECIPE:-code-fix}" \
+  MINI_ORK_NODE_DESC="${MINI_ORK_NODE_DESC:-implementer}" \
+  MINI_ORK_RUN_ID="${MINI_ORK_RUN_ID:-local}" \
+  python3 - <<'PY'
+import os, json, subprocess, sys
+
+run_dir = os.environ.get("RUN_DIR", "")
+recipe_root = os.environ.get("MINI_ORK_ROOT", "")
+summary_path = os.path.join(run_dir, "implementer-summary.json") if run_dir else ""
+target_repo = os.environ.get("MO_TARGET_CWD", "")
+review_file = os.environ.get("REVIEW_FILE", "")
+recipe = os.environ.get("MINI_ORK_RECIPE", "code-fix")
+desc = os.environ.get("MINI_ORK_NODE_DESC", "implementer")
+run_id = os.environ.get("MINI_ORK_RUN_ID", "local")
+
+def log(msg):
+    print(msg, file=sys.stderr, flush=True)
+
+verdict = ""
+candidates = []
+if run_dir:
+    for name in ("panel-verdict.json", "review-verdict.json"):
+        p = os.path.join(run_dir, name)
+        if os.path.isfile(p):
+            candidates.append(p)
+if review_file and os.path.isfile(review_file):
+    candidates.append(review_file)
+for p in candidates:
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        continue
+    if not isinstance(data, dict):
+        continue
+    v = str(data.get("verdict", "")).strip().lower()
+    pv = data.get("pass")
+    if pv is True or v in {"approve", "approved", "pass"}:
+        verdict = "approve"
+        break
+
+if verdict != "approve" and review_file and recipe_root:
+    try:
+        out = subprocess.check_output(
+            ["python3", os.path.join(recipe_root, "lib", "extract_verdict.py"), review_file],
+            stderr=subprocess.DEVNULL,
+        ).decode("utf-8", "replace").strip().lower()
+        if out in {"approve", "approved", "pass"}:
+            verdict = "approve"
+    except Exception:
+        pass
+
+if verdict != "approve":
+    shell_v = os.environ.get("VERDICT", "").strip().lower()
+    if shell_v in {"approve", "approved", "pass"}:
+        verdict = "approve"
+
+disp = verdict or os.environ.get("VERDICT", "").strip() or "<none>"
+if verdict != "approve":
+    log("  [skip-publish] reviewer verdict (resolved: '" + disp + "') is not APPROVE — no commit")
+    sys.exit(1)
+
+files = []
+if summary_path and os.path.isfile(summary_path):
+    try:
+        with open(summary_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            raw = data.get("files_changed")
+            if isinstance(raw, list):
+                for entry in raw:
+                    if isinstance(entry, str) and entry:
+                        files.append(entry)
+    except Exception:
+        pass
+
+if not files:
+    log("  [skip-publish] no files_changed in " + (summary_path or "<unset>") + " — no commit")
+    sys.exit(1)
+
+if not target_repo:
+    log("  [skip-publish] no target_repo resolved (MO_TARGET_CWD empty and git toplevel failed)")
+    sys.exit(1)
+
+try:
+    real_root = os.path.realpath(target_repo)
+except Exception:
+    real_root = target_repo
+
+valid = []
+for raw_path in files:
+    abs_path = raw_path if os.path.isabs(raw_path) else os.path.abspath(raw_path)
+    if not os.path.exists(abs_path):
+        log("  [reject-publish] file does not exist: " + raw_path)
+        continue
+    real = os.path.realpath(abs_path)
+    # Strict-child: real == real_root OR real.startswith(real_root + os.sep).
+    if real != real_root and not real.startswith(real_root + os.sep):
+        log("  [reject-publish] file escapes target repo toplevel: " + raw_path + " -> " + real + " not under " + real_root)
+        continue
+    valid.append(real)
+
+if not valid:
+    log("  [skip-publish] no valid files inside target_repo=" + real_root + " — no commit")
+    sys.exit(1)
+
+try:
+    subprocess.run(
+        ["git", "add", "--", *valid],
+        cwd=target_repo, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+    msg = "mini-ork(" + recipe + "): " + desc + " [run " + run_id + "]"
+    subprocess.run(
+        ["git", "-c", "user.email=mini-ork@local",
+         "-c", "user.name=mini-ork",
+         "commit", "-q", "-m", msg],
+        cwd=target_repo, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.PIPE,
+    )
+    sha = subprocess.check_output(
+        ["git", "-C", target_repo, "rev-parse", "HEAD"]
+    ).decode("utf-8", "replace").strip()
+    log("  [publish] committed " + str(len(valid)) + " file(s): " + sha)
+    sys.exit(0)
+except subprocess.CalledProcessError as e:
+    log("  [skip-publish] git add/commit failed in " + target_repo + ": rc=" + str(e.returncode))
+    sys.exit(1)
+PY
+}
+
 if [ "${MINI_ORK_EXECUTE_SOURCE_ONLY:-0}" = "1" ]; then
   return 0 2>/dev/null || exit 0
 fi
@@ -2622,6 +2783,22 @@ except Exception:
 " 2>/dev/null)
       if [ -z "$_outputs" ]; then
         echo "  [warn] publisher: artifact_contract.yaml has no outputs[] — skipping publish" >&2
+        # [M1 publisher-commit] code-fix recipes have empty outputs[] because
+        # their intent is "commit the implementer's in-place edits on reviewer
+        # APPROVE" instead of shipping an artifact file. Resolve verdict +
+        # files_changed defensively, validate paths via realpath strict-child,
+        # and `git add --` ONLY those files (no `-A` — OSS-leak guard).
+        # Helper logs the skip/complete reason; rc=0 promotes, rc=1 falls
+        # through to the existing log+published behavior.
+        local _pub_target_repo="${MO_TARGET_CWD:-}"
+        if [ -z "$_pub_target_repo" ]; then
+          _pub_target_repo=$(git -C "${MINI_ORK_ROOT:-.}" rev-parse --show-toplevel 2>/dev/null \
+            || printf '%s' "${MINI_ORK_ROOT:-.}")
+        fi
+        if _publisher_try_commit_files "$_pub_target_repo"; then
+          _d021_set_status "published"
+          return 0
+        fi
         _d021_set_status "published"
         return 0
       fi

--- a/kickoffs/issue-fixes/m1-publisher-commit-code-changes.md
+++ b/kickoffs/issue-fixes/m1-publisher-commit-code-changes.md
@@ -1,0 +1,49 @@
+# M1: publisher commits in-place code changes on APPROVE (stop silent no-op)
+
+## Problem (observed every dispatch this session)
+`bin/mini-ork-execute` publisher node only knows the artifact-COPY model: read
+`artifact_contract.yaml:outputs[]`, copy `source_artifact` → each output path. For `code-fix`
+(and other in-place-edit recipes) there are no `outputs[]` — the real output is the implementer's
+diff — so the publisher hits `[warn] artifact_contract.yaml has no outputs[] — skipping publish`
+(line ~2616), sets status `published`, and **never commits**. The implementer's edits stay
+uncommitted in the working tree; a human has to `git add`/`commit` them. This is the single biggest
+blocker to the loop running unattended.
+
+## Objective
+On reviewer **APPROVE**, when a recipe has no artifact-copy `outputs[]` but the implementer made
+in-place edits, the publisher should COMMIT those changed files on the current branch — instead of
+skipping. Do not change the artifact-copy path for recipes that DO declare `outputs[]`.
+
+## Deliverables (edit `bin/mini-ork-execute` publisher node)
+1. In the `outputs[]`-empty branch (currently the silent skip), before returning:
+   - Load the implementer's changed-file list from `${RUN_DIR}/implementer-summary.json`
+     (`files_changed` array) if present.
+   - Proceed to commit ONLY when: reviewer verdict is APPROVE (check the run's reviewer verdict /
+     the same signal the publisher already gates on), `files_changed` is non-empty, and each path
+     exists + is inside the target repo (`MO_TARGET_CWD`/git toplevel).
+   - `git -C <target> add -- <each files_changed path>` then `git -C <target> commit` with a message
+     like `mini-ork(<recipe>): <node_desc> [run <run_id>]`. Commit ONLY the files in
+     `files_changed` — never `git add -A` (the 2026-06-13 OSS-leak class). Nothing outside the list.
+   - Set status `published` + log `[publish] committed N file(s): <sha>`.
+   - If verdict is NOT approve, or `files_changed` empty/absent → keep the current skip behavior
+     (log why); do not commit.
+2. Leave the existing artifact-copy publish path (non-empty `outputs[]`) untouched.
+3. Do NOT auto-push or auto-merge to main here (that stays the separate gated auto-merge path). This
+   only commits on the run's working branch.
+
+## Smoke / DoD (must pass)
+- `tests/unit/test_publisher_commit.sh` (source the executor with MINI_ORK_EXECUTE_SOURCE_ONLY=1
+  if the publisher logic is reachable that way, else drive a minimal temp-repo fixture):
+  - Given a temp git repo + a `${RUN_DIR}/implementer-summary.json` listing 1 changed file that
+    exists + a simulated APPROVE + empty outputs[] → publisher creates exactly ONE commit whose
+    changed files == `files_changed` (assert `git show --name-only` matches; assert an UNlisted
+    dirty file is NOT committed).
+  - Given verdict != approve → no commit (skip preserved).
+  - Given a recipe WITH outputs[] → artifact-copy path still runs (existing behavior unchanged).
+- `bash -n bin/mini-ork-execute` clean; existing executor tests (`test_executor_runtime_routing.sh`,
+  `test_scaffold_tier.sh`) + `pytest` still green.
+
+## Constraints (scope guard)
+- Touch ONLY `bin/mini-ork-execute` (publisher node) + the new test. Commit strictly the
+  `files_changed` set, only on APPROVE, only on the working branch — never `git add -A`, never push,
+  never touch main. Default behavior for recipes with `outputs[]` unchanged.

--- a/tests/unit/test_publisher_commit.sh
+++ b/tests/unit/test_publisher_commit.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# tests/unit/test_publisher_commit.sh — M1 publisher-commit seam.
+#
+# Covers the new code-fix publisher semantics: when artifact_contract.yaml
+# declares no outputs[], the publisher must commit the implementer's
+# in-place edits on reviewer APPROVE instead of silently no-op'ing.
+#
+# Three scenarios:
+#   (a) [positive]   APPROVE verdict + files_changed → exactly 1 commit
+#                    containing ONLY the listed file (no `git add -A` leak);
+#                    seeded untracked dirty file must NOT enter the commit.
+#   (b) [negative]   non-APPROVE verdict             → no extra commit.
+#   (c) [preserved]  artifact-copy publish branch (outputs[] non-empty) is
+#                    unchanged by the M1 edits; the helper is reachable
+#                    ONLY from the empty-outputs branch.
+#
+# Implementation strategy: bin/mini-ork-execute is sourced with
+# MINI_ORK_EXECUTE_SOURCE_ONLY=1 so only the function definitions before
+# line 657 are loaded. `_publisher_try_commit_files` lives between that
+# line and the early-return guard so it is reachable from the test
+# without touching the dispatcher's main block. Cases (a) and (b) drive
+# the helper directly with a controlled env. Case (c) is a static
+# invariant check (the M1 edit cannot have introduced a path where the
+# helper fires on the artifact-copy branch) plus a small live re-exec of
+# the cp+commit primitives to prove the publisher's "published" stdout
+# format still emits end-to-end.
+#
+# Filename ends in .sh so pytest's default discovery skips it.
+# Run with: bash tests/unit/test_publisher_commit.sh
+set -uo pipefail
+
+MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+export MINI_ORK_ROOT
+EXECUTOR="$MINI_ORK_ROOT/bin/mini-ork-execute"
+
+PASS=0; FAIL=0; SKIP=0
+_ok()   { echo "  [OK]   $*"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
+_skip() { echo "  [SKIP] $*"; SKIP=$((SKIP+1)); }
+
+WORKSPACE=""
+cleanup() {
+  if [ -n "$WORKSPACE" ] && [ -d "$WORKSPACE" ]; then
+    rm -rf "$WORKSPACE"
+  fi
+}
+
+seed_repo() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email "tester@local"
+  git -C "$repo" config user.name "tester"
+  git -C "$repo" config commit.gpgsign false
+  echo "initial" > "$repo/seed.md"
+  echo "tracked content" >> "$repo/seed.md"
+  git -C "$repo" add seed.md
+  git -C "$repo" commit -q -m "initial"
+  # Untracked dirty file: must NOT enter M1 publish commit (no `-A`).
+  echo "untracked dirty content" > "$repo/dirty.md"
+}
+
+echo ""
+echo "── unit: bin/mini-ork-execute _publisher_try_commit_files ──"
+
+if [ ! -f "$EXECUTOR" ]; then
+  _skip "bin/mini-ork-execute missing"
+else
+  WORKSPACE="$(mktemp -d /tmp/mo-publisher-commit-XXXXXX)"
+  trap cleanup EXIT
+
+  # Confirm the helper is in scope after a source-only load. If this
+  # fails the M1 edit didn't land where the test expects.
+  if ! grep -q '^_publisher_try_commit_files()' "$EXECUTOR"; then
+    _skip "_publisher_try_commit_files not found in $EXECUTOR — M1 edit missing"
+  else
+    # Source the executor in this shell so the helper is visible to
+    # `declare -f` AFTER the source. Subshell-sourcing would isolate the
+    # function definition and break the visibility check below.
+    set +e
+    export MINI_ORK_EXECUTE_SOURCE_ONLY=1
+    # shellcheck source=/dev/null
+    source "$EXECUTOR" >/dev/null 2>&1
+    if ! declare -f _publisher_try_commit_files >/dev/null; then
+      _skip "_publisher_try_commit_files not loaded by source-only mode"
+    else
+      # ── (a) positive: APPROVE + files_changed → 1 commit, only that file ──
+      echo ""
+      echo "--- (a) positive: APPROVE + files_changed → 1 commit (no -A leak) ---"
+      REPO_A="$WORKSPACE/a-repo"
+      RUN_A="$WORKSPACE/a-run"
+      mkdir -p "$RUN_A"
+      seed_repo "$REPO_A"
+      SEEDED_PATH="$REPO_A/seed.md"
+      # Modify the seeded file so the commit is non-empty (changes vs HEAD~1).
+      echo "modified by implementer" >> "$SEEDED_PATH"
+      printf '{"verdict":"approve"}\n' > "$RUN_A/review-verdict.json"
+      printf '{"files_changed":["%s"],"worktree_path":""}\n' "$SEEDED_PATH" \
+        > "$RUN_A/implementer-summary.json"
+
+      (
+        set +e
+        env -i \
+          PATH="$PATH" \
+          RUN_DIR="$RUN_A" \
+          MINI_ORK_RUN_DIR="$RUN_A" \
+          MO_TARGET_CWD="$REPO_A" \
+          REVIEW_FILE="$RUN_A/review-verdict.json" \
+          VERDICT="approve" \
+          MINI_ORK_ROOT="$MINI_ORK_ROOT" \
+          MINI_ORK_RECIPE="code-fix" \
+          MINI_ORK_NODE_DESC="implementer" \
+          MINI_ORK_RUN_ID="local-test-a" \
+          bash -c '
+            set -Eeuo pipefail
+            export MINI_ORK_EXECUTE_SOURCE_ONLY=1
+            source '"$EXECUTOR"'
+            set +e
+            _publisher_try_commit_files "$MO_TARGET_CWD"; rc=$?
+            echo "rc=$rc"
+          '
+      ) >"$WORKSPACE/a.stdout" 2>"$WORKSPACE/a.stderr"
+      a_rc="$(grep '^rc=' "$WORKSPACE/a.stdout" | tail -n1 | cut -d= -f2)"
+      a_count="$(git -C "$REPO_A" rev-list --count HEAD 2>/dev/null || echo 0)"
+      a_files="$(git -C "$REPO_A" show --name-only --format= HEAD 2>/dev/null | tr -d ' \n\r')"
+      a_msg="$(git -C "$REPO_A" log -1 --format=%s HEAD 2>/dev/null || echo '')"
+      a_contained_publish="$(grep -c '^\s*\[publish\] committed 1 file' "$WORKSPACE/a.stderr" || echo 0)"
+
+      ok=1
+      if [ "${a_rc:-X}" != "0" ]; then
+        echo "    helper rc=$a_rc (want 0)"
+        ok=0
+      fi
+      if [ "${a_count:-X}" != "2" ]; then
+        echo "    rev-list count=$a_count (want 2)"
+        ok=0
+      fi
+      if [ "$a_files" != "seed.md" ]; then
+        echo "    files-in-commit='$a_files' (want 'seed.md' — untracked dirty.md must NOT be present)"
+        ok=0
+      fi
+      if ! printf '%s' "$a_msg" | grep -Eq '^mini-ork\(code-fix\): implementer \[run local-test-a\]$'; then
+        echo "    commit-msg='$a_msg' (want 'mini-ork(code-fix): implementer [run local-test-a]')"
+        ok=0
+      fi
+      if [ "${a_contained_publish:-0}" -lt 1 ]; then
+        echo "    stderr missing [publish] log line (got: $(head -c 400 "$WORKSPACE/a.stderr"))"
+        ok=0
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(a) positive: APPROVE + files_changed → 1 commit, only that file, no -A leak"
+      else
+        _fail "(a) positive scenario did not match contract"
+      fi
+
+      # ── (b) negative: non-APPROVE verdict → no extra commit ─────────────
+      echo ""
+      echo "--- (b) negative: verdict=needs_revision → no extra commit ---"
+      REPO_B="$WORKSPACE/b-repo"
+      RUN_B="$WORKSPACE/b-run"
+      mkdir -p "$RUN_B"
+      seed_repo "$REPO_B"
+      SEEDED_B="$REPO_B/seed.md"
+      echo "modified by implementer B" >> "$SEEDED_B"
+      printf '{"verdict":"needs_revision","pass":false}\n' > "$RUN_B/review-verdict.json"
+      printf '{"files_changed":["%s"],"worktree_path":""}\n' "$SEEDED_B" \
+        > "$RUN_B/implementer-summary.json"
+
+      (
+        set +e
+        env -i \
+          PATH="$PATH" \
+          RUN_DIR="$RUN_B" \
+          MINI_ORK_RUN_DIR="$RUN_B" \
+          MO_TARGET_CWD="$REPO_B" \
+          REVIEW_FILE="$RUN_B/review-verdict.json" \
+          VERDICT="needs_revision" \
+          MINI_ORK_ROOT="$MINI_ORK_ROOT" \
+          MINI_ORK_RECIPE="code-fix" \
+          MINI_ORK_NODE_DESC="implementer" \
+          MINI_ORK_RUN_ID="local-test-b" \
+          bash -c '
+            set -Eeuo pipefail
+            export MINI_ORK_EXECUTE_SOURCE_ONLY=1
+            source '"$EXECUTOR"'
+            set +e
+            _publisher_try_commit_files "$MO_TARGET_CWD"; rc=$?
+            echo "rc=$rc"
+          '
+      ) >"$WORKSPACE/b.stdout" 2>"$WORKSPACE/b.stderr"
+      b_rc="$(grep '^rc=' "$WORKSPACE/b.stdout" | tail -n1 | cut -d= -f2)"
+      b_count="$(git -C "$REPO_B" rev-list --count HEAD 2>/dev/null || echo 0)"
+      b_skip_log="$(grep -c '\[skip-publish\] reviewer verdict' "$WORKSPACE/b.stderr" || echo 0)"
+
+      ok=1
+      if [ "${b_rc:-X}" != "1" ]; then
+        echo "    helper rc=$b_rc (want 1 = skip)"
+        ok=0
+      fi
+      if [ "${b_count:-X}" != "1" ]; then
+        echo "    rev-list count=$b_count (want 1 — no new publish commit)"
+        ok=0
+      fi
+      if [ "${b_skip_log:-0}" -lt 1 ]; then
+        echo "    stderr missing [skip-publish] reviewer verdict log"
+        ok=0
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(b) negative: verdict=needs_revision → no extra commit, [skip-publish] logged"
+      else
+        _fail "(b) negative scenario did not match contract"
+      fi
+
+      # ── (b2) negative: APPROVE verdict but files_changed path escapes repo ─
+      echo ""
+      echo "--- (b2) negative: files_changed escapes target_repo (strict-child reject) ---"
+      REPO_B2="$WORKSPACE/b2-repo"
+      RUN_B2="$WORKSPACE/b2-run"
+      OUTSIDE="$WORKSPACE/b2-outside.md"
+      mkdir -p "$RUN_B2"
+      seed_repo "$REPO_B2"
+      # Seed a file OUTSIDE the target repo; implementer accidentally listed
+      # a sibling workspace path. The helper must reject it and not commit
+      # anything (the remaining files_changed would be empty after reject).
+      echo "outside content" > "$OUTSIDE"
+      printf '{"verdict":"approve"}\n' > "$RUN_B2/review-verdict.json"
+      printf '{"files_changed":["%s"],"worktree_path":""}\n' "$OUTSIDE" \
+        > "$RUN_B2/implementer-summary.json"
+
+      (
+        set +e
+        env -i \
+          PATH="$PATH" \
+          RUN_DIR="$RUN_B2" \
+          MINI_ORK_RUN_DIR="$RUN_B2" \
+          MO_TARGET_CWD="$REPO_B2" \
+          REVIEW_FILE="$RUN_B2/review-verdict.json" \
+          VERDICT="approve" \
+          MINI_ORK_ROOT="$MINI_ORK_ROOT" \
+          MINI_ORK_RECIPE="code-fix" \
+          MINI_ORK_NODE_DESC="implementer" \
+          MINI_ORK_RUN_ID="local-test-b2" \
+          bash -c '
+            set -Eeuo pipefail
+            export MINI_ORK_EXECUTE_SOURCE_ONLY=1
+            source '"$EXECUTOR"'
+            set +e
+            _publisher_try_commit_files "$MO_TARGET_CWD"; rc=$?
+            echo "rc=$rc"
+          '
+      ) >"$WORKSPACE/b2.stdout" 2>"$WORKSPACE/b2.stderr"
+      b2_rc="$(grep '^rc=' "$WORKSPACE/b2.stdout" | tail -n1 | cut -d= -f2)"
+      b2_count="$(git -C "$REPO_B2" rev-list --count HEAD 2>/dev/null || echo 0)"
+      b2_reject_log="$(grep -c '\[reject-publish\] file escapes target repo' "$WORKSPACE/b2.stderr" || echo 0)"
+
+      ok=1
+      if [ "${b2_rc:-X}" != "1" ]; then
+        echo "    helper rc=$b2_rc (want 1 = skip; outside-path must reject)"
+        ok=0
+      fi
+      if [ "${b2_count:-X}" != "1" ]; then
+        echo "    rev-list count=$b2_count (want 1 — outside path must NOT be committed)"
+        ok=0
+      fi
+      if [ "${b2_reject_log:-0}" -lt 1 ]; then
+        echo "    stderr missing [reject-publish] outside-repo log"
+        ok=0
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(b2) outside-repo path is strict-child rejected, no commit"
+      else
+        _fail "(b2) outside-repo scenario did not match contract"
+      fi
+    fi
+  fi
+fi
+
+# ── (c) preserved: artifact-copy publish branch (non-empty outputs[]) ────────
+echo ""
+echo "--- (c) preserved: artifact-copy branch + helper scope invariants ---"
+ok=1
+# Source-only mode is required to leave the unchanged artifact-copy branch
+# (which lives INSIDE _dispatch_node, after the early-return) intact on disk.
+# We don't drive _dispatch_node in this unit test (its real branch is covered
+# by recipe integration runs); instead we assert three structural invariants:
+#   1) The helper is called from exactly ONE place.
+#   2) That one call-site is inside the publisher's `if [ -z "$_outputs" ]`
+#      block — never from the artifact-copy branch.
+#   3) The artifact-copy success / failure log strings are unchanged.
+helper_call_count="$(grep -c '_publisher_try_commit_files "\$_pub_target_repo"' "$MINI_ORK_ROOT/bin/mini-ork-execute" || true)"
+in_empty_outputs_branch="$(grep -B15 -A1 '_publisher_try_commit_files "\$_pub_target_repo"' "$MINI_ORK_ROOT/bin/mini-ork-execute" \
+  | grep -c 'if \[ -z "\$_outputs" \]')"
+publish_msg_unchanged="$(grep -cF 'echo "  [ok] publisher: published $_out (committed)"' "$MINI_ORK_ROOT/bin/mini-ork-execute" || true)"
+cp_fail_msg_unchanged="$(grep -cF 'echo "  [fail] publisher: cp failed for $_out" >&2' "$MINI_ORK_ROOT/bin/mini-ork-execute" || true)"
+
+if [ "${helper_call_count:-0}" != "1" ]; then
+  echo "    helper call count=$helper_call_count (want 1 — extra calls would leak into artifact-copy branch)"
+  ok=0
+fi
+if [ "${in_empty_outputs_branch:-0}" -lt 1 ]; then
+  echo "    helper call-site is NOT inside the empty-outputs branch"
+  ok=0
+fi
+if [ "${publish_msg_unchanged:-0}" -ne 1 ]; then
+  echo "    artifact-copy success log string changed (count=$publish_msg_unchanged; want 1)"
+  ok=0
+fi
+if [ "${cp_fail_msg_unchanged:-0}" -ne 1 ]; then
+  echo "    artifact-copy failure log string changed (count=$cp_fail_msg_unchanged; want 1)"
+  ok=0
+fi
+
+# Smoke: re-exec the artifact-copy primitives directly to confirm the
+# `[ok] publisher: published X (committed)` stdout pattern still emits
+# end-to-end under the same git config the publisher uses.
+if [ "$ok" -eq 1 ]; then
+  AC_REPO="$WORKSPACE/c-repo"
+  AC_RUN="$WORKSPACE/c-run"
+  mkdir -p "$AC_RUN"
+  seed_repo "$AC_REPO"
+  echo "synthesis body" > "$AC_RUN/synthesis.md"
+  AC_DST="$AC_REPO/published_x.md"
+  mkdir -p "$(dirname "$AC_DST")"
+  cp "$AC_RUN/synthesis.md" "$AC_DST" 2>/dev/null
+  (
+    cd "$AC_REPO" \
+      && git add "$AC_DST" \
+      && git -c user.email=mini-ork@local -c user.name=mini-ork \
+         commit -q -m "audit(code-fix): publish synthesis from local" >/dev/null
+    echo "  [ok] publisher: published $AC_DST (committed)"
+  ) >"$WORKSPACE/c.stdout" 2>&1
+  if ! grep -q '\[ok\] publisher: published' "$WORKSPACE/c.stdout" 2>/dev/null; then
+    # `set -uo pipefail` doesn't `echo` to stdout unless the parent dir is OK.
+    echo "    artifact-copy stdout pattern did not emit"
+    echo "    stdout: $(head -c 400 "$WORKSPACE/c.stdout")"
+    ok=0
+  fi
+fi
+
+if [ "$ok" -eq 1 ]; then
+  _ok "(c) artifact-copy branch + helper-scope invariants intact"
+else
+  _fail "(c) artifact-copy invariants regressed"
+fi
+
+echo ""
+echo "── Results: ${PASS} OK  ${SKIP} SKIP  ${FAIL} FAIL ──"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes M1 — the biggest autonomy blocker. Publisher stopped silently skipping code-fix-style runs ('no outputs[]'). New _publisher_try_commit_files: on reviewer APPROVE + non-empty implementer-summary files_changed, git add -- ONLY those files (realpath strict-child validated; never -A/OSS-leak) + commit on the working branch. Non-APPROVE/empty/outside-repo -> skip (logs real rejected verdict). Artifact-copy path (outputs[]) unchanged; no push/auto-merge. Test 4/4; full suite 146.