### PR TITLE
fix(cl_codex): refuse dispatch when cwd resolves to a mini-ork framework tree

### DIFF
--- a/lib/providers/cl_codex.sh
+++ b/lib/providers/cl_codex.sh
@@ -128,6 +128,37 @@ _CODEX_SANDBOX="${CODEX_SANDBOX:-workspace-write}"
 # Both fall back to "" if neither is set, in which case we skip --cd and
 # preserve codex's prior behavior (inherits whatever cwd the process has).
 _CODEX_TARGET_CWD="${MO_TARGET_CWD:-${PWD:-}}"
+
+# ── cwd guard (cross-repo corruption prevention) ──────────────────────────────
+# A codex turn runs `git reset --hard refs/codex/curated-sync` inside its cwd.
+# If that cwd resolves to a mini-ork FRAMEWORK tree (this install, or a sibling
+# framework source clone such as a dev checkout used to vendor updates) rather
+# than the intended TARGET repo, codex clobbers the framework repo's working
+# tree instead of the consumer's project. This is silent and easy to miss: the
+# dispatcher reports a normal run, and the damage only surfaces when the
+# framework repo's own history looks corrupted.
+#
+# Concretely this happens when MO_TARGET_CWD isn't propagated all the way to
+# the subshell that actually invokes codex (e.g. a nested pipeline stage), so
+# the fallback `${PWD:-}` resolves to wherever THAT subshell happens to be —
+# which can drift to a framework tree if the dispatcher or one of its child
+# processes was launched from there.
+#
+# Fail fast rather than corrupt. Override for a genuine framework self-edit
+# (e.g. dogfooding mini-ork on its own source) via MO_ALLOW_FRAMEWORK_CWD=1.
+if [ "${MO_ALLOW_FRAMEWORK_CWD:-0}" != "1" ] && [ -n "$_CODEX_TARGET_CWD" ]; then
+  _cg="$(cd "$_CODEX_TARGET_CWD" 2>/dev/null && pwd -P || echo "$_CODEX_TARGET_CWD")"
+  _is_framework_tree=0
+  [ -f "$_cg/bin/mini-ork" ] && _is_framework_tree=1   # cwd IS a mini-ork install root
+  case "$_cg" in
+    */.mini-ork|*/.mini-ork/*|*/mini-ork|*/mini-ork/*) _is_framework_tree=1 ;;
+  esac
+  if [ "$_is_framework_tree" = "1" ]; then
+    echo "[cl_codex] cwd guard FAILED: '$_cg' looks like a mini-ork framework tree — refusing codex dispatch (it would corrupt that repo instead of your target project). Set MO_TARGET_CWD to your TARGET repo; MO_ALLOW_FRAMEWORK_CWD=1 only for a genuine framework self-edit." >&2
+    exit 2
+  fi
+fi
+
 _CODEX_CD_FLAGS=()
 if [ -n "$_CODEX_TARGET_CWD" ] && [ -d "$_CODEX_TARGET_CWD" ]; then
   _CODEX_CD_FLAGS+=(-C "$_CODEX_TARGET_CWD")

--- a/tests/integration/test_dispatch_telemetry_gate.sh
+++ b/tests/integration/test_dispatch_telemetry_gate.sh
@@ -86,7 +86,11 @@ echo '{"type":"turn.completed","usage":{"input_tokens":1000000,"cached_input_tok
 [ -n "$LAST" ] && printf 'body\n' > "$LAST"
 EOF
 chmod +x "$TMP/stubbin/codex"
+# MO_TARGET_CWD pinned to $TMP: without it the cwd-guard's PWD fallback
+# resolves to this repo's own checkout (which has bin/mini-ork) and refuses
+# the dispatch — this test exercises telemetry sidecars, not the guard.
 PATH="$TMP/stubbin:$PATH" \
+  MO_TARGET_CWD="$TMP" \
   MO_USAGE_FILE="$TMP/u.tokens" MO_TURNS_FILE="$TMP/t.jsonl" MO_COST_FILE="$TMP/c.cost" \
   MO_CODEX_USD_PER_MTOK_IN=1.0 MO_CODEX_USD_PER_MTOK_OUT=10.0 \
   "$ROOT/lib/providers/cl_codex.sh" --print --output-format text "p" >/dev/null 2>&1

--- a/tests/unit/test_cl_codex_cwd_guard.sh
+++ b/tests/unit/test_cl_codex_cwd_guard.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Regression: cl_codex.sh must refuse to dispatch codex when its resolved cwd
+# is a mini-ork FRAMEWORK tree instead of the consumer's target repo. A codex
+# turn runs `git reset --hard refs/codex/curated-sync` inside its cwd — if
+# that cwd is the framework's own source clone (or a vendored install),
+# codex clobbers the framework repo's working tree rather than the intended
+# project. This is silent and easy to miss until the framework repo's own
+# history looks corrupted. The guard fails fast instead.
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+PASS=0; FAIL=0
+ok(){ echo "  [OK]   $1"; PASS=$((PASS+1)); }
+bad(){ echo "  [FAIL] $1"; FAIL=$((FAIL+1)); }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+echo "── unit: cl_codex.sh cwd guard (cross-repo corruption prevention) ──"
+
+# --- stub codex CLI (only reached when the guard correctly lets a dispatch through) ---
+cat > "$TMP/codex" <<'STUB'
+#!/usr/bin/env bash
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --output-last-message) last_msg="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '{"type":"thread.started","thread_id":"th-1"}\n'
+printf '{"type":"item.completed","item":{"type":"agent_message","text":"OK"}}\n'
+[ -n "${last_msg:-}" ] && printf 'OK' > "$last_msg"
+exit 0
+STUB
+chmod +x "$TMP/codex"
+
+run_wrapper(){ # $1=MO_TARGET_CWD  $2=MO_ALLOW_FRAMEWORK_CWD (optional)
+  MO_TARGET_CWD="$1" MO_ALLOW_FRAMEWORK_CWD="${2:-}" \
+    PATH="$TMP:$PATH" bash "$ROOT/lib/providers/cl_codex.sh" --print --output-format text "do the thing"
+}
+
+# ── Scenario A: target cwd IS the framework install root (has bin/mini-ork) ──
+FRAMEWORK_ROOT="$TMP/fake-framework"
+mkdir -p "$FRAMEWORK_ROOT/bin"
+touch "$FRAMEWORK_ROOT/bin/mini-ork"
+OUT_A="$(run_wrapper "$FRAMEWORK_ROOT" 2>"$TMP/a.err")"
+RC_A=$?
+[ "$RC_A" -eq 2 ] && ok "guard refuses dispatch (exit 2) when cwd is a framework install root (A)" \
+  || bad "expected exit 2, got $RC_A (A): $(cat "$TMP/a.err")"
+grep -qi "cwd guard FAILED" "$TMP/a.err" && ok "guard error message present (A)" || bad "guard error message missing (A): $(cat "$TMP/a.err")"
+
+# ── Scenario B: target cwd is a path literally named .mini-ork (vendored install, no bin/mini-ork needed) ──
+DOTDIR_ROOT="$TMP/some-project/.mini-ork"
+mkdir -p "$DOTDIR_ROOT"
+OUT_B="$(run_wrapper "$DOTDIR_ROOT" 2>"$TMP/b.err")"
+RC_B=$?
+[ "$RC_B" -eq 2 ] && ok "guard refuses dispatch for a .mini-ork-named path (B)" \
+  || bad "expected exit 2, got $RC_B (B): $(cat "$TMP/b.err")"
+
+# ── Scenario C: normal target repo — guard must NOT fire ─────────────────────
+TARGET_REPO="$TMP/my-actual-project"
+mkdir -p "$TARGET_REPO"
+OUT_C="$(run_wrapper "$TARGET_REPO" 2>"$TMP/c.err")"
+RC_C=$?
+[ "$RC_C" -eq 0 ] && ok "guard does not block a normal target repo (C)" \
+  || bad "unexpected non-zero exit $RC_C for a normal target repo (C): $(cat "$TMP/c.err")"
+printf '%s' "$OUT_C" | grep -q "OK" && ok "dispatch proceeds normally for a normal target repo (C)" || bad "dispatch output missing for normal target repo (C)"
+
+# ── Scenario D: MO_ALLOW_FRAMEWORK_CWD=1 overrides the guard for a genuine self-edit ──
+OUT_D="$(run_wrapper "$FRAMEWORK_ROOT" 1 2>"$TMP/d.err")"
+RC_D=$?
+[ "$RC_D" -eq 0 ] && ok "MO_ALLOW_FRAMEWORK_CWD=1 overrides the guard (D)" \
+  || bad "override did not bypass guard, rc=$RC_D (D): $(cat "$TMP/d.err")"
+
+echo "── Results: $PASS OK  $FAIL FAIL ──"
+[ "$FAIL" -eq 0 ]

--- a/tests/unit/test_cl_codex_e2big.sh
+++ b/tests/unit/test_cl_codex_e2big.sh
@@ -43,7 +43,11 @@ STUB
 chmod +x "$TMP/codex"
 
 run_wrapper(){ # $1=format ; rest via env already set by caller
-  PATH="$TMP:$PATH" bash "$ROOT/lib/providers/cl_codex.sh" --print --output-format "$1" "do the thing"
+  # MO_TARGET_CWD pinned to $TMP (not $ROOT): without it the cwd-guard's PWD
+  # fallback resolves to this repo's own checkout (which has bin/mini-ork)
+  # and refuses the dispatch — this test isn't exercising the guard, just
+  # the wrapper's E2BIG handling, so it needs a non-framework target cwd.
+  MO_TARGET_CWD="$TMP" PATH="$TMP:$PATH" bash "$ROOT/lib/providers/cl_codex.sh" --print --output-format "$1" "do the thing"
 }
 
 # ── Scenario A: last-message present (sites 187 harvest + 311 clean + 356) ──

--- a/tests/unit/test_cl_codex_stdin.sh
+++ b/tests/unit/test_cl_codex_stdin.sh
@@ -28,7 +28,11 @@ exit 0
 STUB
 chmod +x "$TMP/codex"
 
-run_codex(){ PATH="$TMP:$PATH" CODEX_PROMPT_CAPTURE="$TMP/cap" bash "$ROOT/lib/providers/cl_codex.sh" "$@"; }
+# MO_TARGET_CWD pinned to $TMP (not $ROOT): without it the cwd-guard's PWD
+# fallback resolves to this repo's own checkout (which has bin/mini-ork) and
+# refuses the dispatch — this test isn't exercising the guard, just stdin
+# prompt handling, so it needs a non-framework target cwd.
+run_codex(){ MO_TARGET_CWD="$TMP" PATH="$TMP:$PATH" CODEX_PROMPT_CAPTURE="$TMP/cap" bash "$ROOT/lib/providers/cl_codex.sh" "$@"; }
 
 # 1. prompt via stdin, NO positional prompt → wrapper reads stdin
 : > "$TMP/cap"


### PR DESCRIPTION
## Summary

Adds a fail-fast guard to `cl_codex.sh` that refuses a codex dispatch when its resolved target cwd looks like a mini-ork framework tree instead of the caller's actual target project, preventing codex's `git reset --hard refs/codex/curated-sync` from clobbering the framework repo's own working tree.

## Changes

- `lib/providers/cl_codex.sh`: cwd guard — refuses dispatch (exit 2, clear stderr) when the resolved `MO_TARGET_CWD`/`PWD` fallback has `bin/mini-ork` or is a path literally named `(.)mini-ork`. Override via `MO_ALLOW_FRAMEWORK_CWD=1` for a genuine framework self-edit.
- `tests/unit/test_cl_codex_cwd_guard.sh` (new): 6 assertions — guard fires for a framework install root, fires for a `.mini-ork`-named path, does not fire for a normal target repo, and the override bypasses it.
- `tests/unit/test_cl_codex_e2big.sh`, `tests/unit/test_cl_codex_stdin.sh`, `tests/integration/test_dispatch_telemetry_gate.sh`: pin `MO_TARGET_CWD` to each test's own scratch dir. Without this, the new guard's `PWD` fallback resolves to the repo's own checkout (which has `bin/mini-ork`) when the suite runs from the repo root, and incorrectly refuses dispatches that have nothing to do with cwd validation.

## Why

A codex turn runs `git reset --hard refs/codex/curated-sync` inside its resolved cwd. If `MO_TARGET_CWD` isn't propagated all the way to the subshell that actually invokes codex (e.g. a nested pipeline stage in a multi-node dispatch), the `PWD` fallback can land on a mini-ork framework tree — this install, or a sibling framework source clone used for dogfooding/updates — instead of the intended target project. codex then clobbers the framework repo's own working tree. This is silent and easy to miss: the dispatch itself reports normally, and the damage only surfaces later as unexplained history churn in the framework repo.

## Testing

- [x] `bash tests/run-all.sh smoke unit integration e2e security` passes locally — 108 files, 995 assertions, 0 fail
- [x] `shellcheck -S error lib/providers/cl_codex.sh` clean
- [x] New test added covering guard fire / no-fire / override
- [ ] Docs update for `MO_ALLOW_FRAMEWORK_CWD` — not yet added to `docs/`, happy to add if maintainers want it documented alongside the other `MO_*` env vars

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] No hard-coded paths outside `lib/config.sh` (guard reads `MO_TARGET_CWD`/`PWD` only)
- [x] No `eval` for argument construction
- [x] No secrets or internal identifiers in code, comments, or examples

Note: the pre-push README claim-check reported drift (`lib/*.sh count 85 vs 89`, `db/migrations 46 vs 47`) that also reproduces identically on a plain `origin/main` worktree with zero changes — appears to be a hook-environment quirk with worktree-based pushes rather than real drift (confirmed clean via `bash scripts/readme-claim-check.sh` run directly in this worktree). Pushed with `MO_README_DRIFT_SKIP=1` per the hook's own documented escape hatch; flagging here in case it's worth a maintainer look independent of this PR.