### PR TITLE
fix(verifier): run typecheck only when the project configured it

### DIFF
--- a/recipes/code-fix/verifiers/typecheck.sh
+++ b/recipes/code-fix/verifiers/typecheck.sh
@@ -20,6 +20,40 @@ LOG_PATH="${LOG_DIR}/verifier_typecheck.log"
 
 # ── Detect command ─────────────────────────────────────────────────────────────
 
+# Returns 0 if the cwd looks like a TypeScript project, else 1.
+# Marker rules: tsconfig.json present, OR package.json declares typescript
+# (dep/devDep), OR package.json has a typecheck-style script.
+# A globally-installed tsc is NOT a marker — gate it on real project intent
+# (regression: bash/Python repos with tsc on PATH short-circuited on bare tsc).
+_has_ts_marker() {
+  if [ -f "tsconfig.json" ]; then return 0; fi
+  if [ -f "package.json" ] && command -v jq &>/dev/null; then
+    if jq -e '.dependencies.typescript // .devDependencies.typescript // empty' package.json &>/dev/null; then
+      return 0
+    fi
+    local scripts
+    scripts=$(jq -r '.scripts // {} | keys[]' package.json 2>/dev/null || true)
+    for candidate in typecheck type-check tsc check; do
+      if echo "${scripts}" | grep -qx "${candidate}"; then return 0; fi
+    done
+  fi
+  return 1
+}
+
+# Returns 0 if the cwd has a CONFIGURED mypy setup, else 1.
+# Marker rules: mypy.ini present, OR setup.cfg with a [mypy] section, OR
+# pyproject.toml with a [tool.mypy] section. A bare pyproject.toml is NOT a
+# marker — nearly every Python repo has one, and `mypy .` on an unconfigured
+# tree scans fixtures/vendored code and false-fails (regression: this bash repo
+# has a mini_ork/ package + pyproject.toml but no mypy config, so `mypy .`
+# tripped on duplicate fixture modules).
+_has_mypy_marker() {
+  if [ -f "mypy.ini" ]; then return 0; fi
+  if [ -f "setup.cfg" ] && grep -q '^\[mypy\]' setup.cfg 2>/dev/null; then return 0; fi
+  if [ -f "pyproject.toml" ] && grep -q '^\[tool\.mypy\]' pyproject.toml 2>/dev/null; then return 0; fi
+  return 1
+}
+
 detect_typecheck_cmd() {
   # Explicit override wins.
   if [ -n "${MINI_ORK_TYPECHECK_CMD:-}" ]; then
@@ -41,12 +75,14 @@ detect_typecheck_cmd() {
     fi
   fi
 
-  # Bare tsc
-  if command -v tsc &>/dev/null; then echo "tsc --noEmit"; return; fi
-  if [ -x "./node_modules/.bin/tsc" ]; then echo "./node_modules/.bin/tsc --noEmit"; return; fi
+  # TypeScript project marker required before we trust a tsc binary.
+  if _has_ts_marker; then
+    if command -v tsc &>/dev/null; then echo "tsc --noEmit"; return; fi
+    if [ -x "./node_modules/.bin/tsc" ]; then echo "./node_modules/.bin/tsc --noEmit"; return; fi
+  fi
 
-  # Python mypy
-  if command -v mypy &>/dev/null && [ -f "mypy.ini" -o -f "setup.cfg" -o -f "pyproject.toml" ]; then
+  # Python mypy — require a configured mypy, not just any pyproject.toml.
+  if command -v mypy &>/dev/null && _has_mypy_marker; then
     echo "mypy ."; return
   fi
 

--- a/tests/unit/test_typecheck_detect.sh
+++ b/tests/unit/test_typecheck_detect.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# tests/unit/test_typecheck_detect.sh — gate tsc on a project marker, not global presence.
+#
+# Regression: on bash/Python repos with a globally-installed tsc, the verifier
+# short-circuited on bare `tsc --noEmit`, printing the --help banner and exiting
+# non-zero → verifier reported pass:false on every code_fix run. See kickoff
+# kickoffs/issue-fixes/typecheck-detect-project-marker.md.
+#
+# Usage: bash tests/unit/test_typecheck_detect.sh
+set -uo pipefail
+
+MINI_ORK_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TYPECHECK="$MINI_ORK_ROOT/recipes/code-fix/verifiers/typecheck.sh"
+
+PASS=0; FAIL=0
+_ok()   { echo "  [OK]   $*"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
+
+# Build a fake tsc in $bindir that records its invocation to $sentinel and exits 0.
+_make_fake_tsc() {
+  local bindir="$1" sentinel="$2"
+  mkdir -p "$bindir"
+  cat > "$bindir/tsc" <<EOF
+#!/usr/bin/env bash
+echo "fake-tsc-invoked: \$*" >> "$sentinel"
+exit 0
+EOF
+  chmod +x "$bindir/tsc"
+}
+
+# Build a fake mypy that records its invocation to $sentinel and exits 0.
+_make_fake_mypy() {
+  local bindir="$1" sentinel="$2"
+  mkdir -p "$bindir"
+  cat > "$bindir/mypy" <<EOF
+#!/usr/bin/env bash
+echo "fake-mypy-invoked: \$*" >> "$sentinel"
+exit 0
+EOF
+  chmod +x "$bindir/mypy"
+}
+
+# Minimal PATH: fake bin + system bins. Strips mypy/cargo/go/pyenv shims so the
+# test is hermetic — only what we set up in the tmp cwd is visible to the
+# verifier's command -v probes.
+MIN_PATH="/usr/bin:/bin"
+
+echo "== typecheck.sh: project-marker gating =="
+
+# (a) empty tmp + fake tsc on PATH → skip(pass), tsc NOT invoked
+T1=$(mktemp -d)
+SENT1="$T1/sentinel"
+B1="$T1/bin"
+_make_fake_tsc "$B1" "$SENT1"
+OUT1=$(cd "$T1" && PATH="$B1:$MIN_PATH" MINI_ORK_HOME="$T1/.mini-ork" \
+       MINI_ORK_RUN_ID="t1-$$" bash "$TYPECHECK" 2>&1) || true
+RC1=$?
+if [ "$RC1" -eq 0 ] \
+   && echo "$OUT1" | grep -q '"pass":true' \
+   && echo "$OUT1" | grep -q 'no typecheck tool detected' \
+   && [ ! -f "$SENT1" ]; then
+  _ok "(a) empty tmp + fake tsc → skip(pass), tsc NOT invoked"
+else
+  _fail "(a): rc=$RC1, sent_exists=$([ -f "$SENT1" ] && echo y || echo n), out=$OUT1"
+fi
+rm -rf "$T1"
+
+# (b) tsconfig.json + fake tsc on PATH → tsc selected and invoked
+T2=$(mktemp -d)
+SENT2="$T2/sentinel"
+echo '{}' > "$T2/tsconfig.json"
+B2="$T2/bin"
+_make_fake_tsc "$B2" "$SENT2"
+OUT2=$(cd "$T2" && PATH="$B2:$MIN_PATH" MINI_ORK_HOME="$T2/.mini-ork" \
+       MINI_ORK_RUN_ID="t2-$$" bash "$TYPECHECK" 2>&1) || true
+RC2=$?
+if [ "$RC2" -eq 0 ] \
+   && [ -f "$SENT2" ] \
+   && grep -q "fake-tsc-invoked" "$SENT2"; then
+  _ok "(b) tsconfig.json + fake tsc → tsc selected and invoked"
+else
+  _fail "(b): rc=$RC2, sent_exists=$([ -f "$SENT2" ] && echo y || echo n), sent=$(cat $SENT2 2>/dev/null), out=$OUT2"
+fi
+rm -rf "$T2"
+
+# (c) MINI_ORK_TYPECHECK_CMD override wins regardless of markers
+T3=$(mktemp -d)
+SENT3="$T3/sentinel"
+B3="$T3/bin"
+_make_fake_tsc "$B3" "$SENT3"
+# Override writes to sentinel via shell expansion inside the verifier's eval.
+OUT3=$(cd "$T3" && PATH="$B3:$MIN_PATH" MINI_ORK_HOME="$T3/.mini-ork" \
+       MINI_ORK_RUN_ID="t3-$$" \
+       MINI_ORK_TYPECHECK_CMD="echo override-ran > $SENT3" \
+       bash "$TYPECHECK" 2>&1) || true
+RC3=$?
+if [ "$RC3" -eq 0 ] \
+   && [ -f "$SENT3" ] \
+   && grep -q "override-ran" "$SENT3"; then
+  _ok "(c) override → MINI_ORK_TYPECHECK_CMD runs regardless of markers"
+else
+  _fail "(c): rc=$RC3, sent_exists=$([ -f "$SENT3" ] && echo y || echo n), sent=$(cat $SENT3 2>/dev/null), out=$OUT3"
+fi
+rm -rf "$T3"
+
+# (d) pyproject.toml only + fake tsc on PATH (mypy absent via minimal PATH) → skip(pass), not tsc
+T4=$(mktemp -d)
+SENT4="$T4/sentinel"
+printf '[project]\nname = "x"\n' > "$T4/pyproject.toml"
+B4="$T4/bin"
+_make_fake_tsc "$B4" "$SENT4"
+OUT4=$(cd "$T4" && PATH="$B4:$MIN_PATH" MINI_ORK_HOME="$T4/.mini-ork" \
+       MINI_ORK_RUN_ID="t4-$$" bash "$TYPECHECK" 2>&1) || true
+RC4=$?
+if [ "$RC4" -eq 0 ] \
+   && echo "$OUT4" | grep -q '"pass":true' \
+   && [ ! -f "$SENT4" ]; then
+  _ok "(d) pyproject.toml + fake tsc (mypy absent) → skip(pass), tsc NOT invoked"
+else
+  _fail "(d): rc=$RC4, sent_exists=$([ -f "$SENT4" ] && echo y || echo n), out=$OUT4"
+fi
+rm -rf "$T4"
+
+# (e) pyproject.toml WITHOUT [tool.mypy] + fake mypy on PATH → skip(pass), mypy NOT invoked
+T5=$(mktemp -d)
+SENT5="$T5/sentinel"
+printf '[project]\nname = "x"\n' > "$T5/pyproject.toml"
+B5="$T5/bin"
+_make_fake_mypy "$B5" "$SENT5"
+OUT5=$(cd "$T5" && PATH="$B5:$MIN_PATH" MINI_ORK_HOME="$T5/.mini-ork" \
+       MINI_ORK_RUN_ID="t5-$$" bash "$TYPECHECK" 2>&1) || true
+RC5=$?
+if [ "$RC5" -eq 0 ] \
+   && echo "$OUT5" | grep -q '"pass":true' \
+   && [ ! -f "$SENT5" ]; then
+  _ok "(e) pyproject.toml w/o [tool.mypy] + fake mypy → skip(pass), mypy NOT invoked"
+else
+  _fail "(e): rc=$RC5, sent_exists=$([ -f "$SENT5" ] && echo y || echo n), out=$OUT5"
+fi
+rm -rf "$T5"
+
+# (f) pyproject.toml WITH [tool.mypy] + fake mypy → mypy selected and invoked
+T6=$(mktemp -d)
+SENT6="$T6/sentinel"
+printf '[project]\nname = "x"\n\n[tool.mypy]\nstrict = true\n' > "$T6/pyproject.toml"
+B6="$T6/bin"
+_make_fake_mypy "$B6" "$SENT6"
+OUT6=$(cd "$T6" && PATH="$B6:$MIN_PATH" MINI_ORK_HOME="$T6/.mini-ork" \
+       MINI_ORK_RUN_ID="t6-$$" bash "$TYPECHECK" 2>&1) || true
+RC6=$?
+if [ "$RC6" -eq 0 ] \
+   && [ -f "$SENT6" ] \
+   && grep -q "fake-mypy-invoked" "$SENT6"; then
+  _ok "(f) pyproject.toml w/ [tool.mypy] + fake mypy → mypy selected and invoked"
+else
+  _fail "(f): rc=$RC6, sent_exists=$([ -f "$SENT6" ] && echo y || echo n), sent=$(cat $SENT6 2>/dev/null), out=$OUT6"
+fi
+rm -rf "$T6"
+
+echo
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem (surfaced by code-fix runs #2, #3 and this run)
`recipes/code-fix/verifiers/typecheck.sh` `detect_typecheck_cmd()` returned `tsc --noEmit` whenever `tsc` was **installed globally** — no `tsconfig.json`/TS-marker check. On this bash/Python repo tsc short-circuited before mypy, ran with no inputs, printed its `--help` banner, exited non-zero → `pass:false` on **every** code-fix run, forcing the reviewer to ESCALATE on a bogus red.

Fixing tsc exposed the next layer: the mypy branch fired on **any** `pyproject.toml` (present in ~every Python repo), so `mypy .` scanned test fixtures and false-failed (`Duplicate module named 'tally'` under `docs/research/experiments/fixtures/`).

## Fix
A type-checker now runs only when the project actually **configured** it:
- `_has_ts_marker` — `tsconfig.json`, or `package.json` typescript dep / typecheck script. Gates both tsc branches.
- `_has_mypy_marker` — `mypy.ini`, `setup.cfg [mypy]`, or `pyproject.toml [tool.mypy]`. Gates the mypy branch (bare `pyproject.toml` no longer sufficient).
- No marker → skip(pass); override `MINI_ORK_TYPECHECK_CMD` still wins.

This repo (no `tsconfig`, no `[tool.mypy]`) now correctly **skips** typecheck → code-fix reviewers stop escalating on the phantom red.

## Tests
- `tests/unit/test_typecheck_detect.sh` — 6/6 (tsc gate, override precedence, mypy marker on/off, hermetic fake tsc/mypy on PATH).
- Self-smoke: `MINI_ORK_RUN_ID=smoke bash recipes/code-fix/verifiers/typecheck.sh` exits 0 on this repo.
- `pytest` 146 passed / 2 skipped; `bash -n` clean.

tsc gate dispatched via mini-ork `code-fix` run `run-1782973617-36466`; the mypy-marker gate + test cases (e)(f) were added at the human review gate.