### PR TITLE
fix(reviewer): assemble+inject code-fix reviewer inputs (#2)

### DIFF
--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -159,6 +159,118 @@ PY
   return 1
 }
 
+# _mo_assemble_reviewer_inputs — write review-diff.patch and build the reviewer
+# prompt context block (D-RIA, 2026-07-02).
+#
+# Reads from $RUN_DIR (preferred) or $1 if passed:
+#   - implementer-summary.json (the implementer's JSON summary, including
+#     files_changed and worktree_path)
+#   - verifier_typecheck.json + verifier_test.json (verifier verdicts,
+#     persisted by the verifier node handler)
+# Writes $RUN_DIR/review-diff.patch (unified diff of files_changed scoped to
+# the implementer's worktree, or a `(no diff available)` marker) and prints a
+# reviewer-context block to stdout, ready to append to the reviewer's
+# PROMPT_CONTENT.
+#
+# Missing inputs degrade to "(not available)" — the function never aborts on
+# missing files. The "hard-abstain" instruction in the block tells the LLM to
+# review whatever IS present and only refuse a verdict when BOTH the diff
+# AND the summary are absent.
+_mo_assemble_reviewer_inputs() {
+  local _run_dir="${1:-${MINI_ORK_RUN_DIR:-${RUN_DIR:-}}}"
+  if [ -z "$_run_dir" ]; then
+    return 0
+  fi
+  mkdir -p "$_run_dir" 2>/dev/null || true
+
+  # Resolve the worktree the implementer wrote to (prefer worktree_path from
+  # the summary; fall back to MO_TARGET_CWD, then $PWD).
+  local _worktree=""
+  if [ -f "$_run_dir/implementer-summary.json" ]; then
+    _worktree=$(python3 - "$_run_dir/implementer-summary.json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get("worktree_path") or "")
+except Exception:
+    pass
+PY
+    )
+  fi
+  if [ -z "$_worktree" ] || [ ! -d "$_worktree" ]; then
+    _worktree="${MO_TARGET_CWD:-$PWD}"
+  fi
+
+  # Generate review-diff.patch (D-RIA deliverable #2)
+  local _diff_path="$_run_dir/review-diff.patch"
+  local _files=""
+  if [ -f "$_run_dir/implementer-summary.json" ]; then
+    _files=$(python3 - "$_run_dir/implementer-summary.json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    fc = d.get("files_changed") or []
+    if isinstance(fc, list):
+        print(" ".join(str(x) for x in fc))
+except Exception:
+    pass
+PY
+    )
+  fi
+  if [ -d "$_worktree" ] \
+      && git -C "$_worktree" rev-parse --git-dir >/dev/null 2>&1; then
+    if [ -n "$_files" ]; then
+      git -C "$_worktree" diff --no-color -- "${_files}" \
+        > "$_diff_path" 2>/dev/null || true
+    else
+      git -C "$_worktree" diff --no-color \
+        > "$_diff_path" 2>/dev/null || true
+    fi
+  fi
+  if [ ! -s "$_diff_path" ]; then
+    # Either no diff at all, no worktree, or git error — write an empty
+    # marker so the reviewer LLM can see we tried. Not fatal.
+    : > "$_diff_path"
+  fi
+
+  # Build the context block (D-RIA deliverable #3)
+  local _block=""
+  _block="${_block}--- Reviewer inputs (assembled by mini-ork-execute) ---"$'\n'
+
+  if [ -s "$_run_dir/implementer-summary.json" ]; then
+    _block="${_block}"$'\n'"# implementer-summary.json"$'\n'
+    _block="${_block}$(cat "$_run_dir/implementer-summary.json")"$'\n'
+  else
+    _block="${_block}"$'\n'"# implementer-summary.json"$'\n'
+    _block="${_block}(not available)"$'\n'
+  fi
+
+  for _vstem in typecheck test; do
+    local _vfile="$_run_dir/verifier_${_vstem}.json"
+    if [ -s "$_vfile" ]; then
+      _block="${_block}"$'\n'"# verifier_${_vstem}.json"$'\n'
+      _block="${_block}$(cat "$_vfile")"$'\n'
+    else
+      _block="${_block}"$'\n'"# verifier_${_vstem}.json"$'\n'
+      _block="${_block}(not available)"$'\n'
+    fi
+  done
+
+  _block="${_block}"$'\n'"# review-diff.patch"$'\n'
+  if [ -s "$_diff_path" ]; then
+    _block="${_block}$(cat "$_diff_path")"$'\n'
+  else
+    _block="${_block}(no diff)"$'\n'
+  fi
+
+  _block="${_block}"$'\n'\
+"--- End reviewer inputs ---"$'\n'$'\n'
+  _block="${_block}"\
+"REVIEWER NOTE: The four inputs above are required for a real verdict. If any input is marked '(not available)' or '(no diff)', review what IS present. Only hard-abstain (verdict=needs_revision with reason 'inputs missing') when BOTH the diff and the summary are absent — that is the only genuine no-op case. A missing verifier verdict is a real failure signal, not an abstention excuse."$'\n'
+
+  printf '%s' "$_block"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --help|-h)          _usage; exit 0 ;;
@@ -2499,7 +2611,15 @@ PY
         PROMPT_CONTENT="${_prepend}Synthesize for: ${node_desc}${_learned_block}\n\nPlan:\n${PLAN_CONTENT}\n\nWrite your synthesis to: ${REVIEW_FILE}"
       else
         # Classic reviewer: verdict-JSON envelope expected.
