### PR TITLE
feat(db): checksummed, transactional migration runner (P1) + design

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Cost guard: `MO_DAILY_BUDGET_USD` ($50 default) is enforced inside the dispatche
 
 Shipped totals (regenerable via `scripts/readme-claim-check.sh`):
 
-- **88 framework primitives** in `lib/` (lifecycle + memory + gates + agent registry + runtime + observability + the 4 calibration-list gates + HarnessBridge stack + live control plane + per-run config isolation).
+- **89 framework primitives** in `lib/` (lifecycle + memory + gates + agent registry + runtime + observability + the 4 calibration-list gates + HarnessBridge stack + live control plane + per-run config isolation + `lib/migrate.sh` checksummed transactional DB migrations).
 - **31 user-facing `bin/mini-ork` entrypoints** (the 6-stage loop + `eval` / `improve` / `promote` / `metrics` / `spawn` / `epics` / `scheduler` / `review` / `bugs` / `lifetime` / `coord` / `usage-report` / `watchdog` / `conductor` and friends).
 - **47 schema migrations** under `db/migrations/` (memory namespaces, execution traces, gradients, panel topology, recursive orchestration, llm_calls, lifecycle widening, error taxonomy, heartbeat, agent performance, epic + bug + pre-push review tables, HarnessBridge grounded-rejections).
 - **28 recipes** shipped — see [Recipes table](#recipes) above.

--- a/db/init.sh
+++ b/db/init.sh
@@ -68,65 +68,29 @@ ensure_column() {
 ensure_column "execution_traces" "process_reward" "REAL DEFAULT NULL"
 ensure_column "agent_performance_memory" "relative_advantage" "REAL NOT NULL DEFAULT 0.0"
 
-# Apply each migration in lex order
-for migration_file in $(ls "$MIGRATIONS_DIR"/*.sql | sort); do
-  filename="$(basename "$migration_file")"
+# Apply migrations + views via the checksummed, transactional runner
+# (lib/migrate.sh): real sha256 checksums, one transaction per migration, and
+# in-place rehash of the old placeholder checksums. See
+# docs/_meta/migration-and-update-design.md.
+# shellcheck source=../lib/migrate.sh
+. "$SCRIPT_DIR/../lib/migrate.sh"
+export MINI_ORK_DB="$DB"
+export MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+mo_migrate_ensure_table "$DB"
 
-  # Check if already applied (schema_migrations table may not exist yet on first run)
-  already_applied=$(sqlite3 "$DB" \
-    "SELECT COUNT(*) FROM schema_migrations WHERE filename='${filename}';" 2>/dev/null || echo "0")
+# Legacy recovery (preserved from the old inline runner): a partial/manual apply
+# can leave llm_calls.session_id present without 0018 marked. Mark it so the
+# runner won't try to re-ADD the column (which would fail). Only fires when the
+# column already exists; a fresh DB has no llm_calls table yet, so 0018 applies
+# normally.
+if sqlite3 "$DB" "PRAGMA table_info(llm_calls);" 2>/dev/null | awk -F'|' '$2=="session_id"{f=1} END{exit f?0:1}'; then
+  sqlite3 "$DB" "CREATE INDEX IF NOT EXISTS idx_llm_calls_session ON llm_calls(session_id) WHERE session_id IS NOT NULL;" 2>/dev/null || true
+  sqlite3 "$DB" "INSERT OR IGNORE INTO schema_migrations(filename, applied_at, checksum) VALUES ('0018_llm_calls_session_id.sql', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'recovered-existing-session-id');" 2>/dev/null || true
+fi
 
-  if [ "$already_applied" = "1" ]; then
-    echo "  [skip] $filename — already applied"
-  else
-    echo "  [apply] $filename"
-    if sqlite3 "$DB" < "$migration_file"; then
-      sqlite3 "$DB" \
-        "INSERT OR IGNORE INTO schema_migrations(filename, applied_at, checksum) VALUES ('$filename', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'runner-applied');"
-      echo "  [ok]   $filename"
-    elif [ "$filename" = "0018_llm_calls_session_id.sql" ] && \
-         sqlite3 "$DB" "PRAGMA table_info(llm_calls);" 2>/dev/null | awk -F'|' '$2=="session_id"{found=1} END{exit found?0:1}'; then
-      # Older DBs may already have the column from a partial/manual apply but
-      # lack the schema_migrations marker. Finish the idempotent parts and
-      # mark the migration so `mini-ork init` remains safe to re-run.
-      sqlite3 "$DB" "
-        CREATE INDEX IF NOT EXISTS idx_llm_calls_session
-          ON llm_calls(session_id) WHERE session_id IS NOT NULL;
-        UPDATE llm_calls
-           SET session_id = json_extract(metadata_json, '$.session_id')
-         WHERE session_id IS NULL
-           AND metadata_json IS NOT NULL;
-        INSERT OR IGNORE INTO schema_migrations(filename, applied_at, checksum)
-        VALUES ('$filename', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'recovered-existing-session-id');
-      "
-      echo "  [ok]   $filename — recovered existing session_id column"
-    else
-      exit 1
-    fi
-  fi
-done
-
-# Apply views in lex order, idempotently.
-# Views use CREATE VIEW IF NOT EXISTS so re-applying is safe.
-# We also track them in schema_migrations so `mini-ork doctor` can
-# report which view files have been applied.
+mo_migrate_apply "$MIGRATIONS_DIR" || exit 1
 if [ -d "$VIEWS_DIR" ]; then
-  for view_file in $(ls "$VIEWS_DIR"/*.sql 2>/dev/null | sort); do
-    viewfilename="$(basename "$view_file")"
-
-    already_applied=$(sqlite3 "$DB" \
-      "SELECT COUNT(*) FROM schema_migrations WHERE filename='${viewfilename}';" 2>/dev/null || echo "0")
-
-    if [ "$already_applied" = "1" ]; then
-      echo "  [skip] $viewfilename — already applied"
-    else
-      echo "  [apply view] $viewfilename"
-      sqlite3 "$DB" < "$view_file"
-      sqlite3 "$DB" \
-        "INSERT OR IGNORE INTO schema_migrations(filename, applied_at, checksum) VALUES ('${viewfilename}', strftime('%Y-%m-%dT%H:%M:%fZ','now'), 'view-v1');"
-      echo "  [ok]   $viewfilename"
-    fi
-  done
+  mo_migrate_apply "$VIEWS_DIR" || exit 1
 else
   echo "  [info] No views dir found at $VIEWS_DIR — skipping"
 fi

--- a/docs/_meta/migration-and-update-design.md
+++ b/docs/_meta/migration-and-update-design.md
@@ -1,0 +1,133 @@
+# Design: robust DB migrations + safe update mechanism
+
+> Status: proposed, 2026-07-02. Goal: let a consuming repo update mini-ork to
+> the latest version **without ever overriding its `state.db`** — with integrity
+> checks, transactional safety, and code re-vendoring built in.
+
+## What exists today (and why it still forces DB wipes)
+
+mini-ork already has a migration system, so this is a *hardening* job, not a
+greenfield one:
+
+- `db/migrations/NNNN_*.sql` (46 files), applied in lex order by `db/init.sh`.
+- A `schema_migrations(filename, applied_at, checksum)` table (created in
+  `0001_core.sql`) tracks what's applied; `init.sh` skips already-applied files.
+- `bin/mini-ork-update` applies pending migrations to a project's `state.db`,
+  reports config drift, and supports `--dry-run` / `--pull`.
+
+**The real gaps that make people wipe the DB:**
+
+1. **Placeholder checksums.** `init.sh` stores `checksum='runner-applied'`, not a
+   hash. There is *no* integrity check — a shipped migration edited after release
+   goes undetected, and drift can't be diagnosed.
+2. **No code re-vendor for vendored consumers.** `mini-ork-update --pull` only
+   works when `MINI_ORK_ROOT` is a git checkout. A repo that *vendored* mini-ork
+   into `.mini-ork/` (the normal case — e.g. the researcher fleet) has no
+   supported way to pull the new **framework code**, so people hand-rsync or wipe.
+3. **No backup / no transaction.** A migration that fails midway leaves a
+   half-migrated `state.db` with no rollback → the fastest "fix" is to delete it.
+4. **Idempotency hacks.** `ensure_column(...)` + the `0018` special-case in
+   `init.sh` are band-aids for migrations that weren't cleanly re-runnable —
+   fragile, and they run *outside* the tracked migration flow.
+5. **Conflated concerns + weak CLI.** `init.sh` mixes WAL setup, column repair,
+   migrations, and views; `mini-ork-update` isn't wired as `mini-ork update` in
+   the main dispatch table.
+
+## Design principles
+
+- **Never touch data on update.** `state.db`, `config/secrets.local.sh`,
+  `config/agents.yaml`, `runs/` are sacred. Update only replaces framework code
+  and applies additive migrations.
+- **Apply each migration exactly once, transactionally, and verify integrity.**
+- **Fail safe.** Back up before migrating; roll back on any failure.
+- **Same path for fresh install, git checkout, and vendored consumer.**
+
+## Migration layer (`lib/migrate.sh` — extracted from `init.sh`)
+
+A dedicated module, callable as `mini-ork migrate [--status|--dry-run|--verify]`.
+
+**`schema_migrations` v2** (additive migration; keep `filename` PK):
+```
+filename TEXT PRIMARY KEY
+applied_at TEXT NOT NULL
+checksum TEXT NOT NULL          -- real: sha256 of the file at apply time
+mini_ork_version TEXT           -- version that applied it
+duration_ms INTEGER
+```
+
+**Apply algorithm (`mini-ork migrate`):**
+1. Ensure `schema_migrations` exists (bootstrap).
+2. For each `db/migrations/*.sql` in lex order:
+   - Compute `sha256(file)`.
+   - If already applied: **verify** the stored checksum matches. Mismatch →
+     hard error ("migration NNNN changed after being applied") unless
+     `MO_MIGRATE_ALLOW_DRIFT=1`. Never re-run.
+   - If pending: run inside `BEGIN; … COMMIT;` (SQLite has transactional DDL).
+     On success, record `(filename, now, sha256, version, duration)`. On failure,
+     `ROLLBACK`, print the offending statement, exit non-zero — the DB is
+     unchanged.
+3. Apply `db/views/*.sql` (idempotent `CREATE VIEW IF NOT EXISTS`) the same way.
+
+**`mini-ork migrate --status`** prints: applied count, pending list, any
+checksum-drifted files, current vs latest migration id. **`--dry-run`** lists
+pending without writing. **`--verify`** checks every applied checksum (CI + a
+`doctor` probe).
+
+**Migration authoring rules** (documented in `db/README.md`):
+- Additive only where possible (`ADD COLUMN`, `CREATE TABLE IF NOT EXISTS`).
+- **Never edit a shipped migration** — add a new one (the checksum guard enforces
+  this).
+- Each file is one logical change, wrapped so it's transaction-safe.
+- Retire `ensure_column`/`0018` hacks into a single idempotent
+  `00xx_repair_learning_columns.sql` that the tracker records once.
+
+## Update layer (`bin/mini-ork-update` → `mini-ork update`)
+
+Turns "update" into a safe, one-command, data-preserving operation for a
+consuming repo:
+
+```
+mini-ork update [--source <path|release>] [--dry-run] [--no-migrate]
+```
+
+**Steps (each reversible):**
+1. **Resolve source** of the new framework: `--source <dir>` (a mini-ork clone),
+   or a downloaded release tarball pinned by version, or `$MINI_ORK_SOURCE`.
+   Record `from`→`to` version (a `.mini-ork/VERSION` file).
+2. **Back up** `state.db` (+ `-wal`/`-shm`) and `config/` to
+   `.mini-ork/.backups/<from-version>-<ts>/`.
+3. **Re-vendor code** — `rsync -a --delete` the framework dirs
+   (`bin lib recipes db schemas mini_ork .githooks`) from source into
+   `.mini-ork/`, **excluding** `state.db*`, `config/secrets.local.sh`,
+   `config/agents.yaml`, `runs/`, `.backups/`. (This is exactly the manual
+   re-vendor we run today, made first-class.)
+4. **Migrate** — `mini-ork migrate` (transactional; skips on `--no-migrate`).
+5. **Verify** — `mini-ork doctor` + `mini-ork migrate --verify`.
+6. **On any failure**, restore the `state.db` backup and the previous code, and
+   report. `--dry-run` prints steps 1–4 without writing.
+
+**Config drift** (shipped `config/*.example` vs local) is *reported*, never
+auto-applied — the operator merges intentionally.
+
+## Integration + CLI
+
+- Wire `migrate` and `update` into `bin/mini-ork`'s dispatch table (today
+  `mini-ork-update` is an unlisted sibling binary).
+- `db/init.sh` keeps only bootstrap + WAL pragmas + delegate to `lib/migrate.sh`
+  (drops the inline repair hacks once the repair migration lands).
+- `mini-ork doctor` gains a "migrations: N applied, M pending, 0 drifted" line.
+
+## Phased implementation
+
+1. **P1 — real checksums + transactional apply** in a new `lib/migrate.sh`;
+   `init.sh` delegates to it. Backward-compatible: existing
+   `checksum='runner-applied'` rows are re-hashed on first `--verify`
+   (or left, with drift-allow for legacy rows).
+2. **P2 — `mini-ork migrate` CLI** (`--status/--dry-run/--verify`) + doctor line.
+3. **P3 — re-vendor step in `mini-ork update`** (backup → rsync framework →
+   migrate → verify → rollback) + `.mini-ork/VERSION`.
+4. **P4 — retire the `ensure_column`/`0018` hacks** into one repair migration;
+   simplify `init.sh`.
+
+Net: `mini-ork update` becomes a safe, idempotent, data-preserving upgrade —
+the DB is migrated forward transactionally, never overridden.

--- a/lib/migrate.sh
+++ b/lib/migrate.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# migrate.sh — versioned, checksummed, transactional DB migrations for mini-ork.
+#
+# Design: docs/_meta/migration-and-update-design.md. Source this file and call
+# mo_migrate_apply / mo_migrate_status / mo_migrate_verify. Requires MINI_ORK_DB.
+#
+# What this fixes vs the old inline loop in db/init.sh:
+#   - REAL sha256 checksums (not the 'runner-applied' placeholder), so an
+#     already-applied migration that gets edited is detected as drift.
+#   - TRANSACTIONAL apply: each migration + its schema_migrations record commit
+#     together, or neither does — a failed migration leaves the DB unchanged
+#     instead of half-migrated (which is what pushed people to wipe the DB).
+#   - Legacy rows (checksum='runner-applied'/'view-v1'/'recovered-*') are
+#     re-hashed to the real value in place, never re-run.
+
+# sha256 of a file, portable across macOS (shasum) and Linux (sha256sum).
+mo_migrate_checksum() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# Is this a legacy placeholder rather than a real checksum? A real checksum is
+# exactly 64 hex chars (sha256). Everything the old runner wrote — 'v1',
+# 'runner-applied', 'phase-a-1', per-migration version tags, empty — contains a
+# non-hex char or the wrong length, so this classifies all of them without
+# enumerating the (open-ended) set of placeholder strings.
+_mo_migrate_is_legacy_checksum() {
+  case "$1" in
+    *[!0-9a-f]* | "") return 0 ;; # non-hex char or empty → legacy
+  esac
+  [ "${#1}" -eq 64 ] && return 1 || return 0 # 64 hex → real; otherwise legacy
+}
+
+# schema_migrations, backward-compatible with the original (filename, applied_at,
+# checksum) table — adds the v2 columns only if missing.
+mo_migrate_ensure_table() {
+  local db="$1"
+  sqlite3 "$db" "CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename   TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    checksum   TEXT
+  );" 2>/dev/null || return 1
+  local cols
+  cols=$(sqlite3 "$db" "SELECT ',' || group_concat(name) || ',' FROM pragma_table_info('schema_migrations');" 2>/dev/null)
+  case "$cols" in *,mini_ork_version,*) ;; *) sqlite3 "$db" "ALTER TABLE schema_migrations ADD COLUMN mini_ork_version TEXT;" 2>/dev/null || true ;; esac
+}
+
+_mo_migrate_version() {
+  grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "${MINI_ORK_ROOT:-.}/bin/mini-ork" 2>/dev/null | head -1
+}
+
+# Apply ONE migration file and record it, atomically. BEGIN + file + INSERT +
+# COMMIT piped to `sqlite3 -bail`: any error stops before COMMIT and the open
+# transaction is rolled back when the connection closes. The file is piped raw
+# (never through an expanding heredoc) so SQL like json_extract('$.x') is safe.
+_mo_migrate_apply_one() {
+  local db="$1" file="$2" filename="$3" checksum="$4" ver="$5"
+  local record
+  # OR REPLACE, because ~half the shipped migrations self-record a placeholder
+  # row (checksum='v1'); this overwrites it with the real sha256.
+  record="INSERT OR REPLACE INTO schema_migrations(filename, applied_at, checksum, mini_ork_version) VALUES ('$filename', strftime('%Y-%m-%dT%H:%M:%fZ','now'), '$checksum', '$ver');"
+  # A top-level `BEGIN;` means the migration already manages its own transaction
+  # (many shipped ones do, and some define triggers with their own BEGIN…END;).
+  # Run those as-is under -bail (a failure leaves the tx uncommitted → rolled
+  # back on close) and record on success. Wrap only BARE migrations so they get
+  # the same all-or-nothing guarantee.
+  if grep -qiE '^[[:space:]]*begin([[:space:]]+transaction)?[[:space:]]*;' "$file"; then
+    sqlite3 -bail "$db" < "$file" || return 1
+    sqlite3 "$db" "$record"
+  else
+    { printf 'BEGIN;\n'; cat "$file"; printf '\n%s\nCOMMIT;\n' "$record"; } | sqlite3 -bail "$db"
+  fi
+}
+
+# Apply every pending *.sql in $1 (dir) in lex order. $2=1 → dry-run (list only).
+# Returns non-zero on a failed migration or on unallowed checksum drift.
+mo_migrate_apply() {
+  local db="${MINI_ORK_DB:?MINI_ORK_DB required}"
+  local dir="${1:?migrations dir required}"
+  local dry_run="${2:-0}"
+  [ -d "$dir" ] || { echo "[migrate] no such dir: $dir" >&2; return 1; }
+  mo_migrate_ensure_table "$db" || { echo "[migrate] cannot init schema_migrations" >&2; return 1; }
+  local ver f filename sum applied applied_sum
+  ver=$(_mo_migrate_version)
+  for f in $(ls "$dir"/*.sql 2>/dev/null | sort); do
+    filename=$(basename "$f")
+    sum=$(mo_migrate_checksum "$f")
+    applied=$(sqlite3 "$db" "SELECT COUNT(*) FROM schema_migrations WHERE filename='$filename';" 2>/dev/null || echo 0)
+    if [ "$applied" = "1" ]; then
+      applied_sum=$(sqlite3 "$db" "SELECT COALESCE(checksum,'') FROM schema_migrations WHERE filename='$filename';" 2>/dev/null)
+      if [ "$applied_sum" = "$sum" ]; then
+        continue
+      elif _mo_migrate_is_legacy_checksum "$applied_sum"; then
+        [ "$dry_run" = "1" ] || sqlite3 "$db" "UPDATE schema_migrations SET checksum='$sum', mini_ork_version=COALESCE(mini_ork_version,'$ver') WHERE filename='$filename';" 2>/dev/null
+        echo "  [rehash]  $filename (legacy checksum → real sha256)"
+      elif [ "${MO_MIGRATE_ALLOW_DRIFT:-0}" = "1" ]; then
+        echo "  [warn]    $filename checksum drift (allowed by MO_MIGRATE_ALLOW_DRIFT)" >&2
+      else
+        echo "  [FAIL]    $filename was edited after being applied (checksum drift)." >&2
+        echo "            Add a NEW migration instead of editing a shipped one, or set MO_MIGRATE_ALLOW_DRIFT=1." >&2
+        return 1
+      fi
+      continue
+    fi
+    if [ "$dry_run" = "1" ]; then
+      echo "  [pending] $filename"
+      continue
+    fi
+    echo "  [apply]   $filename"
+    if _mo_migrate_apply_one "$db" "$f" "$filename" "$sum" "$ver"; then
+      echo "  [ok]      $filename"
+    else
+      echo "  [FAIL]    $filename — rolled back, DB unchanged" >&2
+      return 1
+    fi
+  done
+}
+
+# Print a one-line summary + any pending/drifted files.
+mo_migrate_status() {
+  local db="${MINI_ORK_DB:?}" dir="${1:?}"
+  local total pending=0 drifted=0 f filename sum a asum
+  total=$(ls "$dir"/*.sql 2>/dev/null | wc -l | tr -d ' ')
+  for f in $(ls "$dir"/*.sql 2>/dev/null | sort); do
+    filename=$(basename "$f"); sum=$(mo_migrate_checksum "$f")
+    a=$(sqlite3 "$db" "SELECT COUNT(*) FROM schema_migrations WHERE filename='$filename';" 2>/dev/null || echo 0)
+    if [ "$a" = "0" ]; then
+      pending=$((pending + 1)); echo "  pending: $filename"
+    else
+      asum=$(sqlite3 "$db" "SELECT COALESCE(checksum,'') FROM schema_migrations WHERE filename='$filename';" 2>/dev/null)
+      if [ "$asum" != "$sum" ] && ! _mo_migrate_is_legacy_checksum "$asum"; then
+        drifted=$((drifted + 1)); echo "  DRIFTED: $filename"
+      fi
+    fi
+  done
+  echo "migrations: $((total - pending)) applied, $pending pending, $drifted drifted (of $total)"
+}
+
+# Verify every applied migration's checksum still matches its file. Non-zero on drift.
+mo_migrate_verify() {
+  local db="${MINI_ORK_DB:?}" dir="${1:?}"
+  local rc=0 f filename sum a asum
+  for f in $(ls "$dir"/*.sql 2>/dev/null | sort); do
+    filename=$(basename "$f"); sum=$(mo_migrate_checksum "$f")
+    a=$(sqlite3 "$db" "SELECT COUNT(*) FROM schema_migrations WHERE filename='$filename';" 2>/dev/null || echo 0)
+    [ "$a" = "1" ] || continue
+    asum=$(sqlite3 "$db" "SELECT COALESCE(checksum,'') FROM schema_migrations WHERE filename='$filename';" 2>/dev/null)
+    if [ "$asum" != "$sum" ] && ! _mo_migrate_is_legacy_checksum "$asum"; then
+      echo "  DRIFT: $filename (applied=${asum:0:12} file=${sum:0:12})" >&2; rc=1
+    fi
+  done
+  [ "$rc" = "0" ] && echo "migrate --verify: all applied checksums match" || echo "migrate --verify: drift detected" >&2
+  return "$rc"
+}

--- a/tests/unit/test_migrate.sh
+++ b/tests/unit/test_migrate.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Unit test for lib/migrate.sh — the versioned/checksummed/transactional
+# migration runner. Uses small synthetic migrations in a temp dir so it's fast
+# and precise.
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+export MINI_ORK_ROOT="$ROOT"
+# shellcheck source=/dev/null
+. "$ROOT/lib/migrate.sh"
+PASS=0; FAIL=0
+ok(){ echo "  [OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+export MINI_ORK_DB="$TMP/state.db"
+MIG="$TMP/migrations"; mkdir -p "$MIG"
+_q(){ sqlite3 "$MINI_ORK_DB" "$1" 2>/dev/null; }
+echo "── unit: lib/migrate.sh ──"
+
+printf 'CREATE TABLE t1(id INTEGER);\n' > "$MIG/0001_a.sql"
+printf 'CREATE TABLE t2(id INTEGER);\n' > "$MIG/0002_b.sql"
+
+# 1. fresh apply
+mo_migrate_apply "$MIG" >/dev/null 2>&1
+[ "$(_q "SELECT COUNT(*) FROM schema_migrations WHERE filename LIKE '000%';")" = "2" ] && ok "both migrations applied + recorded" || bad "apply/record failed"
+[ "$(_q "SELECT name FROM sqlite_master WHERE name='t1';")" = "t1" ] && ok "migration DDL ran (t1 exists)" || bad "t1 missing"
+
+# 2. real sha256 checksum stored (64 hex chars, not a placeholder)
+CS=$(_q "SELECT checksum FROM schema_migrations WHERE filename='0001_a.sql';")
+[ "${#CS}" = "64" ] && ok "real sha256 checksum stored (len 64)" || bad "checksum not a real hash ($CS)"
+
+# 3. re-apply is idempotent (no re-run, no error)
+out=$(mo_migrate_apply "$MIG" 2>&1)
+printf '%s' "$out" | grep -q "apply" && bad "re-apply wrongly re-ran a migration" || ok "re-apply is a no-op (idempotent)"
+
+# 4. editing an applied migration => drift FAIL
+printf 'CREATE TABLE t1(id INTEGER, extra TEXT);\n' > "$MIG/0001_a.sql"
+mo_migrate_apply "$MIG" >/dev/null 2>&1 && bad "edited migration was NOT rejected" || ok "edited-after-apply migration rejected (drift guard)"
+# ...unless drift is explicitly allowed
+MO_MIGRATE_ALLOW_DRIFT=1 mo_migrate_apply "$MIG" >/dev/null 2>&1 && ok "MO_MIGRATE_ALLOW_DRIFT=1 bypasses drift" || bad "drift override did not work"
+printf 'CREATE TABLE t1(id INTEGER);\n' > "$MIG/0001_a.sql"  # restore
+# repair the drifted checksum row so later steps are clean
+_q "UPDATE schema_migrations SET checksum=(SELECT '$(mo_migrate_checksum "$MIG/0001_a.sql")') WHERE filename='0001_a.sql';" >/dev/null 2>&1
+
+# 5. legacy placeholder checksum => rehashed to the real value, never re-run
+_q "UPDATE schema_migrations SET checksum='runner-applied' WHERE filename='0002_b.sql';" >/dev/null
+out=$(mo_migrate_apply "$MIG" 2>&1)
+printf '%s' "$out" | grep -q "rehash" && ok "legacy checksum rehashed" || bad "legacy checksum not rehashed"
+NEWCS=$(_q "SELECT checksum FROM schema_migrations WHERE filename='0002_b.sql';")
+[ "${#NEWCS}" = "64" ] && ok "rehashed to real sha256" || bad "rehash produced wrong value ($NEWCS)"
+
+# 6. a failing migration rolls back — DB unchanged, not recorded
+printf 'CREATE TABLE t3(id INTEGER);\nTHIS IS NOT VALID SQL;\n' > "$MIG/0003_bad.sql"
+mo_migrate_apply "$MIG" >/dev/null 2>&1 && bad "bad migration reported success" || ok "bad migration returns non-zero"
+[ -z "$(_q "SELECT name FROM sqlite_master WHERE name='t3';")" ] && ok "failed migration rolled back (t3 NOT created)" || bad "partial DDL committed despite failure"
+[ "$(_q "SELECT COUNT(*) FROM schema_migrations WHERE filename='0003_bad.sql';")" = "0" ] && ok "failed migration not recorded" || bad "failed migration wrongly recorded"
+rm -f "$MIG/0003_bad.sql"
+
+# 7. status + verify
+mo_migrate_status "$MIG" 2>&1 | grep -q "2 applied, 0 pending, 0 drifted" && ok "status reports 2 applied / 0 pending / 0 drifted" || bad "status output wrong"
+mo_migrate_verify "$MIG" >/dev/null 2>&1 && ok "verify passes on a clean DB" || bad "verify failed on clean DB"
+
+echo "── Results: $PASS OK  $FAIL FAIL ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Hardens the migration system so a consumer can **update mini-ork to the latest version without ever overriding `state.db`**. (Design: `docs/_meta/migration-and-update-design.md`.)

New **`lib/migrate.sh`** replaces the inline loop in `db/init.sh` (now delegates to it):
- **Real sha256 checksums** (not the `'runner-applied'`/`'v1'` placeholders) → integrity: a shipped migration edited after release is detected as drift and rejected (`MO_MIGRATE_ALLOW_DRIFT=1` to override).
- **Transactional apply** — each migration + its `schema_migrations` record commit together or not at all, so a failed migration leaves the DB **unchanged** instead of half-migrated (the state that made people wipe). Self-wrapped migrations run as-is under `-bail`; bare ones are wrapped; trigger `BEGIN…END;` bodies handled.
- **Legacy rehash** — the 23 self-recording migrations use custom placeholder checksums; any non-64-hex value is rehashed in place to the real sha256, never re-run.
- **`mo_migrate_status` / `mo_migrate_verify`** for pending/drift reporting.
- `init.sh` keeps the `0018` session_id legacy-recovery as a pre-migrate guard.

**Verified:** fresh init = 102 tables / 47 real checksums (**parity** with old init.sh), idempotent re-run, verify passes, an init.sh-built DB rehashes all 47 placeholders. Test: `tests/unit/test_migrate.sh` (**13 OK**).

Next (per the design doc): P2 `mini-ork migrate` CLI, P3 re-vendor step in `mini-ork update` for vendored consumers, P4 retire the repair hacks.