### PR TITLE
fix(dispatch): retry transient throttles on all lanes, not just GLM (#3)

### DIFF
--- a/lib/llm-dispatch.sh
+++ b/lib/llm-dispatch.sh
@@ -1123,6 +1123,23 @@ mo_llm_smoke() {
   return 1
 }
 
+# Generic lane-agnostic retry predicate. Composes the existing classifier
+# (capacity|network|stream|provider → retryable; quota|auth|config|request|safety → terminal)
+# with an attempt-bound guard. Returns 0 only when retryable category AND
+# attempt < max_attempts. Lane-specific overrides (GLM fair-usage) live in their
+# own predicates and must be evaluated first in the retry loop.
+_mo_llm_throttle_retryable() {
+  local model="${1:-}" message="${2:-}" rc="${3:-}" attempt="${4:-1}" max_attempts="${5:-1}"
+  [ -n "$model" ] || return 1
+  case "$attempt" in ''|*[!0-9]*) attempt=1 ;; esac
+  case "$max_attempts" in ''|*[!0-9]*) max_attempts=1 ;; esac
+  [ "$attempt" -lt "$max_attempts" ] || return 1
+  local _category
+  _category=$(_mo_llm_classify_error "$message" "$rc")
+  [ "$(_mo_llm_error_retryable "$_category")" = "1" ] || return 1
+  return 0
+}
+
 _mo_llm_glm_fair_usage_retryable() {
   local model="${1:-}" message="${2:-}" attempt="${3:-1}" max_attempts="${4:-1}"
   [ "$model" = "glm" ] || return 1
@@ -1132,9 +1149,27 @@ _mo_llm_glm_fair_usage_retryable() {
 }
 
 _mo_llm_glm_backoff_seconds() {
-  local attempt="${1:-1}" max_sleep="${MO_GLM_RETRY_MAX_SLEEP_S:-45}" base_s="${MO_GLM_RETRY_BASE_S:-5}"
+  local attempt="${1:-1}"
+  local max_sleep="${MO_GLM_RETRY_MAX_SLEEP_S:-${MO_DISPATCH_RETRY_MAX_SLEEP_S:-45}}"
+  local base_s="${MO_GLM_RETRY_BASE_S:-${MO_DISPATCH_RETRY_BASE_S:-5}}"
+  _mo_llm_backoff_seconds_raw "$attempt" "$max_sleep" "$base_s"
+}
+
+# Generic lane-agnostic backoff: exponential + jitter, capped at max_sleep,
+# floored at 1s. attempt clamped to [1,12] to avoid bash integer overflow
+# (`2**(attempt-1)` exceeds 64-bit past attempt≈31).
+_mo_llm_backoff_seconds() {
+  local attempt="${1:-1}" max_sleep="${MO_DISPATCH_RETRY_MAX_SLEEP_S:-45}" base_s="${MO_DISPATCH_RETRY_BASE_S:-5}"
+  _mo_llm_backoff_seconds_raw "$attempt" "$max_sleep" "$base_s"
+}
+
+_mo_llm_backoff_seconds_raw() {
+  local attempt="$1" max_sleep="$2" base_s="$3"
   case "$max_sleep" in ''|*[!0-9]*) max_sleep=45 ;; esac
   case "$base_s" in ''|*[!0-9]*) base_s=5 ;; esac
+  case "$attempt" in ''|*[!0-9]*) attempt=1 ;; esac
+  [ "$attempt" -lt 1 ] && attempt=1
+  [ "$attempt" -gt 12 ] && attempt=12
   local base=$((2 ** (attempt - 1) * base_s))
   local jitter=$((RANDOM % 4))
   local delay=$((base + jitter))
@@ -1285,11 +1320,11 @@ PY
     _mo_llm_write_duration_ms 0
     return 127
   }