-        PROMPT_CONTENT="${_prepend}Review the implementation for: ${node_desc}${_learned_block}\n\nPlan:\n${PLAN_CONTENT}\n\nRespond with JSON: {\"verdict\": \"pass|fail|needs_revision\", \"notes\": []}"
+        # D-RIA (2026-07-02): assemble + inject the four required reviewer
+        # inputs (implementer-summary.json, verifier_{typecheck,test}.json,
+        # review-diff.patch) into the prompt BEFORE the JSON envelope so the
+        # reviewer LLM actually receives them — previous behavior emitted the
+        # envelope with no inputs, so reviewers hard-abstained with "missing
+        # inputs" every time (a real verdict never happened → gate was theater).
+        local _reviewer_inputs
+        _reviewer_inputs="$(_mo_assemble_reviewer_inputs 2>/dev/null || true)"
+        PROMPT_CONTENT="${_prepend}Review the implementation for: ${node_desc}${_learned_block}\n\nPlan:\n${PLAN_CONTENT}\n\n${_reviewer_inputs}\nRespond with JSON: {\"verdict\": \"pass|fail|needs_revision\", \"notes\": []}"
       fi
       export MO_NODE_ID="$node_id"
       local _dispatch_marker="$RUN_DIR/.dispatch-marker-${node_id}"
@@ -2621,6 +2741,18 @@ PY
           else
             echo "  [fail] verifier_ref $node_verifier_ref failed → $_evidence_path" >&2
             MO_NODE_FINISH_REASON="error"
+          fi
+          # D-RIA (2026-07-02): persist verifier JSON to a stable path the
+          # reviewer reads. The reviewer prompt's "Inputs" table references
+          # `verifier_<name>.json` — without this persist, only the timestamped
+          # evidence log exists and the reviewer hard-abstains ("missing
+          # inputs"). Copy BEFORE the failure return so failures are visible
+          # too (a missing-verifier is a real signal, not an abstention excuse).
+          local _vpersist_dir="${MINI_ORK_RUN_DIR:-${RUN_DIR:-}}"
+          if [ -n "$_vpersist_dir" ] && [ -s "$_evidence_path" ]; then
+            cp "$_evidence_path" "$_vpersist_dir/verifier_${_vstem}.json" 2>/dev/null || true
+          fi
+          if [ "$MO_NODE_FINISH_REASON" = "error" ]; then
             return 1
           fi
         else

--- a/recipes/code-fix/prompts/reviewer.md
+++ b/recipes/code-fix/prompts/reviewer.md
@@ -24,10 +24,17 @@ Run `ls {{MO_CN_PREFETCH_DIR}}` — if any `*.md` files exist there, cat each on
 | Input | Source |
 |---|---|
 | `plan.json` | Planner output |
-| `implementer_summary.json` | Implementer output |
+| `implementer-summary.json` | Implementer output (`files_changed`, `rationale`, `confidence`, `scope_violations`, `skipped_steps`, `notes`) |
 | `verifier_typecheck.json` | typecheck.sh output (`{ verifier, pass, evidence_path, error_summary }`) |
 | `verifier_test.json` | test.sh output (same shape) |