-  local _dispatch_ok=0 _dispatch_rc=0 _attempt=1 _max_attempts=1
-  if [ "$model" = "glm" ]; then
-    _max_attempts="${MO_GLM_MAX_ATTEMPTS:-3}"
-    case "$_max_attempts" in ''|*[!0-9]*) _max_attempts=3 ;; esac
-    [ "$_max_attempts" -lt 1 ] && _max_attempts=1
+  local _dispatch_ok=0 _dispatch_rc=0 _attempt=1 _max_attempts="${MO_DISPATCH_MAX_ATTEMPTS:-3}"
+  case "$_max_attempts" in ''|*[!0-9]*) _max_attempts=3 ;; esac
+  [ "$_max_attempts" -lt 1 ] && _max_attempts=1
+  if [ "$model" = "glm" ] && [ -n "${MO_GLM_MAX_ATTEMPTS:-}" ]; then
+    case "$MO_GLM_MAX_ATTEMPTS" in ''|*[!0-9]*) ;; *) [ "$MO_GLM_MAX_ATTEMPTS" -gt "$_max_attempts" ] && _max_attempts="$MO_GLM_MAX_ATTEMPTS" ;; esac
   fi
   while :; do
     : > "$_err_file" 2>/dev/null || true
@@ -1311,10 +1346,22 @@ PY
         tail -c 1000 "$out_file" 2>/dev/null || true
       } | tail -c 2000
     )
-    if _mo_llm_glm_fair_usage_retryable "$model" "$_retry_probe" "$_attempt" "$_max_attempts"; then
-      local _sleep_s
-      _sleep_s=$(_mo_llm_glm_backoff_seconds "$_attempt")
-      echo "[llm_dispatch RETRY model=glm reason=fair_usage attempt=${_attempt}/${_max_attempts} sleep=${_sleep_s}s]" >&2
+    local _category
+    _category=$(_mo_llm_classify_error "$_retry_probe" "$_dispatch_rc")
+    # GLM fair-usage must be evaluated FIRST: its raw 429/1313 regex catches
+    # 'fair usage' messages that the generic classifier routes to 'quota'
+    # (= non-retryable). Falling through to the generic predicate would lose
+    # GLM retries and silently sink runs (the original failure mode).
+    if _mo_llm_glm_fair_usage_retryable "$model" "$_retry_probe" "$_attempt" "$_max_attempts" \
+       || _mo_llm_throttle_retryable "$model" "$_retry_probe" "$_dispatch_rc" "$_attempt" "$_max_attempts"; then
+      local _sleep_s _reason
+      if _mo_llm_glm_fair_usage_retryable "$model" "$_retry_probe" "$_attempt" "$_max_attempts"; then
+        _reason="fair_usage"
+      else
+        _reason="${_category:-unknown}"
+      fi
+      _sleep_s=$(_mo_llm_backoff_seconds "$_attempt")
+      echo "[llm_dispatch RETRY model=$model reason=${_reason} attempt=${_attempt}/${_max_attempts} sleep=${_sleep_s}s]" >&2
       sleep "$_sleep_s"
       _attempt=$((_attempt + 1))
       continue