-| `diff` | Full unified diff of all changed files |
+| `review-diff.patch` | Unified diff of the files listed in `implementer-summary.files_changed`, scoped to the implementer's worktree |
+
+> **Inputs are pre-assembled for you.** `bin/mini-ork-execute` writes these four
+> files into `$RUN_DIR` (under `implementer-summary.json`, `verifier_typecheck.json`,
+> `verifier_test.json`, `review-diff.patch`) and embeds their contents inline in
+> the prompt below as a "Reviewer inputs" block. Read THAT block — do not try
+> to `cat` paths of your own. If any input is missing, it is shown as
+> `(not available)`.
 
 ---
 
@@ -39,12 +46,12 @@ Issue APPROVE **only** when ALL of the following hold:
 
 1. `verifier_typecheck.json` → `pass: true`
 2. `verifier_test.json` → `pass: true`
-3. Every file in `implementer_summary.files_changed` is within the plan's
+3. Every file in `implementer-summary.files_changed` is within the plan's
    expected edit surface (no scope surprise).
 4. The diff matches the plan's `decomposition` — no unexplained hunks.
 5. No forbidden pattern is introduced (silent catch, default fallback, debug output,
    new global side effect, deleted file not in plan, reformatted unrelated lines).
-6. `implementer_summary.confidence` is ≥ 0.6 (below this, flag in `evidence`).
+6. `implementer-summary.confidence` is ≥ 0.6 (below this, flag in `evidence`).
 
 If any single condition fails: do NOT APPROVE.
 