--- a/tests/unit/test_dispatch_retry.sh
+++ b/tests/unit/test_dispatch_retry.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Unit tests for the lane-agnostic throttle retry primitive in lib/llm-dispatch.sh.
+# Verifies that:
+#   * Retryable categories (capacity|network|stream|provider) → retry
+#   * Terminal categories (quota|auth|request|safety) → fail fast
+#   * attempt-bound guard: never retry once attempt == max_attempts
+#   * Backoff stays within MO_DISPATCH_RETRY_MAX_SLEEP_S cap with floor ≥ 1
+#   * GLM fair-usage regression: GLM-specific regex still routes to retry
+#
+# Usage: bash tests/unit/test_dispatch_retry.sh
+# Exit 0 = all assertions pass.  Exit 1 = any assertion failed.
+set -u
+
+PASS=0; FAIL=0
+_ok()   { echo "[OK]   $*"; PASS=$((PASS+1)); }
+_fail() { echo "[FAIL] $*"; FAIL=$((FAIL+1)); }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINI_ORK_REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DISPATCH_LIB="$MINI_ORK_REPO/lib/llm-dispatch.sh"
+
+echo "=== test_dispatch_retry.sh ==="
+
+# ── Guard: skip if the lib is missing ─────────────────────────────────────────
+
+if [[ ! -f "$DISPATCH_LIB" ]]; then
+  echo "[FAIL] lib/llm-dispatch.sh not found at $DISPATCH_LIB"
+  echo ""
+  echo "=== Results: 0 OK  0 SKIP  1 FAIL ==="
+  exit 1
+fi
+
+# Helper: source the lib in a subshell, invoke a function with args, return
+# its exit code. Sourcing in a subshell keeps the parent shell pristine and
+# avoids side-effects on global state. The lib sets `set -euo pipefail` at
+# load time, so we disable errexit around the call — the function's own rc
+# is what we want to capture, and rc=1 is a valid test outcome (e.g. terminal
+# categories must fail-fast).
+_call_fn() {
+  local fn="$1"; shift
+  bash -c "source '$DISPATCH_LIB' >/dev/null 2>&1; set +e; $fn \"\$@\"; echo \"rc=\$?\"" "$fn" "$@"
+}
+
+# Helper: invoke _mo_llm_throttle_retryable and assert exit code equals expected
+_assert_throttle() {
+  local label="$1" expected_rc="$2" model="$3" message="$4" rc="$5" attempt="$6" max_attempts="$7"
+  local out actual_rc
+  out=$(_call_fn _mo_llm_throttle_retryable "$model" "$message" "$rc" "$attempt" "$max_attempts")
+  actual_rc="${out##*rc=}"
+  if [[ "$actual_rc" == "$expected_rc" ]]; then
+    _ok "$label"
+  else
+    _fail "$label — expected rc=$expected_rc, got rc=$actual_rc (out=$out)"
+  fi
+}
+
+# Helper: invoke _mo_llm_glm_fair_usage_retryable and assert exit code
+_assert_glm_retry() {
+  local label="$1" expected_rc="$2" model="$3" message="$4" attempt="$5" max_attempts="$6"
+  local out actual_rc
+  out=$(_call_fn _mo_llm_glm_fair_usage_retryable "$model" "$message" "$attempt" "$max_attempts")
+  actual_rc="${out##*rc=}"
+  if [[ "$actual_rc" == "$expected_rc" ]]; then
+    _ok "$label"
+  else
+    _fail "$label — expected rc=$expected_rc, got rc=$actual_rc (out=$out)"
+  fi
+}
+
+echo ""
+echo "--- retryable categories retry under attempt<max ---"
+
+# (a) kimi '503 overloaded' — classifier routes 503+overload → capacity → retryable
+_assert_throttle "kimi 503 overloaded rc=1 attempt=1 max=3 → retry (rc=0)" \
+  0 kimi "503 overloaded" 1 1 3
+# (b) kimi '429 capacity exceeded' — classifier routes 429+capacity → capacity → retryable
+_assert_throttle "kimi 429 capacity exceeded rc=1 attempt=1 max=3 → retry (rc=0)" \
+  0 kimi "429 capacity exceeded" 1 1 3
+# (c) kimi '502 bad gateway' — classifier routes 502 → provider → retryable
+_assert_throttle "kimi 502 bad gateway rc=1 attempt=1 max=3 → retry (rc=0)" \
+  0 kimi "502 bad gateway" 1 1 3
+# (extra coverage) network category
+_assert_throttle "kimi connection refused rc=1 attempt=1 max=3 → retry (rc=0)" \
+  0 kimi "connection refused upstream" 1 1 3
+# (extra coverage) stream category
+_assert_throttle "kimi partial stream rc=1 attempt=1 max=3 → retry (rc=0)" \
+  0 kimi "unexpected eof: partial stream" 1 1 3
+
+echo ""
+echo "--- terminal categories fail fast ---"
+
+# (d) kimi '429 insufficient credits' — 429+billing/credits → quota → non-retryable
+_assert_throttle "kimi 429 insufficient credits rc=1 attempt=1 max=3 → fail fast (rc=1)" \
+  1 kimi "429 insufficient credits" 1 1 3
+# (e) kimi '401 unauthorized' — 401 → auth → non-retryable
+_assert_throttle "kimi 401 unauthorized rc=1 attempt=1 max=3 → fail fast (rc=1)" \
+  1 kimi "401 unauthorized" 1 1 3
+# (f) kimi '400 invalid request' — 400 → request → non-retryable
+_assert_throttle "kimi 400 invalid request rc=1 attempt=1 max=3 → fail fast (rc=1)" \
+  1 kimi "400 invalid request: bad prompt" 1 1 3
+# (extra) safety category
+_assert_throttle "kimi content filter rc=1 attempt=1 max=3 → fail fast (rc=1)" \
+  1 kimi "content filter triggered" 1 1 3
+
+echo ""
+echo "--- attempt-bound guard ---"
+
+# (g) attempt == max → never retry even on retryable category
+_assert_throttle "kimi 503 overloaded attempt=3 max=3 → no retry (rc=1)" \
+  1 kimi "503 overloaded" 1 3 3
+_assert_throttle "kimi 503 overloaded attempt=5 max=3 → no retry (rc=1)" \
+  1 kimi "503 overloaded" 1 5 3
+# (extra) attempt=2 max=3 still retries
+_assert_throttle "kimi 503 overloaded attempt=2 max=3 → retry (rc=0)" \
+  0 kimi "503 overloaded" 1 2 3
+# (extra) empty model → no retry (defensive)
+_assert_throttle "empty model 503 overloaded attempt=1 max=3 → no retry (rc=1)" \
+  1 "" "503 overloaded" 1 1 3
+
+echo ""
+echo "--- backoff cap + floor ---"
+
+# (h) backoff for attempt=1..5 with low cap stays in range
+export MO_DISPATCH_RETRY_MAX_SLEEP_S=3
+export MO_DISPATCH_RETRY_BASE_S=1
+for n in 1 2 3 4 5; do
+  out=$(_call_fn _mo_llm_backoff_seconds "$n")
+  delay="${out%%rc=*}"
+  delay="${delay%$'\n'}"
+  if [[ "$delay" =~ ^[0-9]+$ ]] && [ "$delay" -ge 1 ] && [ "$delay" -le 3 ]; then
+    _ok "backoff attempt=$n → ${delay}s (within [1,3])"
+  else
+    _fail "backoff attempt=$n → ${delay}s (expected integer in [1,3])"
+  fi
+done
+unset MO_DISPATCH_RETRY_MAX_SLEEP_S MO_DISPATCH_RETRY_BASE_S
+
+echo ""
+echo "--- GLM fair-usage regression ---"
+
+# (i) regression: GLM 1313 'fair usage' still routes to retry
+_assert_glm_retry "glm 1313 fair usage attempt=1 max=3 → retry (rc=0)" \
+  0 glm "1313 fair usage policy" 1 3
+# GLM with a non-fair-usage message → no retry
+_assert_glm_retry "glm plain 503 attempt=1 max=3 → no retry via GLM predicate (rc=1)" \
+  1 glm "503 overloaded" 1 3
+
+echo ""
+echo "=== Results: $PASS OK  $FAIL FAIL ==="
+(( FAIL > 0 )) && exit 1 || exit 0


### PR DESCRIPTION
## Problem
`llm_dispatch()` had exponential-backoff retry, but **only for GLM fair-usage**. Any other lane (kimi/minimax/codex/opus/sonnet) hitting a transient throttle — 429 capacity, 503, overloaded, provider 5xx, dropped stream — got zero retry: one transient error killed the node, wrote a 0-byte artifact, and cascade-skipped dependents. Silently sank runs (memory: "glm 429 Fair Usage silently sinks runs" — generalized).

## Fix (`lib/llm-dispatch.sh`)
- `_mo_llm_throttle_retryable()` — lane-agnostic predicate reusing the existing `_mo_llm_classify_error` + `_mo_llm_error_retryable` (capacity|network|stream|provider → retry; quota|auth|config|request|safety → fail fast) + attempt-bound guard.
- Generic `_mo_llm_backoff_seconds` + shared `_mo_llm_backoff_seconds_raw` core (attempt clamped [1,12] to avoid `2**n` overflow); GLM backoff delegates to it.
- `MO_DISPATCH_MAX_ATTEMPTS` (default 3) for all lanes; GLM still honors `MO_GLM_MAX_ATTEMPTS` (max of the two).
- Retry loop evaluates GLM-fair-usage **first** (its raw 429/1313 regex catches wording the generic classifier wouldn't treat as retryable), then the generic predicate.

## Researcher-safety
Bounded: **3 attempts, 45s per-sleep cap**, terminal errors fail fast, no cross-run/global cooldown — cannot slow unrelated runs.

## Tests
- `tests/unit/test_dispatch_retry.sh` — 20/20 (terminal fail-fast, attempt-bound, backoff cap+floor, GLM regression).
- `pytest` 146 passed / 2 skipped; `bash -n` clean.

Self-modified via mini-ork `code-fix` run `run-1782972199-98216`. The reviewer (opus_lens) — now fed #2's assembled inputs — returned a real evidence-grounded verdict and correctly escalated only on the pre-existing `tsc`-on-non-TS typecheck false-fail (tracked separately).