--- a/tests/unit/test_reviewer_input_assembly.sh
+++ b/tests/unit/test_reviewer_input_assembly.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# tests/unit/test_reviewer_input_assembly.sh — D-RIA (2026-07-02).
+#
+# Covers the reviewer-input assembly step in bin/mini-ork-execute:
+#
+#   1. _mo_assemble_reviewer_inputs writes $RUN_DIR/review-diff.patch
+#      (non-empty, contains the implementer's diff) before the reviewer
+#      node is dispatched.
+#   2. The function returns a context block that embeds the implementer
+#      summary, BOTH verifier JSONs, and the diff inline.
+#   3. When the four artifacts are present, the assembled block does NOT
+#      take the "missing inputs" abstention path — the reviewer's hard-
+#      abstain instruction fires only when BOTH the diff and the summary
+#      are absent (genuine no-op).
+#   4. Missing inputs degrade to "(not available)" placeholders, not
+#      errors or empty blocks.
+#
+# Also performs two static structural checks on bin/mini-ork-execute:
+#
+#   A. The verifier handler persists verifier_<vstem>.json to $RUN_DIR
+#      (not just the timestamped evidence log).
+#   B. The reviewer handler (classic path) invokes _mo_assemble_reviewer_inputs
+#      and embeds the block in PROMPT_CONTENT before the JSON envelope.
+#
+# Filename ends in .sh so pytest's default discovery skips it.
+# Run with: bash tests/unit/test_reviewer_input_assembly.sh
+set -uo pipefail
+
+MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+export MINI_ORK_ROOT
+EXECUTOR="$MINI_ORK_ROOT/bin/mini-ork-execute"
+PROMPT="$MINI_ORK_ROOT/recipes/code-fix/prompts/reviewer.md"
+
+PASS=0; FAIL=0; SKIP=0
+_ok()   { echo "  [OK]   $*"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
+_skip() { echo "  [SKIP] $*"; SKIP=$((SKIP+1)); }
+
+WORKSPACE=""
+cleanup() {
+  if [ -n "$WORKSPACE" ] && [ -d "$WORKSPACE" ]; then
+    rm -rf "$WORKSPACE"
+  fi
+}
+
+seed_repo_with_change() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q -b main
+  git -C "$repo" config user.email "tester@local"
+  git -C "$repo" config user.name  "tester"
+  git -C "$repo" config commit.gpgsign false
+  printf 'tracked line one\ntracked line two\n' > "$repo/seed.md"
+  git -C "$repo" add seed.md
+  git -C "$repo" commit -q -m "initial"
+  # Modify seed.md so the diff is non-empty + reproducible.
+  printf 'tracked line one\ntracked line two\nimplementer-added-line three\n' > "$repo/seed.md"
+}
+
+seed_run_dir() {
+  local run_dir="$1" repo="$2"
+  rm -rf "$run_dir"
+  mkdir -p "$run_dir"
+  # Implementer summary (hyphen form — what the implementer actually writes).
+  python3 - "$run_dir" "$repo" <<'PY' 2>/dev/null
+import json, sys, os
+run_dir = sys.argv[1]
+repo    = sys.argv[2]
+summary = {
+    "files_changed": ["seed.md"],
+    "rationale":     "Test edit: append a third line to seed.md.",
+    "confidence":    0.8,
+    "scope_violations": [],
+    "skipped_steps":  [],
+    "notes":         "",
+    "worktree_path": repo,
+}
+with open(os.path.join(run_dir, "implementer-summary.json"), "w", encoding="utf-8") as f:
+    json.dump(summary, f, indent=2)
+# Verifier verdicts — pass:true for both (pretty-printed so the assembled
+# block matches what real verifier JSONs look like).
+for stem in ("typecheck", "test"):
+    payload = {
+        "verifier":      stem,
+        "pass":          True,
+        "evidence_path": "/tmp/{0}.log".format(stem),
+        "error_summary": "",
+    }
+    with open(os.path.join(run_dir, "verifier_" + stem + ".json"), "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+PY
+}
+
+echo ""
+echo "── unit: bin/mini-ork-execute _mo_assemble_reviewer_inputs ──"
+
+if [ ! -f "$EXECUTOR" ]; then
+  _skip "bin/mini-ork-execute missing"
+else
+  WORKSPACE="$(mktemp -d /tmp/mo-reviewer-input-XXXXXX)"
+  trap cleanup EXIT
+
+  if ! grep -q '^_mo_assemble_reviewer_inputs()' "$EXECUTOR"; then
+    _skip "_mo_assemble_reviewer_inputs not defined in $EXECUTOR — D-RIA edit missing"
+  else
+    set +e
+    export MINI_ORK_EXECUTE_SOURCE_ONLY=1
+    # shellcheck source=/dev/null
+    source "$EXECUTOR" >/dev/null 2>&1
+    if ! declare -f _mo_assemble_reviewer_inputs >/dev/null; then
+      _skip "_mo_assemble_reviewer_inputs not loaded by source-only mode"
+    else
+
+      # ── (a) positive: all 4 inputs present → block contains all of them ──
+      echo ""
+      echo "--- (a) positive: summary + both verifiers + diff present ---"
+      REPO_A="$WORKSPACE/a-repo"
+      RUN_A="$WORKSPACE/a-run"
+      seed_repo_with_change "$REPO_A"
+      seed_run_dir      "$RUN_A" "$REPO_A"
+
+      BLOCK_A="$(_mo_assemble_reviewer_inputs "$RUN_A" 2>/dev/null)"
+      DIFF_A="$RUN_A/review-diff.patch"
+
+      ok=1
+      if [ ! -s "$DIFF_A" ]; then
+        echo "    review-diff.patch missing or empty at $DIFF_A"
+        ok=0
+      fi
+      if ! grep -q '^--- a/seed.md' "$DIFF_A" 2>/dev/null \
+         && ! grep -q '^diff --git a/seed.md' "$DIFF_A" 2>/dev/null; then
+        echo "    review-diff.patch does not contain the seed.md diff"
+        echo "    first 200 bytes: $(head -c 200 "$DIFF_A")"
+        ok=0
+      fi
+      if ! grep -q 'implementer-added-line three' "$DIFF_A" 2>/dev/null; then
+        echo "    review-diff.patch missing the implementer-added line"
+        ok=0
+      fi
+      for needle in \
+          '--- Reviewer inputs (assembled by mini-ork-execute) ---' \
+          '# implementer-summary.json' \
+          'Test edit: append a third line to seed.md.' \
+          '"confidence": 0.8' \
+          '# verifier_typecheck.json' \
+          '"verifier": "typecheck"' \
+          '"pass": true' \
+          '# verifier_test.json' \
+          '"verifier": "test"' \
+          '# review-diff.patch' \
+          'implementer-added-line three' \
+          '--- End reviewer inputs ---' \
+          'REVIEWER NOTE'; do
+        if ! printf '%s' "$BLOCK_A" | grep -Fq -- "$needle"; then
+          echo "    assembled block missing needle: $needle"
+          ok=0
+        fi
+      done
+      # The hard-abstain-only branch is gated on BOTH diff+summary missing —
+      # here both are present, so the assembly must NOT trigger that branch.
+      # (No structural distinction in the block today, but we assert the block
+      # was actually populated.)
+      if [ -z "$BLOCK_A" ]; then
+        echo "    assembled block is empty"
+        ok=0
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(a) all four inputs assembled into context block + diff artifact non-empty"
+      else
+        _fail "(a) positive assembly"
+      fi
+
+      # ── (b) degraded: missing summary → "(not available)" placeholder, no crash ──
+      echo ""
+      echo "--- (b) degraded: summary absent → '(not available)' placeholder ---"
+      REPO_B="$WORKSPACE/b-repo"
+      RUN_B="$WORKSPACE/b-run"
+      seed_repo_with_change "$REPO_B"
+      mkdir -p "$RUN_B"
+      # Verifier verdicts present but no implementer-summary.json.
+      for stem in typecheck test; do
+        printf '{"verifier":"%s","pass":true}\n' "$stem" > "$RUN_B/verifier_${stem}.json"
+      done
+
+      BLOCK_B="$(_mo_assemble_reviewer_inputs "$RUN_B" 2>/dev/null)"
+      DIFF_B="$RUN_B/review-diff.patch"
+
+      ok=1
+      if ! printf '%s' "$BLOCK_B" | grep -Fq '# implementer-summary.json'; then
+        echo "    block missing summary header"
+        ok=0
+      fi
+      if ! printf '%s' "$BLOCK_B" | grep -Fq '(not available)'; then
+        echo "    block missing '(not available)' placeholder"
+        ok=0
+      fi
+      if [ ! -e "$DIFF_B" ]; then
+        echo "    review-diff.patch should still be written (empty is OK)"
+        ok=0
+      fi
+      # Both verifier verdicts still rendered.
+      for stem in typecheck test; do
+        if ! printf '%s' "$BLOCK_B" | grep -Fq "# verifier_${stem}.json"; then
+          echo "    block missing # verifier_${stem}.json header"
+          ok=0
+        fi
+      done
+      if [ "$ok" -eq 1 ]; then
+        _ok "(b) degraded: summary missing → '(not available)' + other inputs still present"
+      else
+        _fail "(b) degraded assembly"
+      fi
+
+      # ── (c) genuine no-op: BOTH diff and summary missing → empty diff is acceptable ──
+      echo ""
+      echo "--- (c) genuine no-op: BOTH diff + summary missing → empty inputs are tolerated ---"
+      RUN_C="$WORKSPACE/c-run"
+      mkdir -p "$RUN_C"
+      # Nothing at all in RUN_C.
+      BLOCK_C="$(_mo_assemble_reviewer_inputs "$RUN_C" 2>/dev/null)"
+      DIFF_C="$RUN_C/review-diff.patch"
+
+      ok=1
+      # Both diff and summary should report missing in the block.
+      if ! printf '%s' "$BLOCK_C" | grep -Fq '(no diff)'; then
+        echo "    block missing '(no diff)' marker when no worktree"
+        ok=0
+      fi
+      if ! printf '%s' "$BLOCK_C" | grep -Fq '(not available)'; then
+        echo "    block missing '(not available)' placeholder for summary"
+        ok=0
+      fi
+      if [ -z "$BLOCK_C" ]; then
+        echo "    block is empty even when nothing is available — must still emit instructions"
+        ok=0
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(c) genuine no-op: empty inputs tolerated + '(no diff)' marker written"
+      else
+        _fail "(c) no-op assembly"
+      fi
+
+      # ── (d) reviewer prompt contract reconciliation ──
+      echo ""
+      echo "--- (d) reviewer prompt references hyphen-form summary name ---"
+      ok=1
+      if [ ! -f "$PROMPT" ]; then
+        echo "    $PROMPT missing"
+        ok=0
+      else
+        # The reviewer prompt should now reference implementer-summary.json
+        # (matching what the implementer actually writes) — and explain that
+        # the inputs are pre-assembled into the prompt by the executor.
+        if ! grep -q 'implementer-summary.json' "$PROMPT"; then
+          echo "    reviewer prompt still references the wrong summary filename"
+          ok=0
+        fi
+        if grep -q 'implementer_summary\.json' "$PROMPT"; then
+          echo "    reviewer prompt still has the underscore-form reference"
+          ok=0
+        fi
+        if ! grep -q 'pre-assembled for you' "$PROMPT"; then
+          echo "    reviewer prompt missing the 'pre-assembled' hint to the LLM"
+          ok=0
+        fi
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(d) reviewer prompt name reconciliation"
+      else
+        _fail "(d) reviewer prompt reconciliation"
+      fi
+
+      # ── (e) static structural checks on the executor wiring ──
+      echo ""
+      echo "--- (e) static wiring checks on bin/mini-ork-execute ---"
+      ok=1
+      # E1. verifier-persist: cp of evidence → verifier_<vstem>.json
+      if ! grep -q 'verifier_${_vstem}.json' "$EXECUTOR"; then
+        echo "    executor no longer writes verifier_<vstem>.json — D-RIA persist edit missing"
+        ok=0
+      fi
+      # E2. reviewer handler calls the assembler before the JSON envelope.
+      if ! grep -q '_mo_assemble_reviewer_inputs' "$EXECUTOR"; then
+        echo "    executor no longer calls _mo_assemble_reviewer_inputs"
+        ok=0
+      fi
+      if ! grep -q 'D-RIA' "$EXECUTOR"; then
+        echo "    executor missing D-RIA marker comment (regression tripwire)"
+        ok=0
+      fi
+      # E3. The persistence must happen on BOTH pass and fail paths (the cp
+      #     is OUTSIDE the if/else). Guard against future refactors that
+      #     move it back inside the success branch.
+      _persist_line=$(grep -n 'verifier_${_vstem}.json' "$EXECUTOR" | head -1 | cut -d: -f1)
+      _fail_line=$(grep -n 'verifier_ref failed' "$EXECUTOR" | head -1 | cut -d: -f1)
+      if [ -n "$_persist_line" ] && [ -n "$_fail_line" ]; then
+        if [ "$_persist_line" -lt "$_fail_line" ]; then
+          : # persist appears BEFORE the failure log; that means it runs on
+          #   BOTH paths. Good.
+          :
+        else
+          echo "    verifier-persist line ($_persist_line) appears AFTER the failure log ($_fail_line) — may be inside the success branch only"
+          ok=0
+        fi
+      fi
+      if [ "$ok" -eq 1 ]; then
+        _ok "(e) executor wiring (verifier-persist + reviewer assemble + D-RIA marker)"
+      else
+        _fail "(e) executor wiring"
+      fi
+    fi
+  fi
+fi
+
+echo ""
+echo "── unit summary: PASS=$PASS FAIL=$FAIL SKIP=$SKIP ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem
The code-fix reviewer prompt is contracted to read `implementer-summary.json`, `verifier_typecheck.json`, `verifier_test.json` and a diff — but `bin/mini-ork-execute` never assembled or injected them. The reviewer LLM saw nothing and hard-abstained ("required inputs are missing") on **every** run, so the cross-family review gate was theater and every dispatch had to be self-reviewed.

## Fix
- `_mo_assemble_reviewer_inputs()`: writes `$RUN_DIR/review-diff.patch` (git diff scoped to `implementer-summary.files_changed`) + builds a "Reviewer inputs" block embedding the summary + both verifier verdicts + the diff (with `(not available)`/`(no diff)` markers), injected into the reviewer prompt.
- verifier node persists its verdict to `$RUN_DIR/verifier_<name>.json` (failures included).
- `reviewer.md`: reconcile `implementer_summary.json`→`implementer-summary.json`, `diff`→`review-diff.patch`; note inputs are pre-assembled.
- Hard-abstain only when **both** diff and summary are absent (genuine no-op).

## Tests
- `tests/unit/test_reviewer_input_assembly.sh` — 5/5.
- Regression: `test_publisher_commit`, `test_executor_runtime_routing`, `test_scaffold_tier` pass; `pytest` 146 passed / 2 skipped.

Self-modified via mini-ork `code-fix` run `run-1782969910-75998` (executor hand-reviewed since the run's own gates were the bug being fixed + a pre-existing `tsc`-on-non-TS false-fail).

_Note (follow-up, out of scope): the code-fix `typecheck.sh` verifier runs `tsc --noEmit` and false-fails on this bash/Python repo — tracked separately._