### PR TITLE
Python migration: 15 modules + wins #1/#2/#3 + hang-proof dispatch

### DIFF
--- a/bin/mini-ork
+++ b/bin/mini-ork
@@ -468,6 +468,13 @@ PY
       if declare -f mo_rubric_run_score >/dev/null 2>&1; then
         mo_rubric_run_score "$kickoff" "$_run_dir" "${MINI_ORK_TASK_CLASS:-generic}" \
           || echo "  [warn] rubric pre-screen failed (advisory — run unaffected)" >&2
+        # Close the eval loop (win #3): feed the rubric's GRADED 0-8 score into
+        # the learning reward so lane_router learns from run quality, not a
+        # flattened pass/fail. Best-effort — never affects the run outcome.
+        if declare -f mo_grade_run_reward >/dev/null 2>&1; then
+          mo_grade_run_reward "$_run_dir" "${MINI_ORK_RUN_ID:-${MINI_ORK_TASK_RUN_ID:-}}" \
+            || echo "  [warn] grade-run-reward failed (advisory)" >&2
+        fi
       else
         echo "  [warn] mo_rubric_run_score unavailable — skipping rubric" >&2
       fi

--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -181,6 +181,25 @@ _mo_reward_from_status() {
   esac
 }
 
+# Role-aware lane fallback chain: the resolved lane LEADS, then the category
+# fallback lanes, deduped. Consumed by the Python dispatch backend so a
+# hung/flaky lead lane is abandoned and the next lane serves the node — one bad
+# lane can no longer stall a run (the recurring cross_epic_gradient-style stall).
+# Coding roles fall back through MO_FALLBACK_CODING, review roles through
+# MO_FALLBACK_REVIEW. Empty tail (unknown role) → lead only (no behavior change).
+_mo_dispatch_chain() {
+  local _nt="$1" _lead="$2" _tail=""
+  case "$_nt" in
+    implementer|worker|spec_author|healer|planner|researcher|reflector|replanner|synthesizer|bdd_runner)
+      _tail="${MO_FALLBACK_CODING:-minimax,codex,sonnet}" ;;
+    reviewer|spec_reviewer|verifier|brain)
+      _tail="${MO_FALLBACK_REVIEW:-opus,kimi,sonnet}" ;;
+  esac
+  [ -z "$_tail" ] && { printf '%s' "$_lead"; return; }
+  printf '%s,%s' "$_lead" "$_tail" \
+    | awk -F, '{o="";for(i=1;i<=NF;i++)if($i!=""&&!s[$i]++){printf "%s%s",(o?",":""),$i;o=1}}'
+}
+
 _mo_learning_static_lane() {
   local _node_type="$1" _current_lane="$2"
   local _frontier="${MO_FRONTIER_LANE:-opus_lens}"
@@ -1500,11 +1519,23 @@ _trace_write_node_rich() {
   if [ -n "$_output_file" ] && [ -f "${_output_file}.tool-summary" ]; then
     _tool_summary="${_output_file}.tool-summary"
   fi
+  # v0.6: activate the GRPO shared-brain loop — stamp a real reward_g on every
+  # node trace. Previously _trace_write_node_rich never set reward_value/anchor,
+  # so reward_g stayed NULL and lane_router_recompute_advantages processed zero
+  # code-delivery rows — the learning loop was inert in the default runtime.
+  # value = node outcome in [0,1] from status/verdict; a fixed neutral anchor
+  # (MO_REWARD_ANCHOR, default 0.5) makes reward_g = dir*(value-anchor)/|anchor|
+  # land in [-1,+1]; lane_router then derives the group-relative advantage per
+  # (objective_domain, task_class, node_type, code_region). Opt-out: MO_REWARD_STAMP=0.
+  local _reward_value="" _reward_anchor="${MO_REWARD_ANCHOR:-0.5}" _reward_direction="higher_is_better"
+  if [ "${MO_REWARD_STAMP:-1}" = "1" ]; then
+    _reward_value=$(_mo_reward_from_status "$_status" "$_verdict")
+  fi
   # Compose JSON payload via python3 for proper escaping.
   local _payload
   _payload=$(python3 -c "
 import json, sys, os
-trace_id, status, node_type, output_file, verdict, cost, task_class, tool_summary_path, duration_ms, finish_reason, agent_version_id = sys.argv[1:12]
+trace_id, status, node_type, output_file, verdict, cost, task_class, tool_summary_path, duration_ms, finish_reason, agent_version_id, reward_value, reward_anchor, reward_direction = sys.argv[1:15]
 
 tool_calls = []
 files_read = []
@@ -1544,9 +1575,16 @@ if verdict:
     obj['reviewer_verdict'] = verdict
 if finish_reason:
     obj['finish_reason'] = finish_reason
+if reward_value:
+    try:
+        obj['reward_value'] = float(reward_value)
+        obj['reward_anchor'] = float(reward_anchor)
+        obj['reward_direction'] = reward_direction
+    except ValueError:
+        pass
 obj['verifier_output'] = {'node_type': node_type, 'finish_reason': finish_reason or None}
 print(json.dumps(obj))
-" "$_trace_id" "$_status" "$_node_type" "$_output_file" "$_verdict" "$_cost" "${TASK_CLASS:-generic}" "$_tool_summary" "$_duration_ms" "$_finish_reason" "${dispatch_lane:-}" 2>/dev/null)
+" "$_trace_id" "$_status" "$_node_type" "$_output_file" "$_verdict" "$_cost" "${TASK_CLASS:-generic}" "$_tool_summary" "$_duration_ms" "$_finish_reason" "${dispatch_lane:-}" "$_reward_value" "$_reward_anchor" "$_reward_direction" 2>/dev/null)
   if [ -n "$_payload" ]; then
     trace_write "$_payload" >/dev/null 2>&1 || true
     _mo_update_trace_code_region "$_trace_id" "$_payload"
@@ -1813,6 +1851,12 @@ _dispatch_node() {
   local dispatch_lane="${node_model_lane:-$node_type}"
   local workflow_lane="$dispatch_lane"
   dispatch_lane="$(_mo_policy_route_lane "$node_type" "$dispatch_lane")"
+
+  # Export the role-aware fallback chain (lead = resolved lane) so the Python
+  # dispatch backend routes around a hung/flaky lead lane instead of stalling.
+  # Only takes effect under MO_DISPATCH_BACKEND=python; inert otherwise.
+  MO_DISPATCH_CHAIN="$(_mo_dispatch_chain "$node_type" "$dispatch_lane")"
+  export MO_DISPATCH_CHAIN
 
   # Cooperative stop check: UI's POST /api/v1/task-runs/{id}/stop touches
   # this file. We bail BEFORE dispatching the next node so the current

--- a/docs/_meta/python-migration-tracker.md
+++ b/docs/_meta/python-migration-tracker.md
@@ -3,7 +3,7 @@
 Strangler-fig: bash stays until each Python port is parity-verified against the
 LIVE bash. Every ported module has a test that invokes the real bash function.
 
-## DONE + verified (10 modules)
+## DONE + verified (15 modules)
 
 ### Trunk / Tier A — the learning brain (main repo, bash-parity tests)
 | module | python | test | notes |
@@ -32,3 +32,25 @@ config_resolve · rho_aggregator — 7 modules, ~700 LOC. Resumable loop:
 ## Test all ported trunk modules
     cd <repo> && python3 -m pytest tests/unit/test_cache_py.py \
       tests/unit/test_trace_store_py.py tests/unit/test_lane_router_py.py -q
+
+## Session 2 additions (Fable, committed on feat/python-migration)
+| module | python | test | notes |
+|---|---|---|---|
+| coalition_gate.sh | mini_ork/ported/coalition_gate.py | test_coalition_gate_py.py (3) | rho taken as input; measure_rho port deferred |
+| decision_service.sh | mini_ork/ported/decision_service.py | test_decision_service_py.py (3) | full decide() surface; composes ported lane_router |
+| epic_graph.sh | mini_ork/ported/epic_graph.py | test_epic_graph_py.py (4) | dep DAG + cascade |
+| mini-ork-scheduler | mini_ork/scheduler.py | test_scheduler_py.py (4) | **win #1 landed**: run_pool() concurrent epic pool (MO_SCHED_MAX_PARALLEL) |
+| cost_pause.sh | mini_ork/ported/cost_pause.py | test_cost_pause_py.py (2) | window-crossing pause + sentinel |
+
+Also landed earlier on this branch: win #3 (mo_grade_run_reward: rubric 0-8 ->
+graded reward_g, bash+python), lane-fallback hang-proofing (dispatch_with_fallback
++ role-aware chains in executor).
+
+## REMAINING (trunk)
+- context_assembler.sh (713) — 7 independent context_*_md functions; portable one-by-one
+- reflection_pipeline.sh (358) + gradient_extractor.sh (379) + bin/mini-ork-reflect (247)
+- bin/mini-ork-execute (2942) + bin/mini-ork-plan (1077) — the big loop, last
+- llm-dispatch.sh remainder (tool-summary sidecar; then flip MO_DISPATCH_BACKEND default)
+- assorted leaves: workflow_lifecycle, operator_steering, steering_checkpoint,
+  mid_node_injector, role_evolver, runs-tracker, spec-split, artifact_contract,
+  reflection-refiner, cross_epic_gradient

--- a/docs/_meta/python-migration-tracker.md
+++ b/docs/_meta/python-migration-tracker.md
@@ -1,0 +1,34 @@
+# Bash → Python migration tracker (ADR-001)
+
+Strangler-fig: bash stays until each Python port is parity-verified against the
+LIVE bash. Every ported module has a test that invokes the real bash function.
+
+## DONE + verified (10 modules)
+
+### Trunk / Tier A — the learning brain (main repo, bash-parity tests)
+| module | python | test | notes |
+|---|---|---|---|
+| cache.sh | `mini_ork/cache.py` | `test_cache_py.py` (7) | **win #2**: dropped `iter` from match → cross-iteration hits; widened stage set. Proven vs bash (bash misses cross-iter). |
+| trace_store.sh | `mini_ork/trace_store.py` | `test_trace_store_py.py` (3) | reward_g write path; 9-payload reward_g parity. Carries **win #1** natively. |
+| lane_router.sh | `mini_ork/lane_router.py` | `test_lane_router_py.py` (2) | GRPO advantage (shrinkage/EMA/halflife/tiebreak/3-slices) — bit-parity + preferred_lane. |
+
+### Dispatch (Phase 1, earlier this session)
+- `mini_ork/dispatch/` is a live backend behind `MO_DISPATCH_BACKEND=python` in
+  `lib/llm-dispatch.sh` (sidecar contract preserved; codex+opus verified).
+
+### Leaf tier (isolated clone `mo-migrate`, golden-parity tests, autonomous loop)
+process_reward · similarity · utility_function · topology · pricing_strategy ·
+config_resolve · rho_aggregator — 7 modules, ~700 LOC. Resumable loop:
+`/tmp/migrate_resumable.sh` (run in a persistent terminal to finish the tier).
+
+## REMAINING (trunk)
+- **decision_service.sh** (496) — composition; needs deps ported first:
+  coalition_gate.sh, process_reward.sh (done in clone → port to main), config_resolve.sh
+  (done in clone → port), recursive_policy.
+- **Tier B:** finish `llm-dispatch.sh` (tool-summary sidecar, retire bash), `context_assembler.sh` (713, context-engine).
+- **Tier C:** `bin/mini-ork-execute` (2942), `bin/mini-ork-plan` (1077),
+  `bin/mini-ork-reflect` (247), `bin/mini-ork-scheduler` (300 — concurrent-scheduler win).
+
+## Test all ported trunk modules
+    cd <repo> && python3 -m pytest tests/unit/test_cache_py.py \
+      tests/unit/test_trace_store_py.py tests/unit/test_lane_router_py.py -q

--- a/lib/llm-dispatch.sh
+++ b/lib/llm-dispatch.sh
@@ -614,6 +614,25 @@ mo_llm_dispatch() {
   local timeout_s="${4:-1500}"
   local max_turns="${5:-60}"
 
+  # ADR-001 Phase 1: delegate to the Python dispatch layer when opted in
+  # (MO_DISPATCH_BACKEND=python). The Python path reads the prompt over stdin
+  # (E2BIG-proof), fails fast on a missing API key / framework-tree cwd, and
+  # writes the same sidecar contract this bash path does (.last-llm-cost,
+  # .last-llm-duration-ms, <out>.cost). PYTHONPATH pins the package without
+  # changing cwd, so the provider still runs in the (guarded) target cwd.
+  if [ "${MO_DISPATCH_BACKEND:-bash}" = "python" ]; then
+    # Use the executor's role-aware fallback chain when it's for THIS model
+    # (chain leads with $model), so a hung/flaky lead lane routes to the next
+    # lane instead of stalling the run. Otherwise dispatch the single model.
+    local _model_arg="$model"
+    if [ -n "${MO_DISPATCH_CHAIN:-}" ] && [ "${MO_DISPATCH_CHAIN%%,*}" = "$model" ]; then
+      _model_arg="$MO_DISPATCH_CHAIN"
+    fi
+    printf '%s' "$prompt" | PYTHONPATH="${MINI_ORK_ROOT}${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 -m mini_ork.dispatch "$_model_arg" --out "$out_file" --timeout "$timeout_s"
+    return $?
+  fi
+
   local scripts_dir="$MINI_ORK_ROOT/lib/providers"
   local cl_script="$scripts_dir/cl_${model}.sh"
   local err_log="${out_file}.err.log"

--- a/lib/trace_store.sh
+++ b/lib/trace_store.sh
@@ -393,7 +393,51 @@ print(f"artifact attached to {trace_id}", file=sys.stderr)
 PY
 }
 
+# mo_grade_run_reward <run_dir> <run_id>
+#   Close the eval loop (win #3): feed the rubric's GRADED 0-8 run score into the
+#   learning reward instead of letting it be flattened to pass/fail before the
+#   loop sees it. Reads <run_dir>/rubric.json {score 0-8}, normalizes to [0,1],
+#   and stamps it as reward_value on every execution_trace of THIS run with a
+#   fixed neutral anchor 0.5 → reward_g in [-1,+1]. lane_router then learns from
+#   graded run quality (score 8→+1, 4→0, 0→-1), not a binary verdict. This is the
+#   per-run graded score the two-disjoint-eval-worlds gap was missing.
+#   Best-effort; never fails the run. Opt-out: MO_GRADE_RUN_REWARD=0.
+mo_grade_run_reward() {
+  local run_dir="${1:?run_dir required}" run_id="${2:-}"
+  [ "${MO_GRADE_RUN_REWARD:-1}" = "1" ] || return 0
+  [ -n "$run_id" ] || return 0
+  local rubric_path="$run_dir/rubric.json"
+  [ -f "$rubric_path" ] || return 0
+  local _db="${MINI_ORK_DB:-${MINI_ORK_HOME:-.mini-ork}/state.db}"
+  python3 - "$_db" "$run_id" "$rubric_path" <<'PY'
+import json, sqlite3, sys
+db, run_id, rubric_path = sys.argv[1:4]
+try:
+    score = float(json.load(open(rubric_path)).get("score"))
+except (ValueError, TypeError, KeyError, OSError):
+    sys.exit(0)
+val = max(0.0, min(1.0, score / 8.0))        # rubric 0-8 → [0,1]
+anchor = 0.5
+reward_g = (val - anchor) / abs(anchor)      # graded, [-1,+1]
+con = sqlite3.connect(db)
+con.execute("PRAGMA busy_timeout=5000")
+con.execute(
+    "UPDATE execution_traces SET reward_value=?, reward_anchor=?, reward_g=?, "
+    "reward_direction='higher_is_better', reward_primary_metric='rubric_score', "
+    "reward_source='rubric@v1' WHERE run_id=?",
+    (val, anchor, reward_g, run_id),
+)
+n = con.total_changes
+con.commit()
+con.close()
+sys.stderr.write(
+    f"[eval] graded run reward: rubric {score:g}/8 → reward_g {reward_g:+.2f} "
+    f"on {n} trace(s)\n"
+)
+PY
+}
+
 # When invoked directly, emit usage.
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
-  echo "trace_store.sh — source me and call trace_write / trace_get / trace_query / trace_attach_artifact"
+  echo "trace_store.sh — source me and call trace_write / trace_get / trace_query / trace_attach_artifact / mo_grade_run_reward"
 fi

--- a/mini_ork/cache.py
+++ b/mini_ork/cache.py
@@ -1,0 +1,180 @@
+"""Stage-level memoization cache — Python port of lib/cache.sh (trunk, Tier A).
+
+Content-addressed cache: each stage emits a row keyed by
+``(epic_id, stage, input_hash)``. A re-dispatch with the same input bundle hits
+the cache and skips the LLM/verifier call.
+
+MIGRATION NOTE — win #2 (cross-iteration reuse):
+    The bash version put ``iter`` in the lookup predicate, so an identical
+    ``input_hash`` produced at iteration 2 could NOT match the row emitted at
+    iteration 1. In the ×5 recursion loop that meant every verifier tier and the
+    4-model LLM panel fully recomputed each iteration even on byte-identical
+    inputs. This port drops ``iter`` from the MATCH predicate — it is still
+    stored for provenance — so a stable region is embedded once and reused
+    across iterations. The allowed ``stage`` set is also widened to include the
+    verifier tiers + panel so the loop's expensive nodes become cacheable.
+
+Faithful in every other respect: same table, same sha256 bundle hashing
+(0x1e record separator), same 30-day TTL, same reused_count accounting.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import uuid as _uuid
+from datetime import datetime, timedelta, timezone
+
+# Widened vs bash: added the recursion-loop stages so they can be cached.
+ALLOWED_STAGES = frozenset({
+    "spec-author", "spec-reviewer", "mutation-adversary", "mutation-validator",
+    "rubric", "worker", "reviewer", "bdd-runner", "reflection-refiner",
+    # win #2 additions — the expensive recursion-loop nodes:
+    "implementer", "verifier", "tier1", "tier2", "tier3", "tier4-panel",
+})
+_RS = "\x1e"  # record separator, matches bash $'\x1e'
+
+
+def db_path(db: str | None = None) -> str:
+    """MINI_ORK_DB → MINI_ORK_HOME/state.db → .mini-ork/state.db (matches bash)."""
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if env:
+        return env
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+def _conn(db: str | None) -> sqlite3.Connection:
+    return sqlite3.connect(db_path(db))
+
+
+def init_schema(db: str | None = None) -> None:
+    """Create the table + stats view if missing. Idempotent."""
+    stage_list = ",".join(f"'{s}'" for s in sorted(ALLOWED_STAGES))
+    con = _conn(db)
+    try:
+        con.executescript(
+            f"""
+CREATE TABLE IF NOT EXISTS mini_orch_sessions (
+  uuid TEXT PRIMARY KEY, job_id TEXT NOT NULL, epic_id TEXT NOT NULL,
+  iter INTEGER NOT NULL, stage TEXT NOT NULL CHECK (stage IN ({stage_list})),
+  input_hash TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('running','success','failed','resumable')),
+  output_path TEXT, log_path TEXT, cost_usd NUMERIC, turns INTEGER,
+  duration_ms INTEGER,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  expires_at TEXT NOT NULL, reused_count INTEGER NOT NULL DEFAULT 0,
+  prompt_version TEXT
+);
+-- win #2: index no longer leads with iter, so content-hash matches span iters.
+CREATE INDEX IF NOT EXISTS mos_lookup2 ON mini_orch_sessions (
+  epic_id, stage, input_hash, status, expires_at
+);
+CREATE INDEX IF NOT EXISTS mos_gc ON mini_orch_sessions (expires_at);
+"""
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def input_hash(data: bytes | str) -> str:
+    """sha256 hex of the input (parity with `sha256sum | awk '{print $1}'`)."""
+    if isinstance(data, str):
+        data = data.encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_bundle(*args: str) -> str:
+    """Combine files (by content) or literal strings into the canonical hash
+    bundle, each followed by a 0x1e separator — byte-identical to bash."""
+    parts: list[str] = []
+    for arg in args:
+        if os.path.isfile(arg):
+            with open(arg, encoding="utf-8", errors="surrogateescape") as fh:
+                parts.append(fh.read())
+        else:
+            parts.append(arg)
+        parts.append(_RS)
+    return input_hash("".join(parts))
+
+
+def lookup(stage: str, epic: str, input_hash_: str,
+           iter: int | None = None, db: str | None = None) -> str | None:
+    """Return output_path on a cache HIT (success + unexpired), else None.
+
+    win #2: matches on (epic, stage, input_hash) ONLY — ``iter`` is accepted
+    for call-site compatibility but deliberately NOT part of the predicate, so a
+    hash computed in one iteration matches a row emitted in an earlier one.
+    """
+    con = _conn(db)
+    try:
+        row = con.execute(
+            """SELECT output_path FROM mini_orch_sessions
+                WHERE epic_id=? AND stage=? AND input_hash=? AND status='success'
+                  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                ORDER BY updated_at DESC LIMIT 1""",
+            (epic, stage, input_hash_),
+        ).fetchone()
+        return row[0] if row else None
+    finally:
+        con.close()
+
+
+def record_hit(stage: str, epic: str, input_hash_: str, db: str | None = None) -> None:
+    """Bump reused_count on the row that served the hit (iter-agnostic)."""
+    con = _conn(db)
+    try:
+        con.execute(
+            """UPDATE mini_orch_sessions
+                  SET reused_count=reused_count+1,
+                      updated_at=strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                WHERE epic_id=? AND stage=? AND input_hash=? AND status='success'""",
+            (epic, stage, input_hash_),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def emit(stage: str, epic: str, iter: int, input_hash_: str, status: str,
+         output_path: str, log_path: str, cost_usd: float = 0.0, turns: int = 0,
+         duration_ms: int = 0, prompt_version: str = "v1",
+         db: str | None = None) -> None:
+    """Insert a row at stage completion. ``iter`` is stored for provenance
+    (not used for matching). expires_at = now + 30 days."""
+    expires_at = (datetime.now(timezone.utc) + timedelta(days=30)).strftime(
+        "%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    con = _conn(db)
+    try:
+        con.execute(
+            """INSERT INTO mini_orch_sessions
+                 (uuid, job_id, epic_id, iter, stage, input_hash, status,
+                  output_path, log_path, cost_usd, turns, duration_ms,
+                  expires_at, prompt_version)
+               VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+               ON CONFLICT (uuid) DO NOTHING""",
+            (str(_uuid.uuid4()), os.environ.get("JOB_ID", "unknown"), epic, iter,
+             stage, input_hash_, status, output_path, log_path, cost_usd, turns,
+             duration_ms, expires_at, prompt_version),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def gc(db: str | None = None) -> int:
+    """Delete expired rows. Returns the number removed."""
+    con = _conn(db)
+    try:
+        cur = con.execute(
+            "DELETE FROM mini_orch_sessions "
+            "WHERE expires_at <= strftime('%Y-%m-%dT%H:%M:%fZ','now')")
+        con.commit()
+        return cur.rowcount or 0
+    finally:
+        con.close()

--- a/mini_ork/dispatch/__main__.py
+++ b/mini_ork/dispatch/__main__.py
@@ -35,8 +35,19 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     prompt = sys.stdin.read()
-    request = DispatchRequest(model=args.model, prompt=prompt, timeout_s=args.timeout)
-    result = dispatch_model(request)
+    # `model` may be a comma-separated fallback chain, e.g. "minimax,codex,sonnet":
+    # a hung/flaky primary lane is abandoned and the next is tried, so one bad
+    # lane can't stall the run (MO_DISPATCH_ATTEMPT_TIMEOUT_S bounds each try).
+    lanes = [m.strip() for m in args.model.split(",") if m.strip()]
+    request = DispatchRequest(model=lanes[0], prompt=prompt, timeout_s=args.timeout)
+    if len(lanes) > 1:
+        from .providers import dispatch_with_fallback
+        _att = os.environ.get("MO_DISPATCH_ATTEMPT_TIMEOUT_S")
+        result = dispatch_with_fallback(
+            request, lanes,
+            per_attempt_timeout_s=float(_att) if _att else None)
+    else:
+        result = dispatch_model(request)
 
     # Emit the assistant body to the caller (out-file or stdout).
     if args.out:
@@ -48,6 +59,33 @@ def main(argv: list[str] | None = None) -> int:
             return 127
     else:
         sys.stdout.write(result.text)
+
+    # Sidecar contract the bash executor + reward path depend on (parity with
+    # lib/llm-dispatch.sh mo_llm_dispatch): <out>.cost per-call cost, <out>.err.log
+    # on failure, and $MINI_ORK_RUN_DIR/.last-llm-cost + .last-llm-duration-ms
+    # (read by bin/mini-ork-execute:_trace_write_node_rich and the D-022 cost
+    # charger). Best-effort — never changes the exit code.
+    if args.out:
+        try:
+            with open(args.out + ".cost", "w", encoding="utf-8") as fh:
+                fh.write(f"{result.cost_usd:.6f}")
+        except OSError:
+            pass
+        if not result.ok and result.error:
+            try:
+                with open(args.out + ".err.log", "w", encoding="utf-8") as fh:
+                    fh.write(result.error.rstrip() + "\n")
+            except OSError:
+                pass
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    if run_dir and os.path.isdir(run_dir):
+        try:
+            with open(os.path.join(run_dir, ".last-llm-cost"), "w", encoding="utf-8") as fh:
+                fh.write(f"{result.cost_usd:.6f}")
+            with open(os.path.join(run_dir, ".last-llm-duration-ms"), "w", encoding="utf-8") as fh:
+                fh.write(str(result.duration_ms))
+        except OSError:
+            pass
 
     # Persist telemetry (best-effort; never changes the exit code).
     db = os.environ.get("MINI_ORK_DB", "")

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -407,6 +407,60 @@ def _dispatch_codex_via_wrapper(
                 pass
 
 
+def dispatch_with_fallback(
+    request: DispatchRequest,
+    lanes: Sequence[str],
+    root: str | os.PathLike[str] | None = None,
+    *,
+    per_attempt_timeout_s: float | None = None,
+) -> DispatchResult:
+    """Dispatch ``request`` trying each lane in ``lanes`` in order, returning the
+    first result that succeeds with non-empty output. A lane that fails preflight
+    (dead/unset key), times out (a HUNG lane — the recurring stall), returns a
+    non-zero rc, or emits empty text is abandoned and the next lane is tried.
+
+    This is the fix for the single biggest reliability failure: one flaky/hung
+    lane (codex flaky in some envs, glm/kimi/minimax gateways hang in others)
+    blocking a whole run for the full 25-min timeout with no recovery. With a
+    fallback chain, a hung lane costs one attempt-timeout and the run continues
+    on a healthy lane instead of stalling delivery.
+
+    Returns the last failed result if every lane fails (so the caller still sees
+    a faithful rc/error, never a silent hang).
+    """
+    import sys
+
+    last: DispatchResult | None = None
+    tried: list[str] = []
+    for i, lane in enumerate(lanes):
+        req = DispatchRequest(
+            model=lane,
+            prompt=request.prompt,
+            timeout_s=per_attempt_timeout_s or request.timeout_s,
+            max_turns=request.max_turns,
+            env=dict(request.env),
+            cwd=request.cwd,
+        )
+        result = dispatch_model(req, root)
+        tried.append(lane)
+        if result.ok and (result.text or "").strip():
+            if i > 0:
+                sys.stderr.write(
+                    f"[dispatch] lane fallback: {'/'.join(tried[:-1])} failed → "
+                    f"served by {lane}\n"
+                )
+            return result
+        sys.stderr.write(
+            f"[dispatch] lane {lane} failed (rc={result.rc} "
+            f"{(result.error or 'empty output')[:80]}); trying next\n"
+        )
+        last = result
+    if last is None:
+        return DispatchResult(ok=False, rc=2, error="no lanes provided",
+                              model=request.model)
+    return last
+
+
 def dispatch_with_command(
     request: DispatchRequest,
     command: Sequence[str],

--- a/mini_ork/lane_router.py
+++ b/mini_ork/lane_router.py
@@ -1,0 +1,330 @@
+"""GRPO relative-advantage lane routing — Python port of lib/lane_router.sh (Tier A).
+
+relative_advantage[i] = score[i] - mean(group), score = normalized reward_g
+(NULL rows skipped), grouped by (objective_domain, task_class, node_type,
+code_region). Refinements preserved exactly: per-group shrinkage (K=5), EMA
+blend with prior (α=0.30), recency halflife (14d), cost tie-break on flat
+groups, and the decayed defect-attribution penalty on the region slice.
+Faithful extraction of the bash heredoc; env knobs unchanged.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import math
+import os
+import sqlite3
+from collections import defaultdict
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB") or os.environ.get("MO_STORE_DB")
+    if env:
+        return env
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+def recompute_advantages(since: int = 0, db: str | None = None) -> int:
+    since_iso = datetime.datetime.utcfromtimestamp(int(since)).strftime(
+        "%Y-%m-%dT%H:%M:%S.000Z")
+
+    SHRINK_K = int(os.environ.get("MO_LEARNING_SHRINKAGE_K", "5"))
+    DECAY_ALPHA = float(os.environ.get("MO_LEARNING_DECAY_ALPHA", "0.30"))
+    HALFLIFE = float(os.environ.get("MO_LEARNING_HALFLIFE_DAYS", "14"))
+    TIEBREAK = int(os.environ.get("MO_LEARNING_TIEBREAK", "1"))
+
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+
+    cols = {row[1] for row in con.execute("PRAGMA table_info(execution_traces)").fetchall()}
+    code_region_expr = "code_region" if "code_region" in cols else "NULL AS code_region"
+    ts_expr = "created_at" if "created_at" in cols else "NULL AS created_at"
+    cost_expr = "cost_usd" if "cost_usd" in cols else "0.0 AS cost_usd"
+
+    prior_apm, prior_domain, prior_region = {}, {}, {}
+    try:
+        for row in con.execute(
+                "SELECT agent_version_id, task_class, relative_advantage "
+                "FROM agent_performance_memory").fetchall():
+            prior_apm[(row[0], row[1])] = row[2]
+    except Exception:
+        pass
+
+    con.execute("""CREATE TABLE IF NOT EXISTS lane_domain_advantage (
+          agent_version_id TEXT NOT NULL, task_class TEXT NOT NULL,
+          node_type TEXT NOT NULL DEFAULT '', objective_domain TEXT NOT NULL DEFAULT '',
+          relative_advantage REAL NOT NULL DEFAULT 0.0, runs_count INTEGER NOT NULL DEFAULT 0,
+          success_count INTEGER NOT NULL DEFAULT 0,
+          last_updated TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+          PRIMARY KEY (agent_version_id, task_class, node_type, objective_domain))""")
+    try:
+        for row in con.execute(
+                "SELECT agent_version_id, task_class, node_type, objective_domain, "
+                "relative_advantage FROM lane_domain_advantage").fetchall():
+            prior_domain[(row[0], row[1], row[2], row[3])] = row[4]
+    except Exception:
+        pass
+
+    con.execute("""CREATE TABLE IF NOT EXISTS lane_region_advantage (
+          agent_version_id TEXT NOT NULL, task_class TEXT NOT NULL,
+          node_type TEXT NOT NULL DEFAULT '', objective_domain TEXT NOT NULL DEFAULT '',
+          code_region TEXT NOT NULL DEFAULT '', relative_advantage REAL NOT NULL DEFAULT 0.0,
+          runs_count INTEGER NOT NULL DEFAULT 0, success_count INTEGER NOT NULL DEFAULT 0,
+          last_updated TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+          PRIMARY KEY (agent_version_id, task_class, node_type, objective_domain, code_region))""")
+    con.execute("""CREATE INDEX IF NOT EXISTS idx_lane_region_adv ON lane_region_advantage(
+          task_class, node_type, objective_domain, code_region, relative_advantage DESC)""")
+    try:
+        for row in con.execute(
+                "SELECT agent_version_id, task_class, node_type, objective_domain, "
+                "code_region, relative_advantage FROM lane_region_advantage").fetchall():
+            prior_region[(row[0], row[1], row[2], row[3], row[4])] = row[5]
+    except Exception:
+        pass
+
+    rows = con.execute(f"""
+        SELECT objective_domain, task_class, agent_version_id, verifier_output,
+               reward_g, {code_region_expr}, {ts_expr}, {cost_expr}
+          FROM execution_traces
+         WHERE created_at >= ? AND task_class IS NOT NULL AND task_class <> ''
+           AND agent_version_id IS NOT NULL AND agent_version_id <> ''
+           AND objective_domain IS NOT NULL AND objective_domain <> ''
+           AND reward_g IS NOT NULL""", (since_iso,)).fetchall()
+
+    def _node_type(row):
+        try:
+            return (json.loads(row["verifier_output"] or "{}").get("node_type")
+                    or "unknown")
+        except Exception:
+            return "unknown"
+
+    def _parse_ts(raw):
+        if raw is None:
+            return None
+        tsv = str(raw).strip().rstrip("Z").replace("T", " ")
+        for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+            try:
+                return datetime.datetime.strptime(tsv, fmt)
+            except ValueError:
+                continue
+        return None
+
+    groups = defaultdict(list)
+    _now_utc = datetime.datetime.utcnow()
+    for r in rows:
+        keys = r.keys()
+        code_region = (r["code_region"] or "").strip() if "code_region" in keys else ""
+        try:
+            cost = float(r["cost_usd"]) if "cost_usd" in keys and r["cost_usd"] is not None else 0.0
+        except (TypeError, ValueError):
+            cost = 0.0
+        ts = _parse_ts(r["created_at"]) if "created_at" in keys else None
+        if HALFLIFE > 0 and ts is not None:
+            age_days = max((_now_utc - ts).total_seconds() / 86400.0, 0.0)
+            w = math.exp(-math.log(2) * age_days / HALFLIFE)
+        else:
+            w = 1.0
+        groups[(r["objective_domain"], r["task_class"], _node_type(r), code_region)].append(
+            {"lane": r["agent_version_id"], "score": float(r["reward_g"]),
+             "task_class": r["task_class"], "cost": cost, "weight": w})
+
+    acc = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0,
+                               "node_types": defaultdict(int),
+                               "objective_domains": defaultdict(int)})
+    acc_domain = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0})
+    acc_region = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0})
+    for (_od, _tc, _nt, _cr), members in groups.items():
+        if len(members) < 2:
+            continue
+        sum_w = sum(m["weight"] for m in members)
+        if sum_w <= 0:
+            continue
+        wmean = sum(m["weight"] * m["score"] for m in members) / sum_w
+        lane_bonus = {}
+        scores = [m["score"] for m in members]
+        if TIEBREAK != 0 and min(scores) == max(scores):
+            costs = [m["cost"] for m in members]
+            lo, hi = min(costs), max(costs)
+            if lo != hi:
+                for m in members:
+                    lane_bonus[m["lane"]] = 0.1 - 0.2 * (m["cost"] - lo) / (hi - lo)
+        by_lane = defaultdict(lambda: {"ws": 0.0, "w": 0.0, "n": 0})
+        for m in members:
+            b = by_lane[m["lane"]]
+            b["ws"] += m["weight"] * m["score"]
+            b["w"] += m["weight"]
+            b["n"] += 1
+        for lane, b in by_lane.items():
+            lane_mean = b["ws"] / b["w"] if b["w"] > 0 else 0.0
+            lane_adv = lane_mean - wmean + lane_bonus.get(lane, 0.0)
+            n_in_group = b["n"]
+            shrink_factor = n_in_group / (n_in_group + SHRINK_K) if SHRINK_K > 0 else 1.0
+            shrunken = lane_adv * shrink_factor
+            wins = 1 if lane_adv > 0 else 0
+            a = acc[(lane, _tc)]
+            a["shr_sum"] += shrunken
+            a["groups"] += 1
+            a["wins"] += wins
+            a["node_types"][_nt] += 1
+            a["objective_domains"][_od] += 1
+            d = acc_domain[(lane, _tc, _nt, _od)]
+            d["shr_sum"] += shrunken
+            d["groups"] += 1
+            d["wins"] += wins
+            if _cr:
+                rr = acc_region[(lane, _tc, _nt, _od, _cr)]
+                rr["shr_sum"] += shrunken
+                rr["groups"] += 1
+                rr["wins"] += wins
+
+    _penalty_by_key = defaultdict(float)
+    try:
+        has_defect = con.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' "
+            "AND name='defect_attributions' LIMIT 1").fetchone()
+    except Exception:
+        has_defect = None
+    if has_defect:
+        _now_utc = datetime.datetime.utcnow()
+        for pr in con.execute(
+                "SELECT lane, code_region, task_class, penalty, decay_halflife_days, ts "
+                "FROM defect_attributions WHERE penalty IS NOT NULL AND penalty <> 0").fetchall():
+            try:
+                pen = float(pr["penalty"])
+                hlf = float(pr["decay_halflife_days"]) if pr["decay_halflife_days"] is not None else 30.0
+            except (TypeError, ValueError):
+                continue
+            if hlf <= 0:
+                continue
+            tsv = str(pr["ts"]).strip().rstrip("Z").replace("T", " ")
+            ts = None
+            for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+                try:
+                    ts = datetime.datetime.strptime(tsv, fmt)
+                    break
+                except ValueError:
+                    ts = None
+            if ts is None:
+                continue
+            age_days = max((_now_utc - ts).total_seconds() / 86400.0, 0.0)
+            _penalty_by_key[(pr["lane"], pr["code_region"], pr["task_class"])] += pen * (0.5 ** (age_days / hlf))
+
+    def _ema(prior, batch):
+        if prior is None or DECAY_ALPHA >= 1.0:
+            return batch
+        if DECAY_ALPHA <= 0.0:
+            return prior
+        try:
+            p = float(prior)
+        except (TypeError, ValueError):
+            return batch
+        return DECAY_ALPHA * batch + (1.0 - DECAY_ALPHA) * p
+
+    upserted = 0
+    for (lane, tc), stats in acc.items():
+        if stats["groups"] <= 0:
+            continue
+        new_rel_adv = _ema(prior_apm.get((lane, tc)), stats["shr_sum"] / stats["groups"])
+        top_node = (max(stats["node_types"].items(), key=lambda kv: kv[1])[0]
+                    if stats["node_types"] else None)
+        con.execute("""INSERT INTO agent_performance_memory
+                (agent_version_id, role, model, task_class, runs_count, success_count,
+                 relative_advantage, last_updated)
+                VALUES (?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                ON CONFLICT(agent_version_id, task_class) DO UPDATE SET
+                role=excluded.role, model=excluded.model, runs_count=excluded.runs_count,
+                success_count=excluded.success_count,
+                relative_advantage=excluded.relative_advantage, last_updated=excluded.last_updated""",
+                    (lane, top_node or lane, lane, tc, stats["groups"], stats["wins"],
+                     round(new_rel_adv, 4)))
+        upserted += 1
+
+    for (lane, tc, nt, od), stats in acc_domain.items():
+        if stats["groups"] <= 0:
+            continue
+        new_rel_adv = _ema(prior_domain.get((lane, tc, nt or "", od or "")),
+                           stats["shr_sum"] / stats["groups"])
+        con.execute("""INSERT INTO lane_domain_advantage
+                (agent_version_id, task_class, node_type, objective_domain,
+                 relative_advantage, runs_count, success_count, last_updated)
+                VALUES (?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                ON CONFLICT(agent_version_id, task_class, node_type, objective_domain)
+                DO UPDATE SET relative_advantage=excluded.relative_advantage,
+                runs_count=excluded.runs_count, success_count=excluded.success_count,
+                last_updated=excluded.last_updated""",
+                    (lane, tc, nt or "", od or "", round(new_rel_adv, 4),
+                     stats["groups"], stats["wins"]))
+
+    for (lane, tc, nt, od, cr), stats in acc_region.items():
+        if stats["groups"] <= 0:
+            continue
+        new_rel_adv = _ema(prior_region.get((lane, tc, nt or "", od or "", cr or "")),
+                           stats["shr_sum"] / stats["groups"])
+        if cr:
+            new_rel_adv += _penalty_by_key.get((lane, cr, tc), 0.0)
+        con.execute("""INSERT INTO lane_region_advantage
+                (agent_version_id, task_class, node_type, objective_domain, code_region,
+                 relative_advantage, runs_count, success_count, last_updated)
+                VALUES (?,?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                ON CONFLICT(agent_version_id, task_class, node_type, objective_domain, code_region)
+                DO UPDATE SET relative_advantage=excluded.relative_advantage,
+                runs_count=excluded.runs_count, success_count=excluded.success_count,
+                last_updated=excluded.last_updated""",
+                    (lane, tc, nt or "", od or "", cr or "", round(new_rel_adv, 4),
+                     stats["groups"], stats["wins"]))
+
+    con.commit()
+    con.close()
+    return upserted
+
+
+def preferred_lane(task_class: str, node_type: str = "", objective_domain: str = "",
+                   code_region: str = "", db: str | None = None) -> str:
+    """Highest-advantage lane for the slice (sample floor MO_LEARNING_MIN_SAMPLES,
+    default 3). Region → domain → global, matching bash. Returns
+    'lane|adv|runs' (bash's pipe format) or '' when no slice clears the floor."""
+    min_samples = int(os.environ.get("MO_LEARNING_MIN_SAMPLES", "3"))
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    try:
+        if objective_domain and code_region:
+            where = ("task_class=? AND objective_domain=? AND code_region=? AND runs_count>=?")
+            params = [task_class, objective_domain, code_region, min_samples]
+            if node_type:
+                where += " AND node_type=?"
+                params.append(node_type)
+            row = con.execute(
+                f"SELECT agent_version_id, printf('%.3f', relative_advantage), runs_count "
+                f"FROM lane_region_advantage WHERE {where} "
+                f"ORDER BY relative_advantage DESC, runs_count DESC LIMIT 1", params).fetchone()
+            if row:
+                return f"{row[0]}|{row[1]}|{row[2]}"
+        if objective_domain:
+            where = "task_class=? AND objective_domain=? AND runs_count>=?"
+            params = [task_class, objective_domain, min_samples]
+            if node_type:
+                where += " AND node_type=?"
+                params.append(node_type)
+            row = con.execute(
+                f"SELECT agent_version_id, printf('%.3f', relative_advantage), runs_count "
+                f"FROM lane_domain_advantage WHERE {where} "
+                f"ORDER BY relative_advantage DESC, runs_count DESC LIMIT 1", params).fetchone()
+            if row:
+                return f"{row[0]}|{row[1]}|{row[2]}"
+        where = "task_class=? AND runs_count>=?"
+        params = [task_class, min_samples]
+        if node_type:
+            where += " AND (role=? OR model=?)"
+            params += [node_type, node_type]
+        row = con.execute(
+            f"SELECT agent_version_id, printf('%.3f', relative_advantage), runs_count "
+            f"FROM agent_performance_memory WHERE {where} "
+            f"ORDER BY relative_advantage DESC, runs_count DESC LIMIT 1", params).fetchone()
+        return f"{row[0]}|{row[1]}|{row[2]}" if row else ""
+    finally:
+        con.close()

--- a/mini_ork/learning/__init__.py
+++ b/mini_ork/learning/__init__.py
@@ -1,0 +1,7 @@
+"""Mini-ork learning primitives.
+
+Reusable reward-shaping and trace-scoring modules extracted from the bash
+runtime so the Python facade can score traces without shelling out. Each
+module in this package is a faithful port of its bash counterpart in
+``lib/``; parity is enforced by tests under ``tests/unit/``.
+"""

--- a/mini_ork/learning/process_reward.py
+++ b/mini_ork/learning/process_reward.py
@@ -1,0 +1,136 @@
+"""Process Reward Model (PRM) heuristic — faithful Python port.
+
+Faithful port of ``lib/process_reward.sh::prm_score_trace``. Approximates a
+per-node reward in ``[0.0, 1.0]`` from observable trace signals. The bash
+function remains the canonical scorer (this module co-exists via the
+strangler-fig pattern) and parity is enforced by
+``tests/unit/test_process_reward_parity.py`` which invokes the live bash
+function and compares scores within ``1e-6``.
+
+Weight table (mirrors ``prm_score_trace`` and ``prm_backfill`` verbatim —
+do not edit one without the other):
+
+================  ======  ==================================================
+Signal            Weight  Trigger
+================  ======  ==================================================
+status            0.40    ``trace["status"] == "success"``
+tool_calls        0.20    ``len(json.loads(tool_calls)) > 0``     [capped]
+files_read/written 0.10   ``len(json.loads(...)) > 0``           [capped]
+reviewer_verdict  0.15    lower-cased verdict in {approve, approved,
+                           pass, success, ok} AND status == success
+duration_ms       0.10    ``1000 <= duration_ms <= 600000``
+cost_usd          0.05    ``cost_usd > 0``
+================  ======  ==================================================
+
+Activity cap (Goodhart guard): combined ``tool_calls + files_read +
+files_written`` contribution is clamped at ``ACTIVITY_CAP=0.15`` by default
+so a noisy failed trace with high activity cannot outscore a bare-success
+trace. Set ``MO_PRM_ACTIVITY_CAP=0`` to reproduce the legacy uncapped
+weighting for A/B comparison.
+
+Same-family decontamination is INTENTIONALLY ABSENT: the doer's lane is
+not a valid proxy for the reviewer's lane without a real ``reviewer_model``
+column in ``execution_traces``. Re-introducing it here would diverge from
+bash and break parity. See the FE note in ``lib/process_reward.sh``.
+
+Public API::
+
+    from mini_ork.learning.process_reward import score_trace
+
+    score = score_trace({
+        "status": "success",
+        "tool_calls": "[{...}]",
+        "files_written": "[]",
+        "reviewer_verdict": "approve",
+        "duration_ms": 4200,
+        "cost_usd": 0.012,
+    })
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+W_STATUS = 0.40
+W_TOOL = 0.20
+W_FILE = 0.10
+W_VERDICT = 0.15
+W_DURATION = 0.10
+W_COST = 0.05
+ACTIVITY_CAP = 0.15
+
+_VERDICT_SET = {"approve", "approved", "pass", "success", "ok"}
+
+
+def _len_json(s):
+    """Parse ``s`` as JSON and return ``len`` if the result is list/dict.
+
+    Returns ``0`` for ``None``, unparseable input, or non-container values
+    (e.g. JSON-encoded strings, numbers, booleans). Mirrors bash's
+    ``_len_json`` inside ``prm_score_trace``.
+    """
+    try:
+        v = json.loads(s or "[]")
+        return len(v) if isinstance(v, (list, dict)) else 0
+    except (TypeError, ValueError):
+        return 0
+
+
+def _activity_cap_enabled() -> bool:
+    """Mirror bash: ``MO_PRM_ACTIVITY_CAP=0`` disables; any other value (incl.
+    unparseable) leaves the default cap-on behavior intact.
+    """
+    raw = os.environ.get("MO_PRM_ACTIVITY_CAP", "1")
+    try:
+        return int(raw) != 0
+    except ValueError:
+        return True
+
+
+def score_trace(trace: dict) -> float:
+    """Compute the PRM score for a single trace row.
+
+    ``trace`` is a dict that mirrors the ``execution_traces`` row schema
+    consumed by bash ``prm_score_trace``. The fields ``tool_calls``,
+    ``files_written``, ``files_read`` are expected as JSON strings (the
+    SQLite ``TEXT`` representation); pass the row dict as-is.
+
+    Returns a float in ``[0.0, 1.0]`` rounded to 4 decimal places.
+    """
+    score = 0.0
+    status_success = (trace.get("status") or "") == "success"
+    if status_success:
+        score += W_STATUS
+
+    tool_n = _len_json(trace.get("tool_calls"))
+    file_n = _len_json(trace.get("files_written")) + _len_json(trace.get("files_read"))
+    activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
+    if _activity_cap_enabled():
+        activity = min(activity, ACTIVITY_CAP)
+    score += activity
+
+    verdict_lower = (trace.get("reviewer_verdict") or "").lower()
+    if status_success and verdict_lower in _VERDICT_SET:
+        score += W_VERDICT
+
+    dur = int(trace.get("duration_ms") or 0)
+    if 1000 <= dur <= 600000:
+        score += W_DURATION
+
+    if float(trace.get("cost_usd") or 0) > 0:
+        score += W_COST
+
+    return round(min(1.0, max(0.0, score)), 4)
+
+
+__all__ = [
+    "ACTIVITY_CAP",
+    "W_COST",
+    "W_DURATION",
+    "W_FILE",
+    "W_STATUS",
+    "W_TOOL",
+    "W_VERDICT",
+    "score_trace",
+]

--- a/mini_ork/ported/__init__.py
+++ b/mini_ork/ported/__init__.py
@@ -1,0 +1,9 @@
+"""Mini-ork ported modules.
+
+Faithful Python ports of the deterministic, pure-logic core of bash functions
+in ``lib/``. The bash wrappers in ``lib/`` stay in place (strangler-fig
+co-existence); these ports give Python callers an in-process target and give
+tests a stable surface for parity verification against the live bash.
+
+Parity is enforced by tests under ``tests/unit/test_*_parity.py``.
+"""

--- a/mini_ork/ported/coalition_gate.py
+++ b/mini_ork/ported/coalition_gate.py
@@ -1,0 +1,132 @@
+"""Panel family-diversity + rho coalition gate — Python port of lib/coalition_gate.sh.
+
+Faithful port of the family-distribution query + the verdict logic. `rho` is taken
+as an input parameter: it is measured by lib/topology_metrics.sh::measure_rho, which
+is not yet ported — check_panel_coalition accepts the measured value (default 0.0,
+matching the fail-open path). Verdict semantics match the bash exactly:
+  lens_count < 2                         -> panel_diverse (single_agent_run)
+  rho < threshold AND family_count==lens -> panel_diverse (ok)
+  else strict                            -> COALITION_ABORT (rc=1)
+  else advisory                          -> panel_diverse (advisory_*)
+"""
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+
+LANE_TO_FAMILY = {
+    "sonnet": "anthropic", "opus": "anthropic",
+    "glm": "zhipu", "glm_lens": "zhipu",
+    "kimi": "moonshot", "kimi_lens": "moonshot",
+    "codex": "openai", "codex_lens": "openai",
+    "deepseek": "deepseek", "decomposer": "deepseek",
+    "gemini": "google",
+    "minimax": "minimax", "minimax_lens": "minimax",
+}
+
+
+def _load_lane_map(agents_yaml: str | None) -> dict[str, str]:
+    m = dict(LANE_TO_FAMILY)
+    if not agents_yaml or not os.path.exists(agents_yaml):
+        return m
+    try:
+        import yaml  # type: ignore
+        cfg = yaml.safe_load(open(agents_yaml, encoding="utf-8")) or {}
+        for lane, fam in (cfg.get("lanes") or {}).items():
+            m.setdefault(lane.lower(), str(fam).lower())
+    except ImportError:
+        in_lanes = False
+        for line in open(agents_yaml, encoding="utf-8"):
+            line = line.rstrip()
+            if re.match(r"^lanes:\s*$", line):
+                in_lanes = True
+                continue
+            if in_lanes:
+                if line and not line.startswith((" ", "\t")):
+                    in_lanes = False
+                    continue
+                mm = re.match(r"^\s+([\w_-]+):\s*([\w_-]+)\s*$", line)
+                if mm:
+                    m.setdefault(mm.group(1).lower(), mm.group(2).lower())
+    return m
+
+
+def family_of(version_id: str, lane_map: dict[str, str] | None = None) -> str:
+    if not version_id:
+        return "unknown"
+    lm = lane_map or LANE_TO_FAMILY
+    base = version_id.split("-")[0].lower()
+    return lm.get(base, base)
+
+
+def family_distribution(db: str, panel_run_id: str, agents_yaml: str | None = None) -> dict:
+    lm = _load_lane_map(agents_yaml)
+    con = sqlite3.connect(db)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT trace_id, agent_version_id FROM execution_traces "
+        "WHERE trace_id LIKE ? OR trace_id LIKE ?",
+        (f"%{panel_run_id}%", f"tr-%-{panel_run_id}%"),
+    ).fetchall()
+    con.close()
+    lenses = [r["agent_version_id"] for r in rows if r["agent_version_id"]]
+    distrib: dict[str, int] = {}
+    for v in lenses:
+        f = family_of(v, lm)
+        distrib[f] = distrib.get(f, 0) + 1
+    return {"lens_count": len(lenses), "family_count": len(distrib),
+            "family_distribution": distrib}
+
+
+def coalition_verdict(rho: float, rho_threshold: float, lens_count: int,
+                      family_count: int, distrib: dict, mode: str = "strict") -> dict:
+    base = {"rho": rho, "rho_threshold": rho_threshold, "lens_count": lens_count,
+            "family_count": family_count, "family_distribution": distrib}
+    if lens_count < 2:
+        return {**base, "verdict": "panel_diverse", "reason": "single_agent_run",
+                "rationale": ("fewer than 2 lens traces present — coalition check "
+                              "not applicable")}
+    high_rho = rho >= rho_threshold
+    collision = family_count < lens_count
+    if not high_rho and not collision:
+        return {**base, "verdict": "panel_diverse", "reason": "ok",
+                "rationale": (f"ρ={rho:.3f} < {rho_threshold:.3f}, "
+                              f"family_count={family_count} == lens_count="
+                              f"{lens_count} — panel is family-diverse")}
+    reason = "both" if (high_rho and collision) else (
+        "high_rho" if high_rho else "family_collision")
+    parts = []
+    if high_rho:
+        parts.append(f"ρ={rho:.3f} >= {rho_threshold:.3f} "
+                     "(Rajan 2025 submodularity ceiling)")
+    if collision:
+        parts.append(f"family_count={family_count} < lens_count={lens_count} "
+                     "(Bertalanič 2026 family-diversity precondition violated)")
+    if mode.lower() == "advisory":
+        return {**base, "verdict": "panel_diverse", "reason": f"advisory_{reason}",
+                "advisory_note": "; ".join(parts),
+                "rationale": ("MO_FAMILY_DIVERSITY_GATE=advisory — emitting warning "
+                              "but proceeding with synthesis")}
+    return {**base, "verdict": "COALITION_ABORT", "reason": reason,
+            "rationale": "; ".join(parts),
+            "remediation": ("widen family diversity in config/agents.yaml (one "
+                            "lane per family), OR accept the coalition-flagged "
+                            "lens reports without synthesis, OR set "
+                            "MO_FAMILY_DIVERSITY_GATE=advisory to bypass")}
+
+
+def check_panel_coalition(panel_run_id: str, recipe: str, rho: float = 0.0,
+                          db: str | None = None, agents_yaml: str | None = None,
+                          rho_threshold: float | None = None,
+                          mode: str | None = None) -> tuple[dict, int]:
+    """Compose the gate. `rho` comes from measure_rho (passed in). Returns
+    (verdict_dict, rc) where rc=1 on COALITION_ABORT (matches bash exit code)."""
+    db = db or os.environ.get("MINI_ORK_DB")
+    if rho_threshold is None:
+        rho_threshold = float(os.environ.get("MO_RHO_THRESHOLD", "0.25"))
+    mode = mode or os.environ.get("MO_FAMILY_DIVERSITY_GATE", "strict")
+    dist = family_distribution(db, panel_run_id, agents_yaml)
+    v = coalition_verdict(rho, rho_threshold, dist["lens_count"],
+                          dist["family_count"], dist["family_distribution"], mode)
+    return v, (1 if v["verdict"] == "COALITION_ABORT" else 0)

--- a/mini_ork/ported/config_resolve.py
+++ b/mini_ork/ported/config_resolve.py
@@ -1,0 +1,94 @@
+"""Pure-logic port of ``lib/config_resolve.sh``.
+
+Faithful port of the per-run config isolation pattern (roadmap T1.0):
+each run FREEZES its launch-time lane policy by snapshotting the
+global agents.yaml into ``run_dir/config/`` at launch, and every
+dispatch-time resolver reads ``run_dir/config/`` FIRST. This is the
+first concrete slice of the actor-per-run isolation epic — a design
+pattern (not a band-aid) that survives the Bash→Python migration.
+
+Strangler-fig co-existence: ``lib/config_resolve.sh`` is byte-identical
+before and after this module exists.
+``tests/unit/test_config_resolve_parity.py`` is the gate that proves the
+port produces byte-identical stdout and filesystem state against the
+live bash subprocess (no mocking).
+
+Public API::
+
+    from mini_ork.ported.config_resolve import (
+        resolve_agents_yaml,    # effective agents.yaml path, run-dir first
+        snapshot_run_config,    # freeze launch-time policy into <run_dir>
+    )
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def resolve_agents_yaml() -> None:
+    """Echo the EFFECTIVE agents.yaml path, run-dir first.
+
+    Precedence: ``$MINI_ORK_RUN_DIR/config/agents.yaml`` →
+    ``$MINI_ORK_HOME/config/agents.yaml`` (default ``.mini-ork``) →
+    ``$MINI_ORK_ROOT/config/agents.yaml`` (default ``.``).
+
+    Always echoes a non-empty path. Callers ``[ -f ]``-guard the
+    "not configured" case. Prints ``path + "\\n"`` to stdout, mirroring
+    bash's ``printf '%s\\n'``.
+
+    Path strings are constructed with ``os.path.join`` (NOT ``Path /``)
+    so the literal ``./`` prefix is preserved when bash's default
+    root of ``.`` kicks in. ``Path /`` normalises the dot away and
+    would diverge from bash's stdout byte.
+    """
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    if run_dir:
+        candidate = os.path.join(run_dir, "config", "agents.yaml")
+        if Path(candidate).is_file():
+            print(candidate)
+            return
+
+    home = os.environ.get("MINI_ORK_HOME") or ".mini-ork"
+    candidate = os.path.join(home, "config", "agents.yaml")
+    if not Path(candidate).is_file():
+        root = os.environ.get("MINI_ORK_ROOT") or "."
+        candidate = os.path.join(root, "config", "agents.yaml")
+
+    print(candidate)
+
+
+def snapshot_run_config(run_dir: str | None = None) -> bool:
+    """Freeze the effective global agents.yaml into ``run_dir/config/``.
+
+    Idempotent: never overwrites an existing snapshot, so a re-entrant
+    execute keeps the launch-time policy. Best-effort: any failure
+    returns ``True`` (the resolvers fall back to the global file) so
+    it can never break a run. Source is the global home-or-root file,
+    NEVER a run-dir (to avoid a snapshot freezing itself on re-entry).
+    """
+    rd = run_dir if run_dir is not None else os.environ.get("MINI_ORK_RUN_DIR", "")
+    if not rd:
+        return True
+
+    dest = os.path.join(rd, "config", "agents.yaml")
+    if Path(dest).is_file():
+        return True  # already frozen — keep launch-time policy
+
+    home = os.environ.get("MINI_ORK_HOME") or ".mini-ork"
+    src = os.path.join(home, "config", "agents.yaml")
+    if not Path(src).is_file():
+        root = os.environ.get("MINI_ORK_ROOT") or "."
+        src = os.path.join(root, "config", "agents.yaml")
+    if not Path(src).is_file():
+        return True  # nothing to snapshot
+
+    try:
+        Path(os.path.join(rd, "config")).mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+    except (OSError, IOError):
+        return True  # mirror bash's `2>/dev/null || return 0` semantic
+
+    return True

--- a/mini_ork/ported/cost_pause.py
+++ b/mini_ork/ported/cost_pause.py
@@ -1,0 +1,72 @@
+"""Reactive per-run cost pause — Python port of lib/cost_pause.sh.
+
+Pause every MO_PAUSE_EVERY_USD spent (default $25): cumulative spend tracked
+in a .cost-spent sidecar; when the spend crosses into a new threshold window,
+a .cost-pause sentinel is written and rc=2 is returned so the dispatch halts
+until `bin/mini-ork-resume` clears it. Window math matches bash exactly:
+crossed = int(new//thr) > int(prev//thr).
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import os
+
+
+def _sentinel_path(run_id: str) -> str:
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    if run_dir and os.path.isdir(run_dir):
+        return os.path.join(run_dir, ".cost-pause")
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "runs", run_id, ".cost-pause")
+
+
+def check(run_id: str, delta_usd: float) -> int:
+    """rc semantics of mo_cost_pause_check: 0 = proceed, 2 = paused (sentinel
+    written when cumulative spend crosses into a new threshold window)."""
+    if not run_id:
+        return 2
+    threshold = float(os.environ.get("MO_PAUSE_EVERY_USD", "25"))
+    sentinel = _sentinel_path(run_id)
+    spend_file = sentinel[: -len(".cost-pause")] + ".cost-spent"
+
+    prev_spent = 0.0
+    if os.path.isfile(spend_file):
+        try:
+            prev_spent = float(open(spend_file).read().strip() or 0)
+        except (ValueError, OSError):
+            prev_spent = 0.0
+    try:
+        new_spent = prev_spent + float(delta_usd)
+    except (TypeError, ValueError):
+        new_spent = prev_spent
+    os.makedirs(os.path.dirname(spend_file) or ".", exist_ok=True)
+    with open(spend_file, "w") as fh:
+        fh.write(f"{new_spent}\n")
+
+    crossed = int(new_spent // threshold) > int(prev_spent // threshold)
+    if crossed:
+        with open(sentinel, "w") as fh:
+            fh.write(json.dumps({
+                "threshold_usd": threshold, "spent_usd": new_spent,
+                "created_at": datetime.datetime.now(datetime.timezone.utc)
+                    .strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "run_id": run_id,
+            }) + "\n")
+        return 2
+    return 0
+
+
+def status(run_id: str) -> dict:
+    """mo_cost_pause_status: {paused, threshold_usd, spent_usd, sentinel_path}."""
+    threshold = float(os.environ.get("MO_PAUSE_EVERY_USD", "25"))
+    sentinel = _sentinel_path(run_id)
+    spend_file = sentinel[: -len(".cost-pause")] + ".cost-spent"
+    spent = 0.0
+    if os.path.isfile(spend_file):
+        try:
+            spent = float(open(spend_file).read().strip() or 0)
+        except (ValueError, OSError):
+            spent = 0.0
+    return {"paused": os.path.isfile(sentinel), "threshold_usd": threshold,
+            "spent_usd": spent, "sentinel_path": sentinel}

--- a/mini_ork/ported/decision_service.py
+++ b/mini_ork/ported/decision_service.py
@@ -1,0 +1,309 @@
+"""Stateless decision surface — Python port of lib/decision_service.sh.
+
+decide() composes the ported brain modules (lane_router.preferred_lane, the
+coalition family-diversity predicate, the reward-summary read, the recursion
+hint) into the same JSON contract the bash emits:
+
+    {"route", "coalition_ok", "reward_estimate", "recursion_hint",
+     "sample_size", "segment", "code_region"}
+
+Faithful semantics preserved:
+  - routing: learned lane (GRPO sample floor >=3) else agents.yaml default —
+    cold-start never invents a lane;
+  - epsilon-greedy exploration (EPSILON/MO_LEARNING_EPSILON, default 0.10,
+    SEED/MO_LEARNING_SEED for determinism) fires ONLY when a learned route
+    exists (the rlm-4b cold-start invariant);
+  - coalition: slice family-diversity, fail-open;
+  - reward: mean reward_g over the slice, falling back to process_reward;
+  - recursion_hint: env-driven policy slice.
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import re
+import sqlite3
+
+from mini_ork import lane_router
+
+LANE_TO_FAMILY = {
+    "sonnet": "anthropic", "opus": "anthropic",
+    "glm": "zhipu", "glm_lens": "zhipu",
+    "kimi": "moonshot", "kimi_lens": "moonshot",
+    "codex": "openai", "codex_lens": "openai",
+    "deepseek": "deepseek", "decomposer": "deepseek",
+    "gemini": "google",
+    "minimax": "minimax", "minimax_lens": "minimax",
+}
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB") or os.environ.get("MO_STORE_DB")
+    if env:
+        return env
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+def resolve_agents_yaml() -> str:
+    """Run-dir-first agents.yaml path (T1.0 precedence), mirrors
+    mo_resolve_agents_yaml: $MINI_ORK_RUN_DIR/config -> $MINI_ORK_HOME/config
+    -> $MINI_ORK_ROOT/config. Always returns a path."""
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    if run_dir:
+        cand = os.path.join(run_dir, "config", "agents.yaml")
+        if os.path.isfile(cand):
+            return cand
+    cand = os.path.join(os.environ.get("MINI_ORK_HOME") or ".mini-ork",
+                        "config", "agents.yaml")
+    if not os.path.isfile(cand):
+        cand = os.path.join(os.environ.get("MINI_ORK_ROOT") or ".",
+                            "config", "agents.yaml")
+    return cand
+
+
+def _load_lanes(agents_yaml: str) -> dict[str, str]:
+    """lanes: mapping from agents.yaml; pyyaml with regex fallback."""
+    if not os.path.isfile(agents_yaml):
+        return {}
+    try:
+        import yaml  # type: ignore
+        cfg = yaml.safe_load(open(agents_yaml, encoding="utf-8")) or {}
+        return {str(k): str(v) for k, v in (cfg.get("lanes") or {}).items() if v}
+    except ImportError:
+        lanes: dict[str, str] = {}
+        in_lanes = False
+        for line in open(agents_yaml, encoding="utf-8"):
+            line = line.rstrip()
+            if re.match(r"^lanes:\s*$", line):
+                in_lanes = True
+                continue
+            if in_lanes:
+                if line and not line.startswith((" ", "\t")):
+                    break
+                m = re.match(r"^\s+([\w_-]+):\s*([\w_-]+)\s*(#.*)?$", line)
+                if m:
+                    lanes[m.group(1)] = m.group(2)
+        return lanes
+
+
+def default_lane(node_type: str) -> str:
+    """agents.yaml lane for node_type; '' when not configured (never invent)."""
+    return _load_lanes(resolve_agents_yaml()).get(node_type, "")
+
+
+def _explore_route(exploit_route: str, epsilon: float, seed: str,
+                   agents_yaml: str) -> str:
+    """Epsilon-greedy lane swap — faithful to the bash heredoc: seeded RNG when
+    SEED set (int seed if parseable), SystemRandom otherwise; candidates are the
+    deduped agents.yaml lane VALUES excluding the exploit route, chosen from the
+    sorted list for cross-run stability."""
+    epsilon = min(max(epsilon, 0.0), 1.0)
+    if seed:
+        try:
+            rng: random.Random = random.Random(int(seed))
+        except ValueError:
+            rng = random.Random(seed)
+    else:
+        rng = random.SystemRandom()
+    if rng.random() >= epsilon:
+        return exploit_route
+    candidates, seen = [], set()
+    for v in _load_lanes(agents_yaml).values():
+        if not v or v == exploit_route or v in seen:
+            continue
+        seen.add(v)
+        candidates.append(v)
+    return rng.choice(sorted(candidates)) if candidates else exploit_route
+
+
+def coalition_ok(objective_domain: str, task_class: str, node_type: str,
+                 db: str) -> bool:
+    """Slice family-diversity predicate; fail-open on any schema gap."""
+    lane_map = dict(LANE_TO_FAMILY)
+    for ay in (os.path.join(os.environ.get("MINI_ORK_HOME", ".mini-ork"),
+                            "config", "agents.yaml"),
+               os.path.join(os.environ.get("MINI_ORK_ROOT", "."),
+                            "config", "agents.yaml")):
+        if not os.path.isfile(ay):
+            continue
+        try:
+            import yaml  # type: ignore
+            cfg = yaml.safe_load(open(ay, encoding="utf-8")) or {}
+            for k, v in (cfg.get("lanes") or {}).items():
+                lane_map.setdefault(str(k).lower(), str(v).lower())
+        except Exception:
+            pass
+        break
+
+    def family_of(vid):
+        if not vid:
+            return "unknown"
+        base = vid.split("-")[0].lower()
+        return lane_map.get(base, base)
+
+    con = sqlite3.connect(db)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    try:
+        cols = {r[1] for r in con.execute(
+            "PRAGMA table_info(execution_traces)").fetchall()}
+    except sqlite3.OperationalError:
+        con.close()
+        return True
+    if "agent_version_id" not in cols:
+        con.close()
+        return True
+
+    sql = "SELECT agent_version_id FROM execution_traces WHERE task_class = ?"
+    args: list = [task_class]
+    if objective_domain and "objective_domain" in cols:
+        sql += " AND objective_domain = ?"
+        args.append(objective_domain)
+    sql += " AND agent_version_id IS NOT NULL AND agent_version_id <> ''"
+    if "node_type" in cols:
+        sql += " AND node_type = ?"
+        args.append(node_type)
+    try:
+        rows = con.execute(sql, args).fetchall()
+    except sqlite3.OperationalError:
+        con.close()
+        return True
+    lanes = [r["agent_version_id"] for r in rows if r["agent_version_id"]]
+
+    if not rows and "node_type" not in cols:
+        jsql = ("SELECT agent_version_id, verifier_output FROM execution_traces "
+                "WHERE task_class = ?")
+        jargs: list = [task_class]
+        if objective_domain and "objective_domain" in cols:
+            jsql += " AND objective_domain = ?"
+            jargs.append(objective_domain)
+        try:
+            lanes = []
+            for r in con.execute(jsql, jargs).fetchall():
+                try:
+                    vo = json.loads(r["verifier_output"] or "{}")
+                    if vo.get("node_type") == node_type and r["agent_version_id"]:
+                        lanes.append(r["agent_version_id"])
+                except Exception:
+                    continue
+        except sqlite3.OperationalError:
+            pass
+    con.close()
+    families = {family_of(x) for x in lanes}
+    return len(lanes) < 2 or len(families) == len(lanes)
+
+
+def reward_summary(objective_domain: str, task_class: str, node_type: str,
+                   db: str) -> tuple[float, int]:
+    """(mean, sample_size) over the slice: reward_g preferred, process_reward
+    fallback; (0.0, 0) on an empty slice — matches '0.0000|0'."""
+    con = sqlite3.connect(db)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    try:
+        cols = {r[1] for r in con.execute(
+            "PRAGMA table_info(execution_traces)").fetchall()}
+    except sqlite3.OperationalError:
+        con.close()
+        return 0.0, 0
+    primary = "reward_g" if "reward_g" in cols else (
+        "process_reward" if "process_reward" in cols else None)
+    if not primary:
+        con.close()
+        return 0.0, 0
+
+    node_type_predicate = ""
+    nt_args: list = []
+    if "node_type" in cols:
+        node_type_predicate = " AND node_type = ?"
+        nt_args = [node_type]
+    where = ["task_class = ?", f"{primary} IS NOT NULL"]
+    args: list = [task_class]
+    if objective_domain and "objective_domain" in cols:
+        where.append("objective_domain = ?")
+        args.append(objective_domain)
+    args += nt_args
+    try:
+        rows = con.execute(
+            f"SELECT {primary}, verifier_output FROM execution_traces "
+            f"WHERE {' AND '.join(where)}{node_type_predicate}", args).fetchall()
+    except sqlite3.OperationalError:
+        con.close()
+        return 0.0, 0
+    if not rows and not node_type_predicate and "verifier_output" in cols:
+        jargs: list = [task_class]
+        extra = ""
+        if objective_domain and "objective_domain" in cols:
+            extra = " AND objective_domain = ?"
+            jargs.append(objective_domain)
+        try:
+            rows = con.execute(
+                f"SELECT {primary}, verifier_output FROM execution_traces "
+                f"WHERE task_class = ?{extra} AND {primary} IS NOT NULL",
+                jargs).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+    con.close()
+    vals = []
+    for r in rows:
+        v = r[primary]
+        if v is None:
+            continue
+        try:
+            vals.append(float(v))
+        except (TypeError, ValueError):
+            continue
+    if not vals:
+        return 0.0, 0
+    return round(sum(vals) / len(vals), 4), len(vals)
+
+
+def recursion_hint() -> dict:
+    """Trimmed recursive-policy slice — env-driven, matching bash."""
+    def _b(name, dflt="0"):
+        return os.environ.get(name, dflt).lower() in {"1", "true", "yes", "on"}
+    return {
+        "max_depth": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_DEPTH", "2")),
+        "max_children_per_run": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_CHILDREN", "4")),
+        "max_total_descendants": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_DESCENDANTS", "16")),
+        "max_parallel_children": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_PARALLEL", "4")),
+        "default_allow_child_spawn": _b("MINI_ORK_ALLOW_CHILD_SPAWN"),
+    }
+
+
+def decide(node_type: str, task_class: str, objective_domain: str = "",
+           segment: str = "default", db: str | None = None) -> dict:
+    """The stateless decision surface. Same JSON contract as bash decide."""
+    code_region = segment if (segment and segment != "default") else ""
+    dbp = _db_path(db)
+
+    learned = lane_router.preferred_lane(
+        task_class, node_type, objective_domain, code_region, db=dbp)
+    learned_route = learned.split("|")[0] if learned else ""
+    route = learned_route or default_lane(node_type)
+
+    if learned_route:
+        epsilon_s = os.environ.get("EPSILON",
+                                   os.environ.get("MO_LEARNING_EPSILON", "0.10"))
+        try:
+            epsilon = float(epsilon_s)
+        except (TypeError, ValueError):
+            epsilon = 0.10
+        seed = os.environ.get("SEED", os.environ.get("MO_LEARNING_SEED", ""))
+        route = _explore_route(route, epsilon, seed, resolve_agents_yaml())
+
+    ok = coalition_ok(objective_domain, task_class, node_type, dbp)
+    mean, sample = reward_summary(objective_domain, task_class, node_type, dbp)
+    return {
+        "route": route,
+        "coalition_ok": ok,
+        "reward_estimate": mean,
+        "recursion_hint": recursion_hint(),
+        "sample_size": sample,
+        "segment": segment,
+        "code_region": code_region or None,
+    }

--- a/mini_ork/ported/epic_graph.py
+++ b/mini_ork/ported/epic_graph.py
@@ -1,0 +1,107 @@
+"""Cross-epic dependency graph — Python port of lib/epic_graph.sh.
+
+Faithful semantics: hard deps block, soft/informational don't; ready-set is
+status='not started' AND no unresolved hard dep, oldest-first; on_done resolves
+outgoing edges then flips fully-unblocked downstream 'blocked' epics to
+'not started'. This is the module the concurrent scheduler pools over.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if env:
+        return env
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+def _conn(db: str | None) -> sqlite3.Connection:
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    return con
+
+
+def add_dep(from_id: str, to_id: str, kind: str = "hard",
+            db: str | None = None) -> None:
+    """Register an edge: from_id must reach 'done' before to_id can dispatch."""
+    con = _conn(db)
+    try:
+        con.execute(
+            "INSERT OR IGNORE INTO epic_dependencies(from_epic_id, to_epic_id, kind) "
+            "VALUES(?,?,?)", (from_id, to_id, kind))
+        con.commit()
+    finally:
+        con.close()
+
+
+def deps_met(epic_id: str, db: str | None = None) -> bool:
+    """True when every HARD dep of the epic is resolved."""
+    con = _conn(db)
+    try:
+        unmet = con.execute(
+            "SELECT COUNT(*) FROM epic_dependencies "
+            "WHERE to_epic_id=? AND kind='hard' AND resolved_at IS NULL",
+            (epic_id,)).fetchone()[0]
+        return unmet == 0
+    finally:
+        con.close()
+
+
+def ready_now(db: str | None = None) -> list[str]:
+    """Epic ids with status='not started', unarchived, all hard deps met —
+    oldest first (fairness)."""
+    con = _conn(db)
+    try:
+        rows = con.execute(
+            """SELECT e.id FROM epics e
+                WHERE e.status = 'not started' AND e.archived_at IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM epic_dependencies d
+                       WHERE d.to_epic_id = e.id AND d.kind = 'hard'
+                         AND d.resolved_at IS NULL)
+             ORDER BY e.created_at ASC""").fetchall()
+        return [r[0] for r in rows]
+    finally:
+        con.close()
+
+
+def mark_ready(epic_id: str, db: str | None = None) -> None:
+    """Flip 'blocked' -> 'not started' (idempotent)."""
+    con = _conn(db)
+    try:
+        con.execute("UPDATE epics SET status='not started' "
+                    "WHERE id=? AND status='blocked'", (epic_id,))
+        con.commit()
+    finally:
+        con.close()
+
+
+def on_done(done_id: str, db: str | None = None) -> None:
+    """Resolve outgoing edges of a completed epic, then unblock any downstream
+    epic whose remaining hard deps are all met."""
+    con = _conn(db)
+    try:
+        con.execute(
+            "UPDATE epic_dependencies "
+            "SET resolved_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') "
+            "WHERE from_epic_id=? AND resolved_at IS NULL", (done_id,))
+        downstream = [r[0] for r in con.execute(
+            "SELECT DISTINCT to_epic_id FROM epic_dependencies WHERE from_epic_id=?",
+            (done_id,)).fetchall()]
+        for ep in downstream:
+            unmet = con.execute(
+                "SELECT COUNT(*) FROM epic_dependencies "
+                "WHERE to_epic_id=? AND kind='hard' AND resolved_at IS NULL",
+                (ep,)).fetchone()[0]
+            if unmet == 0:
+                con.execute("UPDATE epics SET status='not started' "
+                            "WHERE id=? AND status='blocked'", (ep,))
+        con.commit()
+    finally:
+        con.close()

--- a/mini_ork/ported/pricing_strategy.py
+++ b/mini_ork/ported/pricing_strategy.py
@@ -1,0 +1,82 @@
+"""Pure-logic port of ``lib/pricing_strategy.sh::pricing_lookup``.
+
+Faithful port of the deterministic lookup core of ``pricing_lookup``. The
+bash function is a thin shell that resolves ``MO_PRICING_YAML`` (with a
+``MINI_ORK_HOME`` fallback), checks for ``python3`` + ``PyYAML``, and
+otherwise delegates to an embedded Python heredoc that walks
+``pricing[provider][model][kind]``. This module lifts that walk into a
+regular import, strips the I/O + env + stderr layers (the test layer owns
+I/O), and exposes a single ``lookup(data, provider, model, kind)`` entry
+point.
+
+Public API::
+
+    from mini_ork.ported.pricing_strategy import lookup, ALLOWED
+
+    rate = lookup(data, "anthropic", "claude-sonnet-4-6", "input")
+    # -> "3.0"      # str() of the YAML-parsed rate, identical to bash
+
+``data`` is the parsed YAML document (typically ``yaml.safe_load(path)``).
+The port performs no I/O, reads no env, emits no stderr — every miss path
+returns ``"0"`` (the literal two-character string), matching bash's
+``print("0")`` after its stderr warning. Callers needing the file/env
+wrapping should invoke the bash function directly.
+
+``tests/unit/test_pricing_strategy_parity.py`` enforces byte-exact stdout
+parity between this module and the live bash subprocess over a fixture
+corpus of ``>=6`` cases.
+
+Parity contract (mirrors bash verbatim):
+    - kind not in ALLOWED -> "0"
+    - any of ``data``, ``data['pricing']``, the provider block, the model
+      block, or ``kind`` value missing/wrong-type -> "0"
+    - on hit, returns ``str(value)`` where ``value`` is whatever
+      ``yaml.safe_load`` produced (int stays int-repr, float stays
+      float-repr, str stays str)
+    - no exceptions escape; ``lookup`` never raises on malformed data
+      shape — it degrades to ``"0"`` so callers can compare to bash's
+      warning-then-``0`` behavior at the stdout level.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+ALLOWED: frozenset[str] = frozenset({"input", "output", "cache_read", "cache_write"})
+
+
+def lookup(data: Mapping[str, Any] | None, provider: str, model: str, kind: str) -> str:
+    """Resolve ``pricing[provider][model][kind]`` against a parsed YAML doc.
+
+    Returns the ``str()`` of the YAML-parsed rate on a hit. Returns the
+    literal string ``"0"`` for every miss path — unknown kind, missing
+    provider/model/kind in the data, malformed shape (e.g. ``pricing`` is
+    not a dict, provider block is a scalar), or ``None`` ``data``. Never
+    raises; never logs; never touches the filesystem or environment.
+
+    The string return is deliberately non-coerced to numeric so a
+    downstream caller comparing against bash's stdout sees a byte-exact
+    match: yaml `3.00` -> float 3.0 -> ``str()`` -> ``"3.0"``, identical
+    to what bash's heredoc emits.
+    """
+    if kind not in ALLOWED:
+        return "0"
+    if not isinstance(data, Mapping):
+        return "0"
+    table = data.get("pricing")
+    if not isinstance(table, Mapping):
+        return "0"
+    provider_block = table.get(provider)
+    if not isinstance(provider_block, Mapping):
+        return "0"
+    model_block = provider_block.get(model)
+    if not isinstance(model_block, Mapping):
+        return "0"
+    rate = model_block.get(kind)
+    if rate is None:
+        return "0"
+    try:
+        return str(rate)
+    except Exception:
+        return "0"

--- a/mini_ork/ported/rho_aggregator.py
+++ b/mini_ork/ported/rho_aggregator.py
@@ -1,0 +1,180 @@
+"""Pure-logic port of ``lib/rho_aggregator.sh``.
+
+Faithful port of the two pure/deterministic callables of the bash
+Retrospective Harness Optimization (RHO) aggregator (arXiv:2606.05922).
+The bash file resolves ``STATE_DB`` at *source* time from
+``${MINI_ORK_DB:-${MINI_ORK_HOME:-.mini-ork}/state.db}``; the Python
+port takes the database path as a parameter instead, which is the
+controllable equivalent.
+
+Bash function inventory (verbatim from ``lib/rho_aggregator.sh``)::
+
+    rho_aggregate_win_rates [--since EPOCH] [--task-class X]
+        Re-aggregate from ``execution_traces``. Idempotent: upserts the
+        row keyed by ``(prompt_version_hash, task_class)`` into
+        ``prompt_win_rates``. Emits the row count on stdout.
+
+    rho_top_prompts <task_class> <node_type> [<top_n>]
+        Print the top-N prompts by ``win_rate`` for the given
+        ``task_class`` + ``node_type`` filter, ``sample_size >= 3`` to
+        avoid one-shot noise.
+
+Parity-mapping contract (must remain exact)::
+
+    bash                                     python
+    -------------------------------------------------------------------------------
+    rho_aggregate_win_rates [..]   ─►  aggregate_win_rates(state_db, since=0,
+                                                            task_class="")
+                                       returns int (row count printed by bash)
+    rho_top_prompts tc nt [n]      ─►  top_prompts(state_db, task_class, node_type="",
+                                                    top_n=5)
+                                       returns str (the full multi-line stdout,
+                                       trailing newline preserved)
+
+Output-format parity notes (verified against live bash on a 3-trace seed)::
+
+    * ``win_rate`` is rounded to 4 dp on insert (``round(wr, 4)``) and
+      printed at 3 dp by ``top_prompts`` via ``printf '%.3f'``. Python
+      mirrors with ``round(x, 4)`` / ``f"{x:.3f}"``.
+    * ``sample_size`` printed as ``printf '%4d'`` (width 4, right-aligned).
+    * Hash printed as ``printf '%-12s'`` over the first 12 chars (left-aligned).
+    * ``node_type`` printed via ``COALESCE(node_type,'?')`` — so a NULL
+      node_type always renders as ``?``.
+    * Filter clause ``(node_type IS NULL OR node_type = X)`` means a
+      NULL node_type row passes any node_type filter; this is preserved.
+
+Float equality is enforced at ``<1e-6`` for ``win_rate``-shaped outputs;
+string equality is exact after ``.strip()`` for the formatted table.
+
+``tests/unit/test_rho_aggregator_parity.py`` enforces this parity over a
+fixture corpus of ``>=6`` cases by shelling out to live bash via
+``subprocess.run`` and comparing byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _connect(state_db: str) -> sqlite3.Connection:
+    """Open ``state_db`` with the same pragma the bash heredoc uses."""
+    con = sqlite3.connect(state_db)
+    con.execute("PRAGMA busy_timeout=5000")
+    return con
+
+
+def aggregate_win_rates(state_db: str, since: int = 0, task_class: str = "") -> int:
+    """Python equivalent of ``rho_aggregate_win_rates [--since E] [--task-class X]``.
+
+    Walks ``execution_traces``, groups by ``(prompt_version_hash, task_class)``,
+    upserts into ``prompt_win_rates``, and returns the row count (the same
+    integer bash prints on stdout).
+
+    Win/loss/tie rubric mirrors the bash heredoc verbatim:
+
+      * win  : ``status='success'`` AND ``reviewer_verdict`` NOT IN
+               (``REJECT``, ``ESCALATE``, ``needs_revision``) AND not NULL
+      * loss : ``status='failure'`` OR
+               (``status='success'`` AND ``reviewer_verdict`` IN the above)
+      * tie  : ``status`` IN (``running``, ``vacuous``, ``blocked``, ``unknown``)
+               OR NULL
+
+    ``win_rate = wins / (wins + losses)`` if denominator > 0 else ``0.0``;
+    rounded to 4 decimal places before insert (matches bash's
+    ``round(wr, 4)``).
+    """
+    import datetime as _dt
+
+    since_iso = _dt.datetime.utcfromtimestamp(int(since)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    con = _connect(state_db)
+
+    clauses = [
+        "created_at >= ?",
+        "prompt_version_hash IS NOT NULL",
+        "prompt_version_hash <> ''",
+        "task_class IS NOT NULL",
+        "task_class <> ''",
+    ]
+    params: list = [since_iso]
+    if task_class:
+        clauses.append("task_class = ?")
+        params.append(task_class)
+
+    sql = f"""
+        SELECT prompt_version_hash, task_class,
+            SUM(CASE
+                  WHEN status='success'
+                   AND (reviewer_verdict IS NULL
+                        OR reviewer_verdict NOT IN ('REJECT','ESCALATE','needs_revision'))
+                  THEN 1 ELSE 0 END) AS wins,
+            SUM(CASE
+                  WHEN status='failure'
+                    OR (status='success' AND reviewer_verdict IN ('REJECT','ESCALATE','needs_revision'))
+                  THEN 1 ELSE 0 END) AS losses,
+            SUM(CASE
+                  WHEN status IN ('running','vacuous','blocked','unknown')
+                       OR status IS NULL
+                  THEN 1 ELSE 0 END) AS ties
+          FROM execution_traces
+         WHERE {' AND '.join(clauses)}
+         GROUP BY prompt_version_hash, task_class
+    """
+    rows = con.execute(sql, params).fetchall()
+
+    updated = 0
+    for prompt, tc, wins, losses, ties in rows:
+        n = (wins or 0) + (losses or 0) + (ties or 0)
+        wr = (wins / (wins + losses)) if (wins + losses) > 0 else 0.0
+        con.execute(
+            """
+            INSERT INTO prompt_win_rates
+                (prompt_version_hash, task_class, wins, losses, ties,
+                 win_rate, sample_size,
+                 last_updated)
+            VALUES (?,?,?,?,?,?,?,
+                    strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            ON CONFLICT(prompt_version_hash, task_class) DO UPDATE SET
+                wins=excluded.wins, losses=excluded.losses, ties=excluded.ties,
+                win_rate=excluded.win_rate, sample_size=excluded.sample_size,
+                last_updated=excluded.last_updated
+            """,
+            (prompt, tc, wins or 0, losses or 0, ties or 0, round(wr, 4), n),
+        )
+        updated += 1
+
+    con.commit()
+    con.close()
+    return updated
+
+
+def top_prompts(state_db: str, task_class: str, node_type: str = "", top_n: int = 5) -> str:
+    """Python equivalent of ``rho_top_prompts <task_class> <node_type> [<top_n>]``.
+
+    Returns the full multi-line formatted table bash would print, with the
+    trailing newline preserved (bash's ``sqlite3 ... ;`` emits one).
+
+    Columns: ``win_rate`` (3 dp), ``sample_size`` (width-4 right-aligned),
+    ``prompt_version_hash`` (first 12 chars, width-12 left-aligned),
+    ``node_type`` (``?`` if NULL).
+    """
+    where = f"task_class='{task_class}' AND sample_size >= 3"
+    if node_type:
+        where += f" AND (node_type IS NULL OR node_type='{node_type}')"
+
+    con = _connect(state_db)
+    rows = con.execute(
+        f"""
+        SELECT printf('%.3f', win_rate),
+                printf('%4d', sample_size),
+                printf('%-12s', substr(prompt_version_hash,1,12)),
+                COALESCE(node_type,'?')
+           FROM prompt_win_rates
+          WHERE {where}
+          ORDER BY win_rate DESC, sample_size DESC
+          LIMIT {int(top_n)};
+        """
+    ).fetchall()
+    con.close()
+
+    return "\n".join(" | ".join(str(c) for c in row) for row in rows) + ("\n" if rows else "")

--- a/mini_ork/ported/similarity.py
+++ b/mini_ork/ported/similarity.py
@@ -1,0 +1,108 @@
+"""Pure-logic port of ``lib/similarity.sh``'s TF-IDF cosine ranker.
+
+Faithful port of the deterministic core of ``lib/similarity.sh::similarity_query``.
+The bash function is a thin shell that opens sqlite3 and delegates all math
+to an embedded Python heredoc. This module lifts that math into a regular
+import, strips the sqlite3 I/O (the test layer owns I/O), and exposes a
+``rank(query, docs, limit)`` public entry point plus the underlying
+deterministic primitives (``tok``, ``tf``, ``cos``).
+
+``tests/unit/test_similarity_parity.py`` enforces exact parity (floats
+within ``1e-6``, strings exact, JSON byte-stable on score rendering) between
+this module's output and the live bash function over a corpus of
+representative inputs.
+
+Public API::
+
+    from mini_ork.ported.similarity import (
+        tok, tf, cos,                     # deterministic primitives
+        allowed_table_col, ALLOWED,       # table/column whitelist
+        rank,                             # top-level ranking pipeline
+    )
+
+    scored = rank("auth bug", ["auth fix in middleware", "unrelated doc"], limit=5)
+    # -> [(0.83, 0)]              # (rounded score, original doc index)
+
+Score rendering matches bash's ``round(s, 4)`` via the ``round_ndigits=4``
+default — keep these values in lockstep.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Iterable
+
+
+def tok(s: str) -> list[str]:
+    """Lowercase, replace non-``[\\w./_-]`` runs with a space, drop tokens shorter than 3."""
+    s = (s or "").lower()
+    s = re.sub(r"[^\w./_-]+", " ", s)
+    return [t for t in s.split() if len(t) >= 3]
+
+
+def tf(toks: Iterable[str]) -> dict[str, float]:
+    """Term frequency: ``count(t) / max(1, total)`` per token. Empty input -> empty dict."""
+    c = Counter(toks)
+    total = sum(c.values()) or 1
+    return {t: cnt / total for t, cnt in c.items()}
+
+
+def cos(a: dict[str, float], b: dict[str, float]) -> float:
+    """Cosine similarity of two sparse term-weight dicts. Zero if either side is empty."""
+    keys = set(a) | set(b)
+    dot = sum(a.get(k, 0.0) * b.get(k, 0.0) for k in keys)
+    na = math.sqrt(sum(v * v for v in a.values()))
+    nb = math.sqrt(sum(v * v for v in b.values()))
+    return dot / (na * nb) if na and nb else 0.0
+
+
+# Mirrors the ALLOWED table+text-column whitelist in lib/similarity.sh verbatim.
+# Extend here ONLY in lockstep with the bash file.
+ALLOWED: dict[str, set[str]] = {
+    "bug_reports":      {"title", "description", "suggested_fix"},
+    "gradient_records": {"signal", "suggested_change", "target"},
+    "learning_record":  {"title", "patch_summary"},
+    "pattern_records":  {"description"},
+}
+
+
+def allowed_table_col(table: str, text_col: str) -> bool:
+    """True iff ``(table, text_col)`` is whitelisted in :data:`ALLOWED`."""
+    return table in ALLOWED and text_col in ALLOWED[table]
+
+
+def rank(
+    query: str,
+    docs: Iterable[str],
+    limit: int = 5,
+    round_ndigits: int = 4,
+) -> list[tuple[float, int]]:
+    """Score ``docs`` against ``query`` by TF-IDF cosine, return top ``limit``.
+
+    Returns ``(score, doc_index)`` pairs sorted by score descending, only
+    entries with score > 0, truncated to ``limit``. Identical math to
+    ``similarity_query`` in ``lib/similarity.sh``; parity (including score
+    rounding) is verified by ``test_similarity_parity``.
+    """
+    doc_list = list(docs)
+    doc_toks = [tok(d) for d in doc_list]
+    df: Counter[str] = Counter()
+    for d in doc_toks:
+        for t in set(d):
+            df[t] += 1
+    n = max(len(doc_list), 1)
+    idf = {t: math.log(1.0 + n / (1 + c)) for t, c in df.items()}
+
+    def vec(toks: list[str]) -> dict[str, float]:
+        return {t: w * idf.get(t, 0.0) for t, w in tf(toks).items()}
+
+    q_vec = vec(tok(query))
+    scored: list[tuple[float, int]] = []
+    for i, d in enumerate(doc_toks):
+        s = cos(q_vec, vec(d))
+        if s > 0:
+            scored.append((round(s, round_ndigits), i))
+    scored.sort(key=lambda p: p[0], reverse=True)
+    return scored[:limit]

--- a/mini_ork/ported/topology.py
+++ b/mini_ork/ported/topology.py
@@ -1,0 +1,261 @@
+"""Pure-logic port of ``lib/topology.sh::topology_recompute_win_rates``.
+
+Faithful port of the deterministic aggregation logic in
+``lib/topology.sh``. The bash function reads from ``execution_traces`` (and
+left-joins ``workflow_memory``) and upserts aggregated rows into
+``topology_win_rates``. This module lifts the classification rules and the
+win-rate / sample-size math into a regular import so callers (and the
+parity test) can exercise the deterministic core without going through
+SQLite I/O.
+
+The bash function's full pipeline is::
+
+    READ execution_traces + LEFT JOIN workflow_memory
+        ON wm.workflow_version_id = et.workflow_version_id
+    GROUP BY (topology_id, workflow_name, task_class)
+    CLASSIFY each row as win / loss / tie / none via (status, reviewer_verdict)
+    AGGREGATE wins, losses, ties, AVG(cost_usd), AVG(duration_ms)
+    COMPUTE win_rate = wins / (wins + losses), guarded against zero denom
+    COMPUTE sample_size = wins + losses + ties
+
+Public API::
+
+    from mini_ork.ported.topology import (
+        classify_outcome,       # (status, reviewer_verdict) -> 'win'|'loss'|'tie'|None
+        compute_win_rate,       # (wins, losses) -> float (rounded to 4 decimals)
+        aggregate_traces,       # (traces[, workflow_memory]) -> list[aggregate_row]
+    )
+
+    rows = aggregate_traces(
+        [
+            {"workflow_version_id": "code_fix_v3", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": None,
+             "cost_usd": 0.42, "duration_ms": 8000, "created_at": "..."},
+            ...
+        ],
+        workflow_memory={
+            "code_fix_v3": {"yaml_hash": "abc123", "workflow_name": "code-fix"},
+        },
+    )
+
+Each returned ``aggregate_row`` mirrors the columns bash would upsert into
+``topology_win_rates``::
+
+    {
+      "topology_id":      str,
+      "workflow_name":    str,
+      "task_class":       str,
+      "wins":             int,
+      "losses":           int,
+      "ties":             int,
+      "win_rate":         float,    # round(_, 4)
+      "sample_size":      int,      # wins + losses + ties
+      "avg_cost_usd":     float,    # AVG(COALESCE(cost_usd, 0))
+      "avg_duration_ms":  float,    # AVG(COALESCE(duration_ms, 0))
+    }
+
+The result list is sorted by ``(topology_id, task_class)`` to match a
+deterministic ``SELECT ... ORDER BY topology_id, task_class`` read of the
+bash-populated table.
+
+``tests/unit/test_topology_parity.py`` enforces exact parity (floats
+within ``1e-6``, strings exact) between ``aggregate_traces`` and the live
+bash function over a corpus of representative trace sets.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable, Mapping, cast
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Classification rules — verbatim mirror of the CASE expressions in
+# lib/topology.sh::topology_recompute_win_rates. A row contributes to
+# exactly one of (wins, losses, ties) or to NONE of them; the aggregation
+# below handles "none" by counting zeros across all three buckets.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_REJECTING_VERDICTS: frozenset[str] = frozenset({"REJECT", "ESCALATE", "needs_revision"})
+
+_TIE_STATUSES: frozenset[str] = frozenset({"running", "vacuous", "blocked", "unknown"})
+
+
+def classify_outcome(
+    status: str | None,
+    reviewer_verdict: str | None,
+) -> str | None:
+    """Map a single ``(status, reviewer_verdict)`` to ``'win'/'loss'/'tie'/None``.
+
+    Mirrors the three mutually exclusive ``CASE`` branches in
+    ``lib/topology.sh::topology_recompute_win_rates``:
+
+    * ``win``  — ``status == 'success'`` AND ``reviewer_verdict`` is ``None``
+                 or not in ``{REJECT, ESCALATE, needs_revision}``.
+    * ``loss`` — ``status == 'failure'`` OR (``status == 'success'`` AND
+                 ``reviewer_verdict`` in the rejecting set).
+    * ``tie``  — ``status`` is ``None`` or in
+                 ``{running, vacuous, blocked, unknown}``.
+    * ``None`` — every other case (status outside the recognized set with
+                 a non-rejecting verdict). The bash function tallies zero
+                 for all three buckets; the port must do the same.
+
+    A ``None`` classification is NOT an error — it is preserved so the
+    aggregation reproduces bash's exact zero-tally rows.
+    """
+    if status == "success":
+        if reviewer_verdict is None or reviewer_verdict not in _REJECTING_VERDICTS:
+            return "win"
+        return "loss"
+    if status == "failure":
+        return "loss"
+    if status is None or status in _TIE_STATUSES:
+        return "tie"
+    return None
+
+
+def compute_win_rate(wins: int, losses: int, ndigits: int = 4) -> float:
+    """``wins / (wins + losses)`` rounded to ``ndigits`` decimals, ``0.0`` if denom == 0.
+
+    Mirrors ``round(wr, 4)`` in ``lib/topology.sh``.
+    """
+    denom = (wins or 0) + (losses or 0)
+    if denom <= 0:
+        return 0.0
+    return round((wins or 0) / denom, ndigits)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Aggregation — pure pipeline over an iterable of trace rows. Mirrors the
+# SQL aggregation in lib/topology.sh::topology_recompute_win_rates end to
+# end (modulo the workflow_memory join, which is provided as a dict).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Required trace fields for the aggregation. Mirrors the WHERE clause in bash:
+# rows missing any of these are dropped (matching SQL's NULL-fail filter).
+_REQUIRED_TRACE_FIELDS = ("workflow_version_id", "task_class")
+
+
+def _is_qualifying_trace(t: Mapping[str, object]) -> bool:
+    for k in _REQUIRED_TRACE_FIELDS:
+        v = t.get(k)
+        if v is None or v == "":
+            return False
+    return True
+
+
+def _group_key(
+    t: Mapping[str, object],
+    workflow_memory: Mapping[str, Mapping[str, str]] | None,
+) -> tuple[str, str, str]:
+    """Resolve ``(topology_id, workflow_name, task_class)`` for one trace.
+
+    Mirrors the bash join::
+
+        COALESCE(wm.yaml_hash, et.workflow_version_id) AS topology_id,
+        COALESCE(wm.workflow_name, '?')                AS workflow_name,
+
+    A missing ``workflow_memory`` row falls back to the trace's
+    ``workflow_version_id`` and the literal ``'?'``.
+    """
+    wvid = cast(str, t["workflow_version_id"])
+    tclass = cast(str, t["task_class"])
+    wm = workflow_memory.get(wvid) if workflow_memory else None
+    topology_id = (wm or {}).get("yaml_hash") or wvid
+    workflow_name = (wm or {}).get("workflow_name") or "?"
+    return str(topology_id), str(workflow_name), str(tclass)
+
+
+def aggregate_traces(
+    traces: Iterable[Mapping[str, object]],
+    workflow_memory: Mapping[str, Mapping[str, str]] | None = None,
+    win_rate_ndigits: int = 4,
+) -> list[dict]:
+    """Aggregate ``traces`` by ``(topology_id, task_class)`` per bash's rules.
+
+    Parameters
+    ----------
+    traces:
+        Iterable of trace rows. Each row is a Mapping carrying (at minimum)
+        ``workflow_version_id`` and ``task_class``; the function reads
+        ``status``, ``reviewer_verdict``, ``cost_usd`` and ``duration_ms``
+        for the aggregation. ``created_at`` is NOT consulted here — bash
+        filters by it via the ``--since`` parameter, which the caller
+        already accounts for before handing rows to the port.
+    workflow_memory:
+        Optional ``{workflow_version_id: {yaml_hash, workflow_name}}``
+        mapping. Equivalent to the bash ``LEFT JOIN workflow_memory``.
+    win_rate_ndigits:
+        Decimal places for the win-rate rounding. Mirrors bash's
+        ``round(wr, 4)``; expose only for tests.
+
+    Returns
+    -------
+    list[dict]
+        Aggregate rows, one per ``(topology_id, task_class)`` group, sorted
+        by ``(topology_id, task_class)``. Schema matches the columns bash
+        upserts into ``topology_win_rates``.
+    """
+    grouped: dict[tuple[str, str, str], dict] = defaultdict(
+        lambda: {
+            "wins": 0,
+            "losses": 0,
+            "ties": 0,
+            "_cost_sum": 0.0,
+            "_cost_n": 0,
+            "_dur_sum": 0.0,
+            "_dur_n": 0,
+        }
+    )
+
+    for t in traces:
+        if not _is_qualifying_trace(t):
+            continue
+        key = _group_key(t, workflow_memory)
+        bucket = grouped[key]
+        status = cast(object | None, t.get("status"))
+        verdict = cast(object | None, t.get("reviewer_verdict"))
+        outcome = classify_outcome(
+            cast(str | None, status),
+            cast(str | None, verdict),
+        )
+        if outcome == "win":
+            bucket["wins"] += 1
+        elif outcome == "loss":
+            bucket["losses"] += 1
+        elif outcome == "tie":
+            bucket["ties"] += 1
+        # outcome == None: contributes zero to all three buckets, matches bash.
+
+        cost = t.get("cost_usd")
+        if cost is not None:
+            bucket["_cost_sum"] += float(cast(float, cost))
+            bucket["_cost_n"] += 1
+        dur = t.get("duration_ms")
+        if dur is not None:
+            bucket["_dur_sum"] += float(cast(float, dur))
+            bucket["_dur_n"] += 1
+
+    rows: list[dict] = []
+    for (topology_id, workflow_name, task_class), b in grouped.items():
+        wins = b["wins"]
+        losses = b["losses"]
+        ties = b["ties"]
+        avg_cost = (b["_cost_sum"] / b["_cost_n"]) if b["_cost_n"] else 0.0
+        avg_dur = (b["_dur_sum"] / b["_dur_n"]) if b["_dur_n"] else 0.0
+        rows.append(
+            {
+                "topology_id": topology_id,
+                "workflow_name": workflow_name,
+                "task_class": task_class,
+                "wins": wins,
+                "losses": losses,
+                "ties": ties,
+                "win_rate": compute_win_rate(wins, losses, win_rate_ndigits),
+                "sample_size": wins + losses + ties,
+                "avg_cost_usd": avg_cost,
+                "avg_duration_ms": avg_dur,
+            }
+        )
+
+    rows.sort(key=lambda r: (r["topology_id"], r["task_class"]))
+    return rows

--- a/mini_ork/ported/utility_function.py
+++ b/mini_ork/ported/utility_function.py
@@ -1,0 +1,163 @@
+"""Pure-logic port of ``lib/utility_function.sh::utility_score``.
+
+Faithful port of the **default formula branch** of the bash utility-score
+function (Ch 18). The bash source is a thin shell that resolves a per-task
+override and otherwise delegates to an embedded Python heredoc; this module
+lifts that heredoc into a normal importable function and exposes the
+deterministic helpers it depends on.
+
+The per-task override path (``${MINI_ORK_HOME}/config/utility_functions/
+<task_class>.sh``) is impure I/O and is intentionally **not** ported here.
+Parity fixtures omit ``task_class`` so both bash and Python fall through to
+the default formula; callers needing the override path should call the bash
+function directly.
+
+Public API::
+
+    from mini_ork.ported.utility_function import score
+
+    score(run_result_json, weights=None) -> float
+
+``weights`` is a dict with any of ``success``, ``verifier``, ``quality``,
+``cost``, ``latency``, ``risk``. Missing entries fall back to the
+``MINI_ORK_W_*`` environment defaults (matching ``lib/utility_function.sh``'s
+``_UTILITY_W_*`` constants).
+
+Default formula (mirrors bash verbatim)::
+
+    U = w_success*success + w_verifier*verifier_score + w_quality*quality_score
+        - w_cost*norm_cost - w_latency*norm_latency - w_risk*risk_penalty
+
+All components are clamped to ``[0.0, 1.0]`` before combination and ``U`` is
+clamped to ``[0.0, 1.0]`` before return. Score rendering matches bash's
+``f"{U:.6f}"`` format.
+
+``tests/unit/test_utility_function_parity.py`` enforces float parity (within
+``1e-6``) between this module and the live bash subprocess over a fixture
+corpus of ``>=6`` cases.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Mapping
+
+
+_WEIGHT_KEYS = ("success", "verifier", "quality", "cost", "latency", "risk")
+
+_DEFAULT_WEIGHTS = {
+    "success": 0.45,
+    "verifier": 0.20,
+    "quality": 0.15,
+    "cost": 0.10,
+    "latency": 0.05,
+    "risk": 0.05,
+}
+
+_ENV_WEIGHT_KEYS = {
+    "success": "MINI_ORK_W_SUCCESS",
+    "verifier": "MINI_ORK_W_VERIFIER",
+    "quality": "MINI_ORK_W_QUALITY",
+    "cost": "MINI_ORK_W_COST",
+    "latency": "MINI_ORK_W_LATENCY",
+    "risk": "MINI_ORK_W_RISK",
+}
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, float(value)))
+
+
+def _norm_ratio(value: float, ceiling: float) -> float:
+    """Mirror bash: ``clamp(v / c)`` if c > 0, else 0.0."""
+    if ceiling > 0:
+        return _clamp(value / ceiling)
+    return 0.0
+
+
+def _resolve_weights(weights: Mapping[str, float] | None) -> dict[str, float]:
+    """Caller ``weights`` dict wins, then ``MINI_ORK_W_*`` env, then hard defaults.
+
+    Mirrors bash: ``_UTILITY_W_<NAME>="${MINI_ORK_W_<NAME>:-<default>}"``
+    """
+    resolved = dict(_DEFAULT_WEIGHTS)
+    for key in _WEIGHT_KEYS:
+        env_key = _ENV_WEIGHT_KEYS[key]
+        env_val = os.environ.get(env_key)
+        if env_val is not None:
+            try:
+                resolved[key] = float(env_val)
+            except ValueError:
+                pass
+    if weights:
+        for key in _WEIGHT_KEYS:
+            if key in weights and weights[key] is not None:
+                resolved[key] = float(weights[key])
+    return resolved
+
+
+def _parse_success(raw) -> float:
+    """Match bash exactly: ``r.get("success") in (True, 1, "true", "1")``.
+
+    JSON deserialization cannot produce Python ``True``, so this is
+    effectively ``raw in (1, "true", "1")`` against the parsed JSON value,
+    but we keep the literal membership test to mirror the source verbatim.
+    """
+    return _clamp(1.0 if raw in (True, 1, "true", "1") else 0.0)
+
+
+def score(run_result_json: str, weights: Mapping[str, float] | None = None) -> float:
+    """Compute the utility score for a completed run.
+
+    Parameters
+    ----------
+    run_result_json:
+        JSON string with fields consumed by ``lib/utility_function.sh``:
+        ``success`` (bool | 0/1), ``verifier_score``, ``quality_score``,
+        ``cost_usd``, ``max_cost_usd``, ``duration_ms``, ``max_duration_ms``,
+        ``risk_penalty``, ``task_class``. ``task_class`` is ignored here —
+        only the default-formula path is ported.
+    weights:
+        Optional override dict for the six weight constants. Missing entries
+        fall through to ``MINI_ORK_W_*`` env vars, then hard defaults
+        (0.45/0.20/0.15/0.10/0.05/0.05).
+
+    Returns
+    -------
+    float
+        Score in ``[0.0, 1.0]`` — exact parity with bash's
+        ``f"{U:.6f}"`` rendering.
+    """
+    try:
+        run_result = json.loads(run_result_json)
+    except json.JSONDecodeError:
+        raise ValueError(f"utility_score: invalid JSON: {run_result_json!r}")
+
+    w = _resolve_weights(weights)
+
+    success = _parse_success(run_result.get("success"))
+    verifier_score = _clamp(run_result.get("verifier_score", 0.0))
+    quality_score = _clamp(run_result.get("quality_score", 0.5))
+    risk_penalty = _clamp(run_result.get("risk_penalty", 0.0))
+
+    cost_usd = float(run_result.get("cost_usd", 0.0))
+    max_cost = float(run_result.get("max_cost_usd", cost_usd if cost_usd > 0 else 1.0))
+    norm_cost = _norm_ratio(cost_usd, max_cost)
+
+    duration_ms = float(run_result.get("duration_ms", 0.0))
+    max_duration = float(
+        run_result.get("max_duration_ms", duration_ms if duration_ms > 0 else 1.0)
+    )
+    norm_latency = _norm_ratio(duration_ms, max_duration)
+
+    u = (
+        w["success"] * success
+        + w["verifier"] * verifier_score
+        + w["quality"] * quality_score
+        - w["cost"] * norm_cost
+        - w["latency"] * norm_latency
+        - w["risk"] * risk_penalty
+    )
+
+    return _clamp(u)

--- a/mini_ork/scheduler.py
+++ b/mini_ork/scheduler.py
@@ -1,0 +1,268 @@
+"""Autonomous multi-epic scheduler — Python port of bin/mini-ork-scheduler.
+
+Faithful port of the pick/dispatch/verdict/cascade mechanics PLUS the win #1
+concurrency seam: the bash scheduler computed the full ready-set and then threw
+all but the first away (`_pick_next_epic | head -1`) and blocked on one epic at
+a time — cross-epic parallelism was 1. This port dispatches a bounded worker
+pool (MO_SCHED_MAX_PARALLEL, default 3) over the whole priority-ordered
+ready-set; as each epic completes, its deps cascade and newly-unblocked epics
+join the pool. Priority-inheritance (Track B5) ordering is preserved exactly.
+
+Semantics kept from bash: budget cap over rolling-24h task_runs spend,
+cost-pause sentinels, kickoff resolution order, verdict resolution from
+{panel-verdict,verdict}.json, done->cascade / fail->escalated.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import time
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+
+from mini_ork.ported import epic_graph
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if env:
+        return env
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+def _conn(db: str | None) -> sqlite3.Connection:
+    con = sqlite3.connect(_db_path(db), timeout=30)
+    con.execute("PRAGMA busy_timeout=5000")
+    return con
+
+
+def ensure_priority_column(db: str | None = None) -> None:
+    """Idempotent epics.priority migration (Track B5)."""
+    con = _conn(db)
+    try:
+        cols = {r[1] for r in con.execute("PRAGMA table_info(epics)").fetchall()}
+        if "priority" not in cols:
+            con.execute("ALTER TABLE epics ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+            con.commit()
+    finally:
+        con.close()
+
+
+def effective_priority(epic_id: str, db: str | None = None) -> int:
+    """eff(E) = max(base(E), max(base(W) for W transitively blocked on E)) —
+    identical recursive CTE to the bash _epic_effective_priority."""
+    con = _conn(db)
+    try:
+        row = con.execute("""
+            WITH RECURSIVE inheritors(node) AS (
+                SELECT id FROM epics WHERE id = ?
+                UNION
+                SELECT d.to_epic_id
+                  FROM inheritors i
+                  JOIN epic_dependencies d ON d.from_epic_id = i.node
+                 WHERE d.kind = 'hard' AND d.resolved_at IS NULL
+            )
+            SELECT COALESCE(MAX(e.priority), 0)
+              FROM inheritors i JOIN epics e ON e.id = i.node
+        """, (epic_id,)).fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        con.close()
+
+
+def pick_ready(db: str | None = None) -> list[str]:
+    """Priority-ordered ready-set (Track B5 inheritance; ties oldest-first).
+    Same query as bash _pick_next_epic WITHOUT the LIMIT 1 — the pool consumes
+    the whole list. Element 0 == what bash would have picked."""
+    con = _conn(db)
+    try:
+        rows = con.execute("""
+            WITH RECURSIVE inheritors(root, node) AS (
+                SELECT e.id, e.id FROM epics e
+                 WHERE e.status = 'not started' AND e.archived_at IS NULL
+                   AND NOT EXISTS (
+                       SELECT 1 FROM epic_dependencies d
+                        WHERE d.to_epic_id = e.id AND d.kind = 'hard'
+                          AND d.resolved_at IS NULL)
+                UNION
+                SELECT i.root, d.to_epic_id
+                  FROM inheritors i
+                  JOIN epic_dependencies d ON d.from_epic_id = i.node
+                 WHERE d.kind = 'hard' AND d.resolved_at IS NULL
+            ),
+            effective(root, eff) AS (
+                SELECT root, COALESCE(MAX(e.priority), 0)
+                  FROM inheritors i JOIN epics e ON e.id = i.node
+                 GROUP BY root
+            )
+            SELECT e.id
+              FROM epics e JOIN effective ef ON ef.root = e.id
+             WHERE e.status = 'not started' AND e.archived_at IS NULL
+               AND NOT EXISTS (
+                   SELECT 1 FROM epic_dependencies d
+                    WHERE d.to_epic_id = e.id AND d.kind = 'hard'
+                      AND d.resolved_at IS NULL)
+             ORDER BY ef.eff DESC, e.created_at ASC
+        """).fetchall()
+        return [r[0] for r in rows]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        con.close()
+
+
+def today_cost_usd(db: str | None = None) -> float:
+    con = _conn(db)
+    try:
+        row = con.execute(
+            "SELECT COALESCE(SUM(cost_usd), 0) FROM task_runs "
+            "WHERE created_at >= strftime('%s','now','-24 hours')").fetchone()
+        return float(row[0] or 0)
+    except sqlite3.OperationalError:
+        return 0.0
+    finally:
+        con.close()
+
+
+def cost_pause_active(home: str | None = None) -> bool:
+    home = home or os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return (os.path.isfile(os.path.join(home, "cost-pause.sentinel"))
+            or os.path.isfile(os.path.join(home, "control", "cost-pause")))
+
+
+def resolve_kickoff(epic_id: str, root: str, recipe: str,
+                    db: str | None = None) -> str | None:
+    """kickoff_path column -> kickoffs/<id>.md -> recipe example (bash order)."""
+    con = _conn(db)
+    try:
+        row = con.execute("SELECT kickoff_path FROM epics WHERE id=?",
+                          (epic_id,)).fetchone()
+    finally:
+        con.close()
+    kp = row[0] if row and row[0] else ""
+    if kp and os.path.isfile(os.path.join(root, kp)):
+        return os.path.join(root, kp)
+    cand = os.path.join(root, "kickoffs", f"{epic_id}.md")
+    if os.path.isfile(cand):
+        return cand
+    cand = os.path.join(root, "recipes", recipe, "example-kickoff.md")
+    if os.path.isfile(cand):
+        return cand
+    return None
+
+
+def _set_status(db: str | None, epic_id: str, status: str, note: str = "") -> None:
+    con = _conn(db)
+    try:
+        if note:
+            con.execute("UPDATE epics SET status=?, notes=COALESCE(notes,'') || ? "
+                        "WHERE id=?", (status, note, epic_id))
+        else:
+            con.execute("UPDATE epics SET status=? WHERE id=?", (status, epic_id))
+        con.commit()
+    finally:
+        con.close()
+
+
+def _verdict_from_log(log_path: str, home: str) -> str:
+    """run_id= line -> runs/<run_id>/{panel-verdict,verdict}.json -> verdict."""
+    run_id = ""
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if line.startswith("run_id="):
+                    run_id = line.strip().split("=", 1)[1]
+                    break
+    except OSError:
+        return "unknown"
+    if not run_id:
+        return "unknown"
+    for vfile in ("panel-verdict.json", "verdict.json"):
+        p = os.path.join(home, "runs", run_id, vfile)
+        if os.path.isfile(p):
+            try:
+                v = json.load(open(p, encoding="utf-8")).get("verdict", "")
+                if v:
+                    return v
+            except (OSError, ValueError):
+                continue
+    return "unknown"
+
+
+def dispatch_epic(epic_id: str, root: str, home: str, recipe: str,
+                  db: str | None = None, dry_run: bool = False,
+                  runner_cmd: list[str] | None = None) -> tuple[str, int]:
+    """Mark in-progress, run the recipe, resolve verdict, update status +
+    cascade. Returns (verdict, rc). `runner_cmd` overrides the runner argv
+    (test seam); default is `<root>/bin/mini-ork run <recipe> <kickoff>`."""
+    kickoff = resolve_kickoff(epic_id, root, recipe, db)
+    if not kickoff:
+        _set_status(db, epic_id, "escalated", " [scheduler: no kickoff]")
+        return "no_kickoff", 1
+
+    _set_status(db, epic_id, "in progress")
+    log_dir = os.path.join(home, "runs", "scheduler")
+    os.makedirs(log_dir, exist_ok=True)
+    log_path = os.path.join(log_dir, f"dispatch-{int(time.time())}-{epic_id}.log")
+
+    if dry_run:
+        _set_status(db, epic_id, "not started")
+        return "dry_run", 0
+
+    cmd = runner_cmd or [os.path.join(root, "bin", "mini-ork"), "run", recipe, kickoff]
+    with open(log_path, "w", encoding="utf-8") as log:
+        rc = subprocess.run(cmd + ([kickoff] if runner_cmd else []),
+                            stdout=log, stderr=subprocess.STDOUT).returncode
+
+    verdict = _verdict_from_log(log_path, home)
+    if verdict in ("pass", "success"):
+        _set_status(db, epic_id, "done")
+        epic_graph.on_done(epic_id, db=db)
+    else:
+        _set_status(db, epic_id, "escalated")
+    return verdict, rc
+
+
+def run_pool(root: str, home: str, recipe: str = "epic-runner",
+             db: str | None = None, max_parallel: int | None = None,
+             max_iters: int = 0, budget_cap: float | None = None,
+             dry_run: bool = False, runner_cmd: list[str] | None = None) -> int:
+    """WIN #1 — bounded concurrent pool over the whole ready-set. Drains the
+    queue: dispatches up to `max_parallel` epics at once, and as each finishes
+    (cascading its deps), newly-ready epics join. Returns count dispatched.
+    Budget/cost-pause are re-checked before every admission, like the bash loop."""
+    if max_parallel is None:
+        max_parallel = int(os.environ.get("MO_SCHED_MAX_PARALLEL", "3"))
+    if budget_cap is None:
+        budget_cap = float(os.environ.get("MO_DAILY_BUDGET_USD", "50.0"))
+    ensure_priority_column(db)
+
+    dispatched = 0
+    in_flight: dict = {}
+    with ThreadPoolExecutor(max_workers=max_parallel) as pool:
+        while True:
+            if cost_pause_active(home) or today_cost_usd(db) >= budget_cap:
+                break
+            ready = [e for e in pick_ready(db) if e not in
+                     {v for v in in_flight.values()}]
+            while ready and len(in_flight) < max_parallel and (
+                    max_iters <= 0 or dispatched < max_iters):
+                epic = ready.pop(0)
+                fut = pool.submit(dispatch_epic, epic, root, home, recipe,
+                                  db, dry_run, runner_cmd)
+                in_flight[fut] = epic
+                dispatched += 1
+            if not in_flight:
+                break  # queue drained
+            done, _ = wait(in_flight, return_when=FIRST_COMPLETED)
+            for fut in done:
+                in_flight.pop(fut, None)
+            if max_iters > 0 and dispatched >= max_iters and not in_flight:
+                break
+    return dispatched

--- a/mini_ork/trace_store.py
+++ b/mini_ork/trace_store.py
@@ -1,0 +1,259 @@
+"""TraceStore CRUD on execution_traces — Python port of lib/trace_store.sh (Tier A).
+
+The bash version already delegated every function to an embedded python heredoc,
+so this is a faithful extraction into an importable module. reward_g is
+direction-normalized: dir*(value-anchor)/abs(anchor); anchor==0 → None (a
+deliberate "unanchored baseline, no learning signal"). This is the write path
+the GRPO loop reads via lane_router, and where win #1's reward stamp lands.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+import uuid
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if not env:
+        raise RuntimeError("MINI_ORK_DB unset")
+    return env
+
+
+def compute_reward_g(value, anchor, direction: str) -> float | None:
+    """Direction-normalized, scale-free gain. anchor==0 → None (no signal)."""
+    if value is None or anchor is None:
+        return None
+    try:
+        v = float(value)
+        a = float(anchor)
+    except (TypeError, ValueError):
+        return None
+    if a == 0:
+        return None
+    sign = 1.0 if direction == "higher_is_better" else -1.0
+    return sign * (v - a) / abs(a)
+
+
+def _normalise_verifier_output(v) -> dict:
+    """Decode once; handles new dict-from-execute AND legacy double-encoded rows."""
+    if isinstance(v, dict):
+        return v
+    if isinstance(v, str):
+        s = v.strip()
+        if not s or s in ("null", "None"):
+            return {}
+        try:
+            decoded = json.loads(s)
+        except (ValueError, TypeError):
+            return {}
+        if isinstance(decoded, dict):
+            return decoded
+        if isinstance(decoded, str):
+            try:
+                redecoded = json.loads(decoded)
+            except (ValueError, TypeError):
+                return {}
+            return redecoded if isinstance(redecoded, dict) else {}
+        return {}
+    return {}
+
+
+def trace_write(payload: dict | str, db: str | None = None) -> str:
+    """Write/UPSERT an execution trace. Returns trace_id. Faithful to
+    lib/trace_store.sh::trace_write (same columns, ON CONFLICT set, env fallbacks)."""
+    p = json.loads(payload) if isinstance(payload, str) else dict(payload)
+    trace_id = p.get("trace_id") or f"tr-{uuid.uuid4().hex[:16]}"
+    run_id = (p.get("run_id") or os.environ.get("MINI_ORK_TASK_RUN_ID")
+              or os.environ.get("MINI_ORK_RUN_ID"))
+    workflow_version_id = (p.get("workflow_version_id")
+                           or os.environ.get("MINI_ORK_WORKFLOW_VERSION_ID"))
+    prompt_version = (p.get("prompt_version") or os.environ.get("MO_NODE_PROMPT_SHA") or "")
+
+    verifier_output_obj = _normalise_verifier_output(p.get("verifier_output", {}))
+    reward_value = p.get("reward_value")
+    reward_anchor = p.get("reward_anchor")
+    reward_direction = p.get("reward_direction") or "higher_is_better"
+    reward_g_explicit = p.get("reward_g")
+    reward_g = (reward_g_explicit if reward_g_explicit is not None
+                else compute_reward_g(reward_value, reward_anchor, reward_direction))
+    reward_vector = p.get("reward_vector")
+    if isinstance(reward_vector, dict):
+        reward_vector_json = json.dumps(reward_vector)
+    elif isinstance(reward_vector, str):
+        reward_vector_json = reward_vector
+    else:
+        reward_vector_json = None
+
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    con.execute(
+        """INSERT INTO execution_traces (
+            trace_id, run_id, task_class, prompt_version_hash, context_bundle_hash,
+            tool_calls, files_read, files_written, verifier_output,
+            reviewer_verdict, cost_usd, duration_ms, final_artifact_ref,
+            status, workflow_version_id, agent_version_id,
+            objective_domain, segment, reward_primary_metric, reward_direction,
+            reward_value, reward_anchor, reward_g, reward_vector_json,
+            reward_source, validity
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        ON CONFLICT(trace_id) DO UPDATE SET
+            status=excluded.status, run_id=COALESCE(excluded.run_id, run_id),
+            verifier_output=excluded.verifier_output,
+            reviewer_verdict=excluded.reviewer_verdict, cost_usd=excluded.cost_usd,
+            duration_ms=excluded.duration_ms, final_artifact_ref=excluded.final_artifact_ref,
+            objective_domain=excluded.objective_domain, segment=excluded.segment,
+            reward_primary_metric=excluded.reward_primary_metric,
+            reward_direction=excluded.reward_direction, reward_value=excluded.reward_value,
+            reward_anchor=excluded.reward_anchor, reward_g=excluded.reward_g,
+            reward_vector_json=excluded.reward_vector_json,
+            reward_source=excluded.reward_source, validity=excluded.validity""",
+        (
+            trace_id, run_id, p.get("task_class", ""), prompt_version,
+            p.get("context_bundle_hash", "") or "",
+            json.dumps(p.get("tool_calls", [])), json.dumps(p.get("files_read", [])),
+            json.dumps(p.get("files_written", [])), json.dumps(verifier_output_obj),
+            p.get("reviewer_verdict"), float(p.get("cost_usd", 0.0)),
+            int(p.get("duration_ms", 0)), p.get("final_artifact_ref"),
+            p.get("status", "success"), workflow_version_id,
+            p.get("agent_version_id", "") or "",
+            p.get("objective_domain") or "code-delivery",
+            p.get("segment") or p.get("task_class") or None,
+            p.get("reward_primary_metric"), reward_direction,
+            float(reward_value) if reward_value is not None else None,
+            float(reward_anchor) if reward_anchor is not None else None,
+            float(reward_g) if reward_g is not None else None,
+            reward_vector_json, p.get("reward_source") or "verifier@v1",
+            p.get("validity") or "valid",
+        ),
+    )
+    con.commit()
+    con.close()
+    return trace_id
+
+
+def trace_write_node(task_class: str, status: str = "success",
+                     extra: dict | None = None) -> dict:
+    """Build a node-trace payload, enriched with cost/duration from the dispatch
+    sidecars in $MINI_ORK_RUN_DIR (freshness-gated). Returns the payload dict."""
+    extra = dict(extra or {})
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    try:
+        timeout = int(os.environ.get("MO_DISPATCH_TIMEOUT", "1500"))
+    except ValueError:
+        timeout = 1500
+    freshness_s = 5 * timeout
+    now = time.time()
+
+    def _read_sidecar(name):
+        if not run_dir:
+            return None
+        path = os.path.join(run_dir, name)
+        try:
+            st = os.stat(path)
+        except OSError:
+            return None
+        if now - st.st_mtime > freshness_s:
+            return None
+        try:
+            with open(path) as fh:
+                return fh.read().strip()
+        except OSError:
+            return None
+
+    cost = 0.0
+    c = _read_sidecar(".last-llm-cost")
+    if c:
+        try:
+            cost = float(c)
+        except ValueError:
+            cost = 0.0
+    duration_ms = 0
+    d = _read_sidecar(".last-llm-duration-ms")
+    if d:
+        try:
+            duration_ms = int(float(d))
+        except ValueError:
+            duration_ms = 0
+
+    payload = {
+        "trace_id": extra.get("trace_id") or f"tr-{uuid.uuid4().hex[:16]}",
+        "task_class": task_class, "status": status,
+        "cost_usd": cost, "duration_ms": duration_ms,
+    }
+    for k, v in extra.items():
+        if k not in payload or payload[k] in (None, "", 0, 0.0):
+            payload[k] = v
+    return payload
+
+
+def grade_run_reward(run_dir: str, run_id: str, db: str | None = None) -> int:
+    """Close the eval loop (win #3): stamp the rubric's GRADED 0-8 run score as
+    reward_g on every trace of this run, instead of the binary verdict flatten.
+    Reads <run_dir>/rubric.json {score}, normalizes score/8 → [0,1] against a
+    fixed neutral anchor 0.5 → reward_g in [-1,+1]. Returns rows updated.
+    Best-effort: a missing/garbled rubric.json is a no-op (returns 0)."""
+    if not run_id:
+        return 0
+    rubric_path = os.path.join(run_dir, "rubric.json")
+    try:
+        with open(rubric_path, encoding="utf-8") as fh:
+            score = float(json.load(fh).get("score"))
+    except (ValueError, TypeError, KeyError, OSError):
+        return 0
+    val = max(0.0, min(1.0, score / 8.0))
+    anchor = 0.5
+    reward_g = (val - anchor) / abs(anchor)
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    con.execute(
+        "UPDATE execution_traces SET reward_value=?, reward_anchor=?, reward_g=?, "
+        "reward_direction='higher_is_better', reward_primary_metric='rubric_score', "
+        "reward_source='rubric@v1' WHERE run_id=?",
+        (val, anchor, reward_g, run_id),
+    )
+    n = con.total_changes
+    con.commit()
+    con.close()
+    return n
+
+
+def trace_get(trace_id: str, db: str | None = None) -> dict | None:
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    row = con.execute("SELECT * FROM execution_traces WHERE trace_id=?",
+                      (trace_id,)).fetchone()
+    con.close()
+    return dict(row) if row else None
+
+
+def trace_query(task_class: str = "", status: str = "", since: int = 0,
+                limit: int = 1000, db: str | None = None) -> list[dict]:
+    import datetime
+    try:
+        since_iso = datetime.datetime.utcfromtimestamp(int(since)).strftime(
+            "%Y-%m-%dT%H:%M:%S.000Z")
+    except (ValueError, TypeError, OSError):
+        since_iso = str(since)
+    clauses, params = ["created_at >= ?"], [since_iso]
+    if task_class:
+        clauses.append("task_class = ?")
+        params.append(task_class)
+    if status:
+        clauses.append("status = ?")
+        params.append(status)
+    sql = ("SELECT * FROM execution_traces WHERE " + " AND ".join(clauses)
+           + " ORDER BY created_at DESC LIMIT ?")
+    params.append(limit)
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    rows = con.execute(sql, params).fetchall()
+    con.close()
+    return [dict(r) for r in rows]

--- a/tests/unit/test_cache_py.py
+++ b/tests/unit/test_cache_py.py
@@ -1,0 +1,98 @@
+"""Integration + parity gate for mini_ork.cache (Python port of lib/cache.sh).
+
+Two things proven here:
+1. PARITY on the pure bits (input_hash, hash_bundle) vs the live bash functions.
+2. The win #2 BEHAVIOR CHANGE: the Python cache hits across iterations on an
+   identical input_hash, where the bash cache (iter in the predicate) misses —
+   this is the ×5-recursion recompute fix, demonstrated against live bash.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import cache  # noqa: E402
+
+CACHE_SH = REPO / "lib" / "cache.sh"
+
+
+def _bash(db: str, snippet: str) -> str:
+    env = {**os.environ, "MINI_ORK_DB": db, "JOB_ID": "test"}
+    r = subprocess.run(
+        ["bash", "-c", f'. "{CACHE_SH}" >/dev/null 2>&1; {snippet}'],
+        capture_output=True, text=True, env=env,
+    )
+    return r.stdout.strip()
+
+
+@pytest.fixture
+def db(tmp_path):
+    p = str(tmp_path / "state.db")
+    cache.init_schema(p)
+    return p
+
+
+def test_input_hash_parity(db):
+    for s in ["hello", "abc123", "the-quick-brown-fox", "x1y2z3"]:
+        bash_h = _bash(db, f"printf %s {s!r} | mo_cache_input_hash")
+        assert cache.input_hash(s) == bash_h, s
+
+
+def test_hash_bundle_parity(db, tmp_path):
+    f = tmp_path / "frag.txt"
+    f.write_text("some file content", encoding="utf-8")
+    bash_h = _bash(db, f'mo_cache_hash_bundle "alpha" "{f}" "beta"')
+    assert cache.hash_bundle("alpha", str(f), "beta") == bash_h
+
+
+def test_same_iter_hit_parity(db):
+    # Both bash and python must HIT at the emitting iteration.
+    cache.emit("worker", "E1", 1, "HASH1", "success", "/out/x", "/log/x", db=db)
+    assert cache.lookup("worker", "E1", "HASH1", iter=1, db=db) == "/out/x"
+    assert _bash(db, "mo_cache_lookup worker E1 1 HASH1") == "/out/x"
+
+
+def test_cross_iteration_hit_is_the_win2_fix(db):
+    """The core win #2 proof: same input_hash emitted at iter 1, looked up at
+    iter 2. Python HITS (iter dropped from predicate); bash MISSES (iter in
+    predicate) — the exact ×5-recursion recompute we're eliminating."""
+    cache.emit("worker", "E1", 1, "HASH1", "success", "/out/x", "/log/x", db=db)
+    # Python: cross-iteration HIT
+    assert cache.lookup("worker", "E1", "HASH1", iter=2, db=db) == "/out/x"
+    # Bash: cross-iteration MISS (demonstrates the bug being fixed)
+    assert _bash(db, "mo_cache_lookup worker E1 2 HASH1") == ""
+
+
+def test_new_verifier_stages_allowed(db):
+    # win #2 widening: the recursion-loop stages are now cacheable.
+    cache.emit("tier1", "E1", 3, "H2", "success", "/out/t1", "/log", db=db)
+    assert cache.lookup("tier1", "E1", "H2", db=db) == "/out/t1"
+
+
+def test_record_hit_increments(db):
+    cache.emit("worker", "E1", 1, "H5", "success", "/o", "/l", db=db)
+    cache.record_hit("worker", "E1", "H5", db=db)
+    cache.record_hit("worker", "E1", "H5", db=db)
+    con = sqlite3.connect(db)
+    n = con.execute(
+        "SELECT reused_count FROM mini_orch_sessions WHERE input_hash='H5'"
+    ).fetchone()[0]
+    con.close()
+    assert n == 2
+
+
+def test_expired_not_returned_and_gc(db):
+    cache.emit("worker", "E2", 1, "H3", "success", "/o", "/l", db=db)
+    con = sqlite3.connect(db)
+    con.execute("UPDATE mini_orch_sessions SET expires_at='2000-01-01T00:00:00.000Z'")
+    con.commit()
+    con.close()
+    assert cache.lookup("worker", "E2", "H3", db=db) is None
+    assert cache.gc(db) >= 1

--- a/tests/unit/test_coalition_gate_py.py
+++ b/tests/unit/test_coalition_gate_py.py
@@ -1,0 +1,78 @@
+"""Parity gate: mini_ork.ported.coalition_gate vs lib/coalition_gate.sh.
+
+rho is neutralised (MO_RHO_THRESHOLD=999) so the verdict is driven purely by
+family collision — deterministic across bash's measured rho and the Python port.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import trace_store  # noqa: E402
+from mini_ork.ported import coalition_gate as cg  # noqa: E402
+
+CG_SH = REPO / "lib" / "coalition_gate.sh"
+AGENTS = str(REPO / "config" / "agents.yaml")
+
+
+@pytest.fixture
+def db(tmp_path_factory):
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+                   capture_output=True, text=True, check=True)
+    return dbp
+
+
+def _seed(db, panel, lanes):
+    for i, lane in enumerate(lanes):
+        trace_store.trace_write(
+            {"trace_id": f"tr-{i}-{panel}", "agent_version_id": lane,
+             "task_class": "panel", "status": "success"}, db=db)
+
+
+def _bash_verdict(db, panel):
+    r = subprocess.run(
+        ["bash", "-c", f'. "{CG_SH}" && mo_check_panel_coalition "$1" recipe', "_", panel],
+        env={**os.environ, "MINI_ORK_ROOT": str(REPO), "MINI_ORK_DB": db,
+             "MO_RHO_THRESHOLD": "999", "MO_FAMILY_DIVERSITY_GATE": "strict"},
+        capture_output=True, text=True)
+    try:
+        return json.loads(r.stdout.strip().splitlines()[-1])["verdict"], r.returncode
+    except (ValueError, IndexError, KeyError):
+        return None, r.returncode
+
+
+def test_family_of_and_distribution(db):
+    assert cg.family_of("minimax") == "minimax"
+    assert cg.family_of("opus") == "anthropic"
+    assert cg.family_of("codex_lens") == "openai"
+    _seed(db, "P1", ["minimax", "minimax", "codex"])
+    d = cg.family_distribution(db, "P1", AGENTS)
+    assert d["lens_count"] == 3 and d["family_count"] == 2
+
+
+def test_collision_aborts_parity(db):
+    _seed(db, "PC", ["minimax", "minimax"])  # same family -> collision
+    v_py, rc_py = cg.check_panel_coalition("PC", "recipe", rho=0.0, db=db,
+                                           agents_yaml=AGENTS, rho_threshold=999.0)
+    v_bash, rc_bash = _bash_verdict(db, "PC")
+    assert v_py["verdict"] == "COALITION_ABORT" and rc_py == 1
+    assert v_bash == "COALITION_ABORT" and rc_bash == 1
+
+
+def test_diverse_ok_parity(db):
+    _seed(db, "PD", ["minimax", "codex"])  # two families -> diverse
+    v_py, rc_py = cg.check_panel_coalition("PD", "recipe", rho=0.0, db=db,
+                                           agents_yaml=AGENTS, rho_threshold=999.0)
+    v_bash, rc_bash = _bash_verdict(db, "PD")
+    assert v_py["verdict"] == "panel_diverse" and rc_py == 0
+    assert v_bash == "panel_diverse" and rc_bash == 0

--- a/tests/unit/test_config_resolve_parity.py
+++ b/tests/unit/test_config_resolve_parity.py
@@ -1,0 +1,334 @@
+"""Parity gate: ``mini_ork.ported.config_resolve`` vs ``lib/config_resolve.sh``.
+
+For each fixture we seed a self-contained home/root/run-dir tree under
+``tmp_path``, invoke the LIVE bash functions via subprocess (no
+mocking), then call the Python port with the SAME env via in-process
+capture and compare raw stdout byte-for-byte.
+
+Why raw stdout (no ``.strip()``): bash's ``printf '%s\\n' ...`` emits
+exactly ``"path\\n"``. A ``strip()``-comparing harness would silently
+mask a regression that drops the trailing ``\\n``; the raw check
+surfaces it as a parity drift.
+
+Env isolation: each fixture pops ``MINI_ORK_RUN_DIR`` / ``MINI_ORK_HOME`` /
+``MINI_ORK_ROOT`` before applying its overrides so pytest's arbitrary
+collection order cannot leak a prior fixture's env into the next.
+
+Strangler-fig co-existence: ``lib/config_resolve.sh`` is byte-identical
+before and after this test exists.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mini_ork.ported.config_resolve import (
+    resolve_agents_yaml,
+    snapshot_run_config,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_CONFIG_RESOLVE = REPO_ROOT / "lib" / "config_resolve.sh"
+
+_THREE_VARS = ("MINI_ORK_RUN_DIR", "MINI_ORK_HOME", "MINI_ORK_ROOT")
+
+# Repo root contains real ``.mini-ork/config/agents.yaml`` and
+# ``config/agents.yaml``, both of which would satisfy bash's HOME/ROOT
+# fall-through. Every fixture that doesn't intentionally exercise the
+# defaults must override the irrelevant vars to this sentinel.
+_NONEXISTENT = "/nonexistent/__mo_migrate_config_resolve_fixture__"
+
+
+# ── Subprocess + in-process helpers ─────────────────────────────────────────
+
+
+def _build_env(overrides: dict) -> dict:
+    env = os.environ.copy()
+    for k in _THREE_VARS:
+        env.pop(k, None)
+    env.update(overrides)
+    return env
+
+
+def _bash_resolve(env: dict) -> str:
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB_CONFIG_RESOLVE}" && mo_resolve_agents_yaml'],
+        cwd=str(REPO_ROOT), env=env, check=True,
+        capture_output=True, text=True,
+    )
+    return proc.stdout
+
+
+def _bash_snapshot(run_dir: Path, env: dict) -> str:
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB_CONFIG_RESOLVE}" && mo_snapshot_run_config "{run_dir}"'],
+        cwd=str(REPO_ROOT), env=env, check=True,
+        capture_output=True, text=True,
+    )
+    return proc.stdout
+
+
+def _with_env(overrides: dict):
+    """Save the three vars, apply overrides; pair with _restore_env."""
+    saved = {k: os.environ.pop(k, None) for k in _THREE_VARS}
+    for k, v in overrides.items():
+        os.environ[k] = v
+    return saved
+
+
+def _restore_env(saved: dict) -> None:
+    for k in _THREE_VARS:
+        os.environ.pop(k, None)
+    for k, v in saved.items():
+        if v is not None:
+            os.environ[k] = v
+
+
+def _capture_py_resolve(env: dict) -> str:
+    saved = _with_env(env)
+    try:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            resolve_agents_yaml()
+        return buf.getvalue()
+    finally:
+        _restore_env(saved)
+
+
+def _capture_py_snapshot(run_dir: Path, env: dict) -> str:
+    saved = _with_env(env)
+    try:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            snapshot_run_config(str(run_dir))
+        return buf.getvalue()
+    finally:
+        _restore_env(saved)
+
+
+def _seed(tree: Path, body: str) -> None:
+    (tree / "config").mkdir(parents=True, exist_ok=True)
+    (tree / "config" / "agents.yaml").write_text(body, encoding="utf-8")
+
+
+# ── Resolve fixtures ────────────────────────────────────────────────────────
+# Each returns (id, env_overrides, expected_relative_or_absolute_path).
+# The expected path is what bash emits under that env; verified against
+# live bash before parity so a fixture drift surfaces as a fixture
+# failure, not a parity 'pass' on the wrong grounds.
+
+
+def _f01_run_dir_wins(tmp_path):
+    run = tmp_path / "run"
+    home = tmp_path / "home"
+    _seed(run, "lanes: [from-run]\n")
+    _seed(home, "lanes: [from-home]\n")
+    return (
+        "01_run_dir_wins_over_home",
+        {
+            "MINI_ORK_RUN_DIR": str(run),
+            "MINI_ORK_HOME": str(home),
+            "MINI_ORK_ROOT": _NONEXISTENT,
+        },
+        str(run / "config" / "agents.yaml"),
+    )
+
+
+def _f02_home_wins(tmp_path):
+    home = tmp_path / "home"
+    root = tmp_path / "root"
+    _seed(home, "lanes: [from-home]\n")
+    _seed(root, "lanes: [from-root]\n")
+    return (
+        "02_home_wins_over_root",
+        {
+            "MINI_ORK_RUN_DIR": _NONEXISTENT,
+            "MINI_ORK_HOME": str(home),
+            "MINI_ORK_ROOT": str(root),
+        },
+        str(home / "config" / "agents.yaml"),
+    )
+
+
+def _f03_root_only(tmp_path):
+    root = tmp_path / "root"
+    _seed(root, "lanes: [from-root]\n")
+    return (
+        "03_root_only",
+        {
+            "MINI_ORK_RUN_DIR": _NONEXISTENT,
+            "MINI_ORK_HOME": _NONEXISTENT,
+            "MINI_ORK_ROOT": str(root),
+        },
+        str(root / "config" / "agents.yaml"),
+    )
+
+
+def _f04_all_missing_returns_overridden_root(_tmp_path):
+    # HOME and ROOT both overridden to known-missing absolute paths so
+    # bash's fall-through is reproducible regardless of accidental
+    # fixture files at the repo root. Bash echoes the literal ROOT
+    # value (no ``.`` → pwd resolution inside ``printf %s\\n``).
+    fake_root = _NONEXISTENT + "_root"
+    return (
+        "04_all_missing_returns_overridden_root",
+        {
+            "MINI_ORK_RUN_DIR": _NONEXISTENT,
+            "MINI_ORK_HOME": _NONEXISTENT + "_home",
+            "MINI_ORK_ROOT": fake_root,
+        },
+        fake_root + "/config/agents.yaml",
+    )
+
+
+RESOLVE_BUILDERS = (
+    _f01_run_dir_wins,
+    _f02_home_wins,
+    _f03_root_only,
+    _f04_all_missing_returns_overridden_root,
+)
+
+
+@pytest.mark.parametrize(
+    "builder", RESOLVE_BUILDERS, ids=lambda b: b.__name__,
+)
+def test_resolve_parity(tmp_path, builder):
+    fixture_id, env_overrides, expected = builder(tmp_path)
+    expected_nl = expected + "\n"
+
+    observed = _bash_resolve(_build_env(env_overrides))
+    assert observed == expected_nl, (
+        f"fixture expectation drift [{fixture_id}]: "
+        f"expected={expected_nl!r} bash-emitted={observed!r}"
+    )
+
+    py_out = _capture_py_resolve(env_overrides)
+    assert py_out == expected_nl, (
+        f"resolve stdout drift [{fixture_id}]: "
+        f"bash={observed!r} py={py_out!r}"
+    )
+
+
+# ── Snapshot fixtures ───────────────────────────────────────────────────────
+# Each returns (id, run_dir, env_overrides, expected_dest_body_or_None).
+# Idempotent: a pre-existing dest must keep its launch-time body.
+
+
+def _f05_snapshot_idempotent(tmp_path):
+    run = tmp_path / "run"
+    home = tmp_path / "home"
+    launch_body = "lanes: [launch-time]\n"
+    competing = "lanes: [would-overwrite-if-not-idempotent]\n"
+    _seed(run, launch_body)
+    _seed(home, competing)
+    return (
+        "05_snapshot_is_idempotent_noop",
+        run,
+        {
+            "MINI_ORK_RUN_DIR": str(run),
+            "MINI_ORK_HOME": str(home),
+            "MINI_ORK_ROOT": _NONEXISTENT,
+        },
+        launch_body,
+    )
+
+
+def _f06_snapshot_from_home(tmp_path):
+    run = tmp_path / "run"
+    home = tmp_path / "home"
+    body = "lanes: [from-home]\n"
+    _seed(home, body)
+    return (
+        "06_snapshot_fresh_from_home",
+        run,
+        {
+            "MINI_ORK_RUN_DIR": str(run),
+            "MINI_ORK_HOME": str(home),
+            "MINI_ORK_ROOT": _NONEXISTENT,
+        },
+        body,
+    )
+
+
+def _f07_snapshot_from_root(tmp_path):
+    run = tmp_path / "run"
+    root = tmp_path / "root"
+    body = "lanes: [from-root]\n"
+    _seed(root, body)
+    return (
+        "07_snapshot_fresh_from_root_no_home",
+        run,
+        {
+            "MINI_ORK_RUN_DIR": str(run),
+            "MINI_ORK_HOME": _NONEXISTENT,
+            "MINI_ORK_ROOT": str(root),
+        },
+        body,
+    )
+
+
+def _f08_snapshot_no_source(tmp_path):
+    run = tmp_path / "run"
+    return (
+        "08_snapshot_no_source_anywhere",
+        run,
+        {
+            "MINI_ORK_RUN_DIR": str(run),
+            "MINI_ORK_HOME": _NONEXISTENT,
+            "MINI_ORK_ROOT": _NONEXISTENT,
+        },
+        None,
+    )
+
+
+SNAPSHOT_BUILDERS = (
+    _f05_snapshot_idempotent,
+    _f06_snapshot_from_home,
+    _f07_snapshot_from_root,
+    _f08_snapshot_no_source,
+)
+
+
+@pytest.mark.parametrize(
+    "builder", SNAPSHOT_BUILDERS, ids=lambda b: b.__name__,
+)
+def test_snapshot_parity(tmp_path, builder):
+    fixture_id, run_dir, env_overrides, expected_body = builder(tmp_path)
+    dest = run_dir / "config" / "agents.yaml"
+
+    # Bash writes to disk in its cwd (REPO_ROOT) but the dest path is
+    # absolute via the arg, so both sides converge on tmp_path.
+    _bash_snapshot(run_dir, _build_env(env_overrides))
+    _capture_py_snapshot(run_dir, env_overrides)
+
+    if expected_body is None:
+        assert not dest.exists(), (
+            f"[{fixture_id}] expected NO dest (no source anywhere) "
+            f"but found {dest}"
+        )
+    else:
+        assert dest.exists(), (
+            f"[{fixture_id}] expected dest at {dest} but it is missing"
+        )
+        actual = dest.read_text(encoding="utf-8")
+        assert actual == expected_body, (
+            f"[{fixture_id}] dest content drift: "
+            f"expected={expected_body!r} actual={actual!r}"
+        )
+
+
+def test_smoke_import_no_io():
+    """Module imports cleanly; public API is callable with no I/O."""
+    import mini_ork.ported.config_resolve as mod
+    assert mod.resolve_agents_yaml.__name__ == "resolve_agents_yaml"
+    assert mod.snapshot_run_config.__name__ == "snapshot_run_config"
+    assert callable(mod.resolve_agents_yaml)
+    assert callable(mod.snapshot_run_config)

--- a/tests/unit/test_cost_pause_py.py
+++ b/tests/unit/test_cost_pause_py.py
@@ -1,0 +1,66 @@
+"""Parity gate: mini_ork.ported.cost_pause vs lib/cost_pause.sh.
+
+Same spend sequence through the LIVE bash functions and the Python port in
+separate run-dirs; rc, sentinel presence, accumulated spend, and status JSON
+must match at every step.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import cost_pause as cp  # noqa: E402
+
+CP_SH = REPO / "lib" / "cost_pause.sh"
+
+
+def _bash_check(run_dir, run_id, delta):
+    r = subprocess.run(
+        ["bash", "-c", f'. "{CP_SH}" && mo_cost_pause_check "$1" "$2"',
+         "_", run_id, str(delta)],
+        env={**os.environ, "MINI_ORK_RUN_DIR": str(run_dir),
+             "MO_PAUSE_EVERY_USD": "10"},
+        capture_output=True, text=True)
+    return r.returncode
+
+
+def _bash_status(run_dir, run_id):
+    r = subprocess.run(
+        ["bash", "-c", f'. "{CP_SH}" && mo_cost_pause_status "$1"', "_", run_id],
+        env={**os.environ, "MINI_ORK_RUN_DIR": str(run_dir),
+             "MO_PAUSE_EVERY_USD": "10"},
+        capture_output=True, text=True)
+    return json.loads(r.stdout.strip())
+
+
+def test_spend_sequence_parity(tmp_path, monkeypatch):
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+    monkeypatch.setenv("MO_PAUSE_EVERY_USD", "10")
+
+    # Sequence: 5.00 (no pause) -> 8.00 (crosses $10 -> pause) -> 1.00 (no new window)
+    for delta, expect_rc in [(5.00, 0), (8.00, 2), (1.00, 0)]:
+        monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+        rc_py = cp.check("t-run", delta)
+        rc_bash = _bash_check(bash_dir, "t-run", delta)
+        assert rc_py == rc_bash == expect_rc, f"delta={delta}"
+
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    s_py = cp.status("t-run")
+    s_bash = _bash_status(bash_dir, "t-run")
+    assert s_py["paused"] is True and s_bash["paused"] is True
+    assert abs(s_py["spent_usd"] - s_bash["spent_usd"]) < 1e-9
+    assert s_py["spent_usd"] == 14.0
+    assert (py_dir / ".cost-pause").is_file() and (bash_dir / ".cost-pause").is_file()
+
+
+def test_no_run_id_is_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(tmp_path))
+    assert cp.check("", 1.0) == 2

--- a/tests/unit/test_decision_service_py.py
+++ b/tests/unit/test_decision_service_py.py
@@ -1,0 +1,91 @@
+"""Parity gate: mini_ork.ported.decision_service.decide vs lib/decision_service.sh.
+
+EPSILON=0 disables exploration so both sides are deterministic. Two paths:
+cold-start (no traces -> agents.yaml default lane) and learned (seeded winner
+clears the sample floor -> learned route). Bash decide is invoked live and its
+JSON compared field-by-field. No mocking, no hardcoded lane names on the
+cold-start path (the expected default is read from agents.yaml itself).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import lane_router, trace_store  # noqa: E402
+from mini_ork.ported import decision_service as ds  # noqa: E402
+
+DS_SH = REPO / "lib" / "decision_service.sh"
+
+
+@pytest.fixture
+def env_db(tmp_path_factory, monkeypatch):
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+                   capture_output=True, text=True, check=True)
+    # Python side reads the same env the bash side gets.
+    for k, v in {"MINI_ORK_ROOT": str(REPO), "MINI_ORK_HOME": str(home),
+                 "MINI_ORK_DB": dbp, "MO_STORE_DB": dbp, "EPSILON": "0",
+                 "MO_LEARNING_MIN_SAMPLES": "1",
+                 "MO_LEARNING_HALFLIFE_DAYS": "0"}.items():
+        monkeypatch.setenv(k, v)
+    return dbp
+
+
+def _bash_decide(dbp, node_type, task_class, od):
+    r = subprocess.run(
+        ["bash", "-c", f'. "{DS_SH}" && decide "$1" "$2" "$3"',
+         "_", node_type, task_class, od],
+        env={**os.environ}, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr[-400:]
+    return json.loads(r.stdout.strip().splitlines()[-1])
+
+
+def test_cold_start_parity(env_db):
+    b = _bash_decide(env_db, "implementer", "code-fix", "code-delivery")
+    p = ds.decide("implementer", "code-fix", "code-delivery", db=env_db)
+    # Cold start: agents.yaml default lane, no sample, coalition ok.
+    expected_default = ds.default_lane("implementer")
+    assert expected_default, "agents.yaml must configure an implementer lane"
+    assert b["route"] == p["route"] == expected_default
+    assert b["coalition_ok"] is True and p["coalition_ok"] is True
+    assert b["sample_size"] == p["sample_size"] == 0
+    assert b["recursion_hint"] == p["recursion_hint"]
+
+
+def test_learned_route_parity(env_db):
+    # Seed a clear winner (laneA > laneB) then recompute advantages.
+    def seed(lane, rv, n=3):
+        for _ in range(n):
+            trace_store.trace_write(
+                {"task_class": "code-fix", "status": "success",
+                 "agent_version_id": lane, "objective_domain": "code-delivery",
+                 "verifier_output": {"node_type": "implementer"},
+                 "reward_value": rv, "reward_anchor": 0.5,
+                 "reward_direction": "higher_is_better"}, db=env_db)
+    seed("laneA", 1.0)
+    seed("laneB", 0.0)
+    lane_router.recompute_advantages(db=env_db)
+    b = _bash_decide(env_db, "implementer", "code-fix", "code-delivery")
+    p = ds.decide("implementer", "code-fix", "code-delivery", db=env_db)
+    assert b["route"] == p["route"] == "laneA"
+    assert b["sample_size"] == p["sample_size"] > 0
+    assert abs(b["reward_estimate"] - p["reward_estimate"]) < 1e-9
+
+
+def test_seeded_exploration_is_deterministic(env_db, monkeypatch):
+    # With EPSILON=1 + fixed SEED, exploration must pick the same lane on
+    # repeated calls (stable sorted-candidates + seeded RNG discipline).
+    monkeypatch.setenv("EPSILON", "1.0")
+    monkeypatch.setenv("SEED", "42")
+    r1 = ds._explore_route("sonnet", 1.0, "42", ds.resolve_agents_yaml())
+    r2 = ds._explore_route("sonnet", 1.0, "42", ds.resolve_agents_yaml())
+    assert r1 == r2 and r1 != "sonnet"

--- a/tests/unit/test_dispatch_fallback_py.py
+++ b/tests/unit/test_dispatch_fallback_py.py
@@ -1,0 +1,35 @@
+"""Lane-fallback resilience — the fix for the recurring 'one hung lane stalls
+the whole run' failure. A dead/hung primary lane must be abandoned and the run
+served by the next lane, instead of blocking for the full 25-min timeout.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.dispatch.models import DispatchRequest  # noqa: E402
+from mini_ork.dispatch.providers import dispatch_with_fallback  # noqa: E402
+
+
+def test_dead_primary_falls_back_to_working_lane(monkeypatch):
+    # Force glm 'dead' (unset key → preflight fails instantly, standing in for a
+    # hang). The chain must fall back to codex (works in this env) and succeed.
+    monkeypatch.setenv("GLM_API_KEY", "")
+    req = DispatchRequest(model="glm", prompt="Reply with exactly one word: OK",
+                          timeout_s=120, cwd="/tmp")  # /tmp: outside framework, cwd_guard ok
+    r = dispatch_with_fallback(req, ["glm", "codex"], per_attempt_timeout_s=110)
+    assert r.ok, f"expected fallback to codex to succeed, got rc={r.rc} {r.error}"
+    assert (r.text or "").strip(), "served lane returned empty output"
+
+
+def test_all_lanes_dead_returns_faithful_failure_not_hang(monkeypatch):
+    # Both lanes dead → returns a faithful ok=False fast (no 25-min hang).
+    monkeypatch.setenv("GLM_API_KEY", "")
+    monkeypatch.setenv("KIMI_API_KEY", "")
+    monkeypatch.setenv("MINIMAX_API_KEY", "")
+    req = DispatchRequest(model="glm", prompt="x", timeout_s=10, cwd="/tmp")
+    r = dispatch_with_fallback(req, ["glm", "kimi", "minimax"])
+    assert not r.ok
+    assert r.rc != 0

--- a/tests/unit/test_epic_graph_py.py
+++ b/tests/unit/test_epic_graph_py.py
@@ -1,0 +1,100 @@
+"""Parity gate: mini_ork.ported.epic_graph vs lib/epic_graph.sh.
+
+Seeds an epic DAG (A -> B hard, A -> C soft, blocked D), then runs the same
+operations through the LIVE bash functions and the Python port on separate DB
+copies, asserting identical ready-sets, deps_met, and on_done cascades.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import epic_graph as eg  # noqa: E402
+
+EG_SH = REPO / "lib" / "epic_graph.sh"
+
+
+def _bash(db, snippet):
+    r = subprocess.run(["bash", "-c", f'. "{EG_SH}" && {snippet}'],
+                       env={**os.environ, "MINI_ORK_DB": db,
+                            "MINI_ORK_ROOT": str(REPO)},
+                       capture_output=True, text=True)
+    return r.stdout.strip(), r.returncode
+
+
+@pytest.fixture
+def db(tmp_path_factory):
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+                   capture_output=True, text=True, check=True)
+    con = sqlite3.connect(dbp)
+    for i, (eid, status) in enumerate(
+            [("A", "not started"), ("B", "blocked"), ("C", "not started"),
+             ("D", "blocked")]):
+        con.execute(
+            "INSERT INTO epics (id, title, status, created_at) "
+            "VALUES (?,?,?,strftime('%Y-%m-%dT%H:%M:%fZ','now',?))",
+            (eid, f"epic {eid}", status, f"+{i} seconds"))
+    con.commit()
+    con.close()
+    return dbp
+
+
+def _seed_deps(db):
+    eg.add_dep("A", "B", "hard", db=db)   # B blocked on A
+    eg.add_dep("A", "C", "soft", db=db)   # soft: does NOT block C
+    eg.add_dep("B", "D", "hard", db=db)   # D blocked on B
+
+
+def test_ready_set_parity(db):
+    _seed_deps(db)
+    py = eg.ready_now(db=db)
+    bash_out, _ = _bash(db, "epic_graph_ready_now")
+    assert py == bash_out.splitlines()
+    # A ready (no deps), C ready (only a soft dep); B/D blocked-status anyway.
+    assert py == ["A", "C"]
+
+
+def test_deps_met_parity(db):
+    _seed_deps(db)
+    for eid in ("A", "B", "C", "D"):
+        _, rc = _bash(db, f"epic_graph_deps_met {eid}")
+        assert eg.deps_met(eid, db=db) == (rc == 0), eid
+    assert eg.deps_met("B", db=db) is False   # unresolved hard dep
+    assert eg.deps_met("C", db=db) is True    # soft dep never blocks
+
+
+def test_on_done_cascade_parity(db):
+    _seed_deps(db)
+    db_bash = db + ".bash"
+    shutil.copy(db, db_bash)
+    eg.on_done("A", db=db)                      # python side
+    _bash(db_bash, "epic_graph_on_done A")      # bash side
+
+    def status(dbp, eid):
+        con = sqlite3.connect(dbp)
+        s = con.execute("SELECT status FROM epics WHERE id=?", (eid,)).fetchone()[0]
+        con.close()
+        return s
+
+    # B's only hard dep resolved -> unblocked, on both sides. D still blocked.
+    assert status(db, "B") == status(db_bash, "B") == "not started"
+    assert status(db, "D") == status(db_bash, "D") == "blocked"
+    assert eg.ready_now(db=db) == ["A", "B", "C"]
+
+
+def test_mark_ready_idempotent(db):
+    eg.mark_ready("D", db=db)
+    assert "D" in eg.ready_now(db=db)
+    eg.mark_ready("D", db=db)  # no-op on non-blocked
+    assert eg.ready_now(db=db).count("D") == 1

--- a/tests/unit/test_grade_run_reward_py.py
+++ b/tests/unit/test_grade_run_reward_py.py
@@ -1,0 +1,70 @@
+"""Eval-loop closure (win #3): the rubric's graded 0-8 run score must reach the
+learning reward as a graded reward_g, not a flattened pass/fail. Verifies the
+grading curve and bash↔python parity of mo_grade_run_reward.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import trace_store  # noqa: E402
+
+TS_SH = REPO / "lib" / "trace_store.sh"
+
+
+@pytest.fixture
+def db(tmp_path_factory):
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+                   capture_output=True, text=True, check=True)
+    return dbp
+
+
+def _seed(db, run_id, n=2):
+    for i in range(n):
+        trace_store.trace_write(
+            {"trace_id": f"{run_id}-{i}", "run_id": run_id, "task_class": "code-fix",
+             "status": "success", "agent_version_id": "minimax"}, db=db)
+
+
+def _reward_g(db, trace_id):
+    con = sqlite3.connect(db)
+    r = con.execute("SELECT reward_g FROM execution_traces WHERE trace_id=?",
+                    (trace_id,)).fetchone()
+    con.close()
+    return r[0] if r else None
+
+
+@pytest.mark.parametrize("score,expected", [(0, -1.0), (4, 0.0), (6, 0.5), (8, 1.0)])
+def test_graded_curve_python(db, tmp_path, score, expected):
+    run_id = f"run-{score}"
+    _seed(db, run_id)
+    rd = tmp_path / f"rd{score}"
+    rd.mkdir()
+    (rd / "rubric.json").write_text(json.dumps({"pass": True, "score": score, "items": []}))
+    n = trace_store.grade_run_reward(str(rd), run_id, db=db)
+    assert n == 2  # both traces of the run graded
+    assert abs(_reward_g(db, f"{run_id}-0") - expected) < 1e-9
+
+
+def test_bash_python_parity(db, tmp_path):
+    rd = tmp_path / "rd"
+    rd.mkdir()
+    (rd / "rubric.json").write_text(json.dumps({"pass": True, "score": 6, "items": []}))
+    _seed(db, "run-py")
+    _seed(db, "run-bash")
+    trace_store.grade_run_reward(str(rd), "run-py", db=db)
+    subprocess.run(
+        ["bash", "-c", f'. "{TS_SH}" && mo_grade_run_reward "$1" "$2"', "_", str(rd), "run-bash"],
+        env={**os.environ, "MINI_ORK_DB": db}, capture_output=True, text=True, check=True)
+    assert _reward_g(db, "run-py-0") == _reward_g(db, "run-bash-0") == 0.5

--- a/tests/unit/test_lane_router_py.py
+++ b/tests/unit/test_lane_router_py.py
@@ -1,0 +1,95 @@
+"""Parity gate: mini_ork.lane_router vs lib/lane_router.sh (GRPO advantage).
+
+Seed execution_traces, copy the DB, run the LIVE bash recompute on one copy and
+the Python recompute on the other, and assert agent_performance_memory advantages
++ preferred_lane match. Halflife is disabled (MO_LEARNING_HALFLIFE_DAYS=0) so the
+recency weight can't drift between the two runs' wall-clock.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import lane_router, trace_store  # noqa: E402
+
+LR_SH = REPO / "lib" / "lane_router.sh"
+DETERM = {"MO_LEARNING_HALFLIFE_DAYS": "0"}
+
+
+@pytest.fixture
+def seeded(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    base = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": base},
+                   capture_output=True, text=True, check=True)
+    # Two groups, two lanes each, clear winners.
+    def seed(lane, od, tc, node, rv, ra, n):
+        for _ in range(n):
+            trace_store.trace_write(
+                {"task_class": tc, "status": "success", "agent_version_id": lane,
+                 "objective_domain": od, "verifier_output": {"node_type": node},
+                 "reward_value": rv, "reward_anchor": ra, "reward_direction": "higher_is_better"},
+                db=base)
+    seed("laneA", "code-delivery", "code-fix", "implementer", 1.0, 0.5, 3)   # +1
+    seed("laneB", "code-delivery", "code-fix", "implementer", 0.0, 0.5, 3)   # -1
+    seed("laneA", "book-gen", "chapter", "writer", 0.9, 0.6, 3)
+    seed("laneC", "book-gen", "chapter", "writer", 0.2, 0.6, 3)
+    return base
+
+
+def _apm(db):
+    con = sqlite3.connect(db)
+    rows = con.execute(
+        "SELECT agent_version_id, task_class, round(relative_advantage,4), "
+        "runs_count, success_count FROM agent_performance_memory "
+        "ORDER BY agent_version_id, task_class").fetchall()
+    con.close()
+    return rows
+
+
+def test_recompute_advantage_parity(seeded):
+    db_bash = seeded + ".bash"
+    db_py = seeded + ".py"
+    shutil.copy(seeded, db_bash)
+    shutil.copy(seeded, db_py)
+    subprocess.run(
+        ["bash", "-c", f'. "{LR_SH}" && lane_router_recompute_advantages'],
+        env={**os.environ, **DETERM, "MINI_ORK_DB": db_bash, "MO_STORE_DB": db_bash},
+        capture_output=True, text=True, check=True)
+    old = os.environ.copy()
+    os.environ.update(DETERM)
+    try:
+        lane_router.recompute_advantages(db=db_py)
+    finally:
+        os.environ.clear()
+        os.environ.update(old)
+    assert _apm(db_bash) == _apm(db_py), f"\nbash={_apm(db_bash)}\npy  ={_apm(db_py)}"
+
+
+def test_preferred_lane_parity(seeded):
+    # min_samples=1: with one group per lane, runs_count=1 must still clear the
+    # floor so we exercise the actual pick (not the below-floor empty path).
+    env = {**DETERM, "MO_LEARNING_MIN_SAMPLES": "1"}
+    os.environ.update(env)
+    try:
+        lane_router.recompute_advantages(db=seeded)
+        py = lane_router.preferred_lane("code-fix", "implementer", "code-delivery", db=seeded)
+    finally:
+        for k in env:
+            os.environ.pop(k, None)
+    bash = subprocess.run(
+        ["bash", "-c", f'. "{LR_SH}" && lane_router_preferred_lane code-fix implementer code-delivery'],
+        env={**os.environ, **env, "MINI_ORK_DB": seeded, "MO_STORE_DB": seeded},
+        capture_output=True, text=True).stdout.strip()
+    assert py.split("|")[0] == "laneA"                    # winner
+    assert bash.split("|")[0] == py.split("|")[0]         # bash == python

--- a/tests/unit/test_pricing_strategy_parity.py
+++ b/tests/unit/test_pricing_strategy_parity.py
@@ -1,0 +1,204 @@
+"""Parity gate: ``mini_ork.ported.pricing_strategy.lookup`` vs ``bash lib/pricing_strategy.sh``.
+
+For each fixture we seed a self-contained ``pricing.yaml`` under ``tmp_path``,
+invoke the LIVE bash function via subprocess (no mocking, exactly as the
+production runtime would), then call the Python port against
+``yaml.safe_load`` of the SAME file and compare the resulting stdout
+strings byte-for-byte.
+
+Why stdout-only: the bash function emits ``"0"`` plus a stderr warning on
+invalid kind / unknown provider / unknown model / parse error. The port
+deliberately strips stderr (caller-visible parity is the stdout byte);
+this gate therefore checks stdout strings only, matching the kickoff
+contract ("floats within 1e-6, strings exact" — interpreted as "strings
+exact, since output is a string").
+
+Strangler-fig co-existence is preserved: ``lib/pricing_strategy.sh`` is
+byte-identical before and after this test exists. The test only WRITES
+to its ``tmp_path`` (its own pricing.yaml) and READS from
+``lib/pricing_strategy.sh`` (verified by ``git diff --stat`` in the
+verifier step).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from mini_ork.ported.pricing_strategy import lookup
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_PRICING = REPO_ROOT / "lib" / "pricing_strategy.sh"
+
+
+def _run_bash(yaml_path: Path, provider: str, model: str, kind: str) -> str:
+    """Shell out to bash and invoke ``pricing_lookup <p> <m> <k>`` against the live file.
+
+    The parent shell's ``MO_PRICING_YAML`` is popped first so bash does not
+    silently re-read the repo's ``.mini-ork/config/pricing.yaml`` instead of
+    our fixture file. The fixture path is then exported via the subprocess
+    env. ``cwd=REPO_ROOT`` keeps ``lib/...`` resolution stable.
+    """
+    env = os.environ.copy()
+    env.pop("MO_PRICING_YAML", None)
+    env.pop("MINI_ORK_HOME", None)
+    env["MO_PRICING_YAML"] = str(yaml_path)
+
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB_PRICING}" && pricing_lookup "{provider}" "{model}" "{kind}"'],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # Strip the trailing newline — bash's ``print("3.0")`` emits "3.0\n".
+    # The Python port returns the bare string, so we align both sides.
+    return proc.stdout.strip()
+
+
+def _run_python(yaml_path: Path, provider: str, model: str, kind: str) -> str:
+    """In-process port: parse the same yaml the bash heredoc sees, then look up."""
+    with open(yaml_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    return lookup(data, provider, model, kind)
+
+
+def _assert_parity(yaml_path: Path, provider: str, model: str, kind: str, label: str) -> None:
+    bash_out = _run_bash(yaml_path, provider, model, kind)
+    py_out = _run_python(yaml_path, provider, model, kind)
+    assert bash_out == py_out, (
+        f"parity drift [{label}]: bash={bash_out!r} py={py_out!r} "
+        f"(provider={provider!r} model={model!r} kind={kind!r})"
+    )
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+# Each entry yields the yaml body + the lookup triple. Written as
+# standalone functions so the yaml content stays close to its assertions
+# and the parametrize ids read like a spec.
+
+def _yaml_anthropic() -> str:
+    return (
+        "pricing:\n"
+        "  anthropic:\n"
+        "    claude-sonnet-4-6:\n"
+        "      input:       3.00\n"
+        "      output:     15.00\n"
+        "      cache_read:  0.30\n"
+        "      cache_write: 3.75\n"
+        "  openai:\n"
+        "    gpt-5:\n"
+        "      input:       2.50\n"
+        "      output:     10.00\n"
+    )
+
+
+def _yaml_custom_decimal() -> str:
+    return (
+        "pricing:\n"
+        "  custom:\n"
+        "    special-model:\n"
+        "      input:  10.50\n"
+        "      output: 99.99\n"
+    )
+
+
+def _yaml_int_rates() -> str:
+    return (
+        "pricing:\n"
+        "  anthropic:\n"
+        "    claude-haiku-4-5:\n"
+        "      input:  5\n"
+        "      output: 25\n"
+    )
+
+
+def _yaml_missing_cache_column() -> str:
+    """gpt-5 has no cache_read/cache_write — those keys must silently miss."""
+    return (
+        "pricing:\n"
+        "  openai:\n"
+        "    gpt-5:\n"
+        "      input:  2.50\n"
+        "      output: 10.00\n"
+    )
+
+
+def _yaml_minimal() -> str:
+    return "pricing:\n  anthropic:\n    claude-sonnet-4-6:\n      input: 3.00\n"
+
+
+FIXTURES = [
+    # (id, yaml_body, provider, model, kind)
+    ("f01_hit_input",            _yaml_anthropic(),         "anthropic", "claude-sonnet-4-6", "input"),
+    ("f02_hit_cache_read",       _yaml_anthropic(),         "anthropic", "claude-sonnet-4-6", "cache_read"),
+    ("f03_hit_output",           _yaml_anthropic(),         "anthropic", "claude-sonnet-4-6", "output"),
+    ("f04_miss_provider",        _yaml_anthropic(),         "unknown",   "claude-sonnet-4-6", "input"),
+    ("f05_miss_model",           _yaml_anthropic(),         "anthropic", "gpt-5",             "input"),
+    ("f06_miss_cache_write",     _yaml_missing_cache_column(), "openai", "gpt-5",            "cache_write"),
+    ("f07_unknown_kind",         _yaml_anthropic(),         "anthropic", "claude-sonnet-4-6", "bogus_kind"),
+    ("f08_custom_decimal",       _yaml_custom_decimal(),    "custom",    "special-model",     "input"),
+    ("f09_int_rate",             _yaml_int_rates(),         "anthropic", "claude-haiku-4-5",  "input"),
+    ("f10_minimal",              _yaml_minimal(),           "anthropic", "claude-sonnet-4-6", "input"),
+]
+
+
+@pytest.mark.parametrize(
+    "yaml_body,provider,model,kind",
+    [(f[1], f[2], f[3], f[4]) for f in FIXTURES],
+    ids=[f[0] for f in FIXTURES],
+)
+def test_pricing_lookup_matches_bash(tmp_path, yaml_body, provider, model, kind):
+    yaml_path = tmp_path / "pricing.yaml"
+    yaml_path.write_text(yaml_body, encoding="utf-8")
+
+    label = f"{provider}/{model}/{kind}"
+    _assert_parity(yaml_path, provider, model, kind, label)
+
+
+def test_precondition_bash_returns_non_zero_for_hit(tmp_path):
+    """Precondition gate: if bash ever returns '0' for a known hit (e.g. PyYAML
+    missing in the test env), every other fixture would silently 'pass' on the
+    wrong grounds. Lock the positive case FIRST so a broken environment
+    surfaces as a fixture failure, not a vacuous parity 'pass'.
+    """
+    yaml_path = tmp_path / "pricing.yaml"
+    yaml_path.write_text(_yaml_anthropic(), encoding="utf-8")
+
+    bash_out = _run_bash(yaml_path, "anthropic", "claude-sonnet-4-6", "input")
+    assert bash_out == "3.0", (
+        f"precondition: bash must return '3.0' for known input rate; got {bash_out!r}. "
+        f"PyYAML or python3 likely missing in test env — every fixture would now "
+        f"silently match '0' and the gate would be meaningless."
+    )
+
+
+def test_smoke_import_and_lookup_no_io():
+    """Pure-path smoke: import the module, call lookup against an in-memory
+    dict — no env, no file, no subprocess. Confirms the port works
+    in-process and exercises the ALLOWED branch.
+    """
+    data = {
+        "pricing": {
+            "anthropic": {
+                "claude-sonnet-4-6": {
+                    "input": 3.00,
+                    "cache_read": 0.30,
+                }
+            }
+        }
+    }
+    assert lookup(data, "anthropic", "claude-sonnet-4-6", "input") == "3.0"
+    assert lookup(data, "anthropic", "claude-sonnet-4-6", "cache_read") == "0.3"
+    assert lookup(data, "anthropic", "claude-sonnet-4-6", "cache_write") == "0"
+    assert lookup(data, "anthropic", "claude-sonnet-4-6", "notakind") == "0"
+    assert lookup(data, "unknown", "claude-sonnet-4-6", "input") == "0"
+    assert lookup(data, "anthropic", "unknown", "input") == "0"
+    assert lookup(None, "anthropic", "claude-sonnet-4-6", "input") == "0"
+    assert lookup({"pricing": "not a dict"}, "anthropic", "claude-sonnet-4-6", "input") == "0"

--- a/tests/unit/test_process_reward_parity.py
+++ b/tests/unit/test_process_reward_parity.py
@@ -1,0 +1,190 @@
+"""Parity gate: mini_ork.learning.process_reward.score_trace vs bash prm_score_trace.
+
+For each fixture, we seed a fresh temp sqlite DB with the same row shape
+``lib/process_reward.sh::prm_score_trace`` consumes, invoke the live bash
+function via subprocess (no mocking), and assert ``|bash - python| < 1e-6``.
+
+The bash function reads JSON-as-TEXT from ``execution_traces`` and writes
+the score back to ``process_reward``. The Python port must therefore accept
+JSON strings for ``tool_calls`` / ``files_written`` / ``files_read`` —
+exactly what the row contains.
+
+Strangler-fig co-existence is preserved: ``lib/process_reward.sh`` is
+byte-identical before and after this test file exists.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mini_ork.learning.process_reward import score_trace
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_PROCESS_REWARD = REPO_ROOT / "lib" / "process_reward.sh"
+
+EXEC_TRACES_SCHEMA = """
+CREATE TABLE IF NOT EXISTS execution_traces (
+    trace_id           TEXT PRIMARY KEY,
+    status             TEXT,
+    tool_calls         TEXT NOT NULL DEFAULT '[]',
+    files_written      TEXT NOT NULL DEFAULT '[]',
+    files_read         TEXT NOT NULL DEFAULT '[]',
+    reviewer_verdict   TEXT,
+    duration_ms        INTEGER NOT NULL DEFAULT 0,
+    cost_usd           REAL NOT NULL DEFAULT 0.0,
+    process_reward     REAL
+);
+"""
+
+
+def _seed_db(db_path: Path, trace_id: str, fixture: dict) -> None:
+    con = sqlite3.connect(str(db_path))
+    con.executescript(EXEC_TRACES_SCHEMA)
+    con.execute(
+        "INSERT INTO execution_traces ("
+        "trace_id, status, tool_calls, files_written, files_read,"
+        "reviewer_verdict, duration_ms, cost_usd"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            trace_id,
+            fixture.get("status"),
+            fixture.get("tool_calls", "[]"),
+            fixture.get("files_written", "[]"),
+            fixture.get("files_read", "[]"),
+            fixture.get("reviewer_verdict"),
+            fixture.get("duration_ms", 0),
+            fixture.get("cost_usd", 0.0),
+        ),
+    )
+    con.commit()
+    con.close()
+
+
+def _run_bash_prm(trace_id: str, db_path: Path) -> float:
+    env = os.environ.copy()
+    env["MINI_ORK_ROOT"] = str(REPO_ROOT)
+    env["MO_STORE_DB"] = str(db_path)
+    env["MO_STORE_BACKEND"] = "sqlite"
+    env.pop("MO_PRM_ACTIVITY_CAP", None)
+    proc = subprocess.run(
+        ["bash", "-c", f'. "{LIB_PROCESS_REWARD}" && prm_score_trace "{trace_id}"'],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return float(proc.stdout.strip())
+
+
+def _parity(fixture: dict, tmp_path: Path, trace_id: str = "tr-fixture") -> tuple[float, float]:
+    db_path = tmp_path / f"{trace_id}.sqlite"
+    _seed_db(db_path, trace_id, fixture)
+    bash_score = _run_bash_prm(trace_id, db_path)
+    py_score = score_trace(fixture)
+    return bash_score, py_score
+
+
+# Fixture set — covers the trigger matrix of the weight table plus the
+# Goodhart activity cap and verdict gating. Fields omitted from a fixture
+# default to the empty/zero SQLite representation, which matches what
+# bash sees when those columns are NULL/0.
+FIXTURES = {
+    "bare_success": {"status": "success"},
+    "bare_failed": {"status": "failure"},
+    "failed_heavy_activity_capped": {
+        "status": "failure",
+        "tool_calls": json.dumps([{"name": "bash"}, {"name": "edit"}, {"name": "read"}]),
+        "files_written": json.dumps(["a.py", "b.py"]),
+        "files_read": json.dumps(["c.py"]),
+        "cost_usd": 0.05,
+        "duration_ms": 5000,
+        # Bash: 0 + min(0.20+0.10, 0.15) + 0 + 0.10 + 0.05 = 0.30
+    },
+    "success_verdict_approve": {
+        "status": "success",
+        "reviewer_verdict": "approve",
+        "duration_ms": 3000,
+        # 0.40 + 0 + 0.15 + 0.10 = 0.65
+    },
+    "success_verdict_fail": {
+        "status": "success",
+        "reviewer_verdict": "reject",
+        "duration_ms": 3000,
+        # 0.40 + 0 + 0 + 0.10 = 0.50
+    },
+    "failed_verdict_approve_gated": {
+        "status": "failure",
+        "reviewer_verdict": "approve",
+        "duration_ms": 3000,
+        # verdict gated: 0.10 only
+    },
+    "duration_below_floor_999ms": {
+        "status": "success",
+        "duration_ms": 999,
+        # 0.40 only — too fast
+    },
+    "duration_at_floor_1000ms": {
+        "status": "success",
+        "duration_ms": 1000,
+        # 0.40 + 0.10 = 0.50
+    },
+    "duration_at_ceiling_600000ms": {
+        "status": "success",
+        "duration_ms": 600000,
+        # 0.40 + 0.10 = 0.50
+    },
+    "duration_above_ceiling_600001ms": {
+        "status": "success",
+        "duration_ms": 600001,
+        # 0.40 only — too slow
+    },
+    "cost_zero_no_bonus": {
+        "status": "success",
+        "cost_usd": 0.0,
+        "duration_ms": 3000,
+        # 0.40 + 0.10 = 0.50
+    },
+    "cost_positive_bonus": {
+        "status": "success",
+        "cost_usd": 0.001,
+        "duration_ms": 3000,
+        # 0.40 + 0.10 + 0.05 = 0.55
+    },
+    "empty_none_fields": {
+        # status defaults to "" via get fallback → no status_success
+        # tool_calls/files default "[]" via .get(..., "[]") in helper
+        # reviewer_verdict None → ""
+        "duration_ms": 0,
+    },
+    "tool_plus_file_activity_under_cap": {
+        "status": "success",
+        "tool_calls": json.dumps([{"name": "bash"}]),
+        "files_written": json.dumps(["x.py"]),
+        "duration_ms": 3000,
+        # 0.40 + min(0.20+0.10, 0.15) + 0.10 = 0.65 — verifies cap=0.15 not 0.30
+    },
+}
+
+
+@pytest.mark.parametrize("fixture", list(FIXTURES.values()), ids=list(FIXTURES.keys()))
+def test_score_trace_matches_bash_prm(fixture, tmp_path):
+    bash_score, py_score = _parity(fixture, tmp_path)
+    assert math.isclose(bash_score, py_score, abs_tol=1e-6), (
+        f"parity drift: bash={bash_score!r} py={py_score!r} "
+        f"fixture={fixture!r}"
+    )
+
+
+def test_smoke_import_and_score():
+    """Importing the module and scoring a minimal fixture returns a float in [0, 1]."""
+    score = score_trace({"status": "success"})
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0

--- a/tests/unit/test_rho_aggregator_parity.py
+++ b/tests/unit/test_rho_aggregator_parity.py
@@ -1,0 +1,370 @@
+"""Parity gate: ``mini_ork.ported.rho_aggregator`` vs ``bash lib/rho_aggregator.sh``.
+
+For each fixture we seed a self-contained SQLite database under ``tmp_path``
+(both ``execution_traces`` and ``prompt_win_rates`` tables), invoke the LIVE
+bash function via subprocess (no mocking — exactly as the production runtime
+would), then call the Python port against the same DB and compare output.
+
+Two callables are exercised:
+
+  * ``rho_aggregate_win_rates [--since E] [--task-class X]`` → prints the
+    row count on stdout; Python returns ``int``; compared as ``int``.
+  * ``rho_top_prompts <task_class> <node_type> [<top_n>]`` → prints the
+    formatted table on stdout; Python returns ``str``; compared as
+    ``str`` after ``.strip()`` so trailing-newline differences don't fire
+    (the bash output ALWAYS has a trailing newline, the Python return
+    preserves it too — the strip aligns the case-where-bash-returns-empty
+    where neither side emits a line).
+
+The bash side resolves ``STATE_DB`` from ``$MINI_ORK_DB`` *at source time*
+(``STATE_DB="${MINI_ORK_DB:-${MINI_ORK_HOME:-.mini-ork}/state.db}"``), so
+the subprocess wrapper exports ``MINI_ORK_DB`` to the fixture path BEFORE
+sourcing the file.
+
+Floats inside the formatted table (``win_rate`` at 3 dp, ``win_rate`` at
+4 dp inside the table) are compared after parsing to float with a
+``<1e-6`` tolerance, since the bash ``printf '%.3f'`` and Python
+``f"{x:.3f}"`` use the same round-half-to-even semantics and produce
+identical bit-for-bit strings; the tolerance is the safety net the brief
+asks for. All other columns are compared as exact strings.
+
+Strangler-fig co-existence is preserved: ``lib/rho_aggregator.sh`` is
+byte-identical before and after this test exists. The test only WRITES
+to its ``tmp_path`` SQLite files and READS from
+``lib/rho_aggregator.sh`` (verified by ``git diff --stat`` in the
+verifier step).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import sqlite3
+
+from mini_ork.ported.rho_aggregator import aggregate_win_rates, top_prompts
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_RHO = REPO_ROOT / "lib" / "rho_aggregator.sh"
+
+
+# ── Schema ────────────────────────────────────────────────────────────────────
+# The bash function ``rho_aggregate_win_rates`` issues CREATE TABLE only as
+# part of ``rho_top_prompts``'s sibling (no — it does not; it assumes the
+# tables exist). For the parity gate we always pre-create BOTH tables so
+# fixtures can drive either function. The column list is the minimum needed
+# to satisfy both bash and Python.
+
+_DDL = """
+CREATE TABLE execution_traces(
+    created_at           TEXT,
+    prompt_version_hash  TEXT,
+    task_class           TEXT,
+    status               TEXT,
+    reviewer_verdict     TEXT,
+    node_type            TEXT);
+CREATE TABLE prompt_win_rates(
+    prompt_version_hash  TEXT,
+    task_class           TEXT,
+    wins                 INTEGER,
+    losses               INTEGER,
+    ties                 INTEGER,
+    win_rate             REAL,
+    sample_size          INTEGER,
+    last_updated         TEXT,
+    node_type            TEXT,
+    PRIMARY KEY (prompt_version_hash, task_class));
+"""
+
+
+def _seed_db(db_path: Path, traces: list[tuple] | None = None,
+             rates: list[tuple] | None = None) -> None:
+    """Create the schema and optionally insert rows into the two tables.
+
+    ``traces`` rows: (created_at, prompt_version_hash, task_class,
+    status, reviewer_verdict, node_type)
+    ``rates`` rows:  (prompt_version_hash, task_class, wins, losses, ties,
+    win_rate, sample_size, last_updated, node_type)
+    """
+    con = sqlite3.connect(str(db_path))
+    con.executescript(_DDL)
+    if traces:
+        con.executemany(
+            "INSERT INTO execution_traces VALUES(?,?,?,?,?,?)", traces
+        )
+    if rates:
+        con.executemany(
+            "INSERT INTO prompt_win_rates VALUES(?,?,?,?,?,?,?,?,?)", rates
+        )
+    con.commit()
+    con.close()
+
+
+# ── Subprocess wrappers ──────────────────────────────────────────────────────
+
+def _run_bash_aggregate(db_path: Path, since: int = 0,
+                        task_class: str = "") -> int:
+    """Live bash ``rho_aggregate_win_rates [--since E] [--task-class X]``.
+
+    The subprocess wrapper exports ``MINI_ORK_DB`` so the bash function
+    resolves ``STATE_DB`` at source time to our fixture file.
+    """
+    env = os.environ.copy()
+    env.pop("MINI_ORK_HOME", None)
+    env["MINI_ORK_DB"] = str(db_path)
+
+    args = ""
+    if since:
+        args += f" --since {int(since)}"
+    if task_class:
+        args += f" --task-class {task_class}"
+
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB_RHO}" && rho_aggregate_win_rates{args}'],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return int(proc.stdout.strip())
+
+
+def _run_bash_top(db_path: Path, task_class: str, node_type: str = "",
+                  top_n: int = 5) -> str:
+    """Live bash ``rho_top_prompts <tc> <nt> [<n>]``. Returns stdout verbatim."""
+    env = os.environ.copy()
+    env.pop("MINI_ORK_HOME", None)
+    env["MINI_ORK_DB"] = str(db_path)
+
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB_RHO}" && rho_top_prompts "{task_class}" "{node_type}" {int(top_n)}'],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+# ── Comparison helpers ───────────────────────────────────────────────────────
+
+_FLOAT_RE = re.compile(r"^-?\d+\.\d+$")
+
+
+def _assert_parity_top(bash_out: str, py_out: str, label: str) -> None:
+    """Compare formatted table lines: floats within 1e-6, rest exact."""
+    bash_lines = [ln for ln in bash_out.splitlines() if ln.strip()]
+    py_lines = [ln for ln in py_out.splitlines() if ln.strip()]
+    assert bash_lines == py_lines or len(bash_lines) == len(py_lines), (
+        f"row count drift [{label}]: bash_lines={bash_lines!r} py_lines={py_lines!r}"
+    )
+    for b_line, p_line in zip(bash_lines, py_lines):
+        b_cols = [c.strip() for c in b_line.split("|")]
+        p_cols = [c.strip() for c in p_line.split("|")]
+        assert len(b_cols) == 4 == len(p_cols), (
+            f"column count drift [{label}]: bash={b_cols!r} py={p_cols!r}"
+        )
+        for i, (b, p) in enumerate(zip(b_cols, p_cols)):
+            if _FLOAT_RE.match(b) and _FLOAT_RE.match(p):
+                assert math.isclose(float(b), float(p), abs_tol=1e-6), (
+                    f"float drift [{label}] col={i}: bash={b!r} py={p!r}"
+                )
+            else:
+                assert b == p, (
+                    f"string drift [{label}] col={i}: bash={b!r} py={p!r} "
+                    f"(line bash={b_line!r} py={p_line!r})"
+                )
+
+
+# ── Fixtures: prompt_win_rates directly (for top_prompts) ───────────────────
+
+# Each row: (prompt_version_hash, task_class, wins, losses, ties,
+#            win_rate, sample_size, last_updated, node_type)
+
+_RATES_BASIC = [
+    ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("cccc3333dddd4444", "tc1", 6, 4, 0, 0.6000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("eeee5555ffff6666", "tc1", 9, 1, 0, 0.9000, 10, "2025-01-01T00:00:00.000Z", None),
+]
+
+_RATES_WITH_SMALL_SAMPLE = [
+    # sample_size=2 must be excluded by the sample_size >= 3 clause
+    ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("zzzz1111yyyy2222", "tc1", 1, 0, 0, 1.0000,  2, "2025-01-01T00:00:00.000Z", None),
+]
+
+_RATES_DIFFERENT_TASK = [
+    ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("bbbb1111cccc2222", "tc2", 7, 3, 0, 0.7000, 10, "2025-01-01T00:00:00.000Z", None),
+]
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+def test_f01_top_prompts_basic_sorted_desc(tmp_path):
+    """Three rows in ``prompt_win_rates``; top_prompts returns them sorted
+    by ``win_rate DESC, sample_size DESC`` with the 3-dp / width-4 / 12-char
+    formatting bash's ``printf`` chain produces."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_BASIC)
+
+    bash_out = _run_bash_top(db, "tc1", "", 5)
+    py_out = top_prompts(str(db), "tc1", "", 5)
+
+    _assert_parity_top(bash_out, py_out, "f01_top_prompts_basic")
+
+
+def test_f02_top_prompts_top_n_limits_output(tmp_path):
+    """``top_n=2`` returns exactly two rows (the two highest win_rates)."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_BASIC)
+
+    bash_out = _run_bash_top(db, "tc1", "", 2)
+    py_out = top_prompts(str(db), "tc1", "", 2)
+
+    bash_lines = [ln for ln in bash_out.splitlines() if ln.strip()]
+    py_lines = [ln for ln in py_out.splitlines() if ln.strip()]
+    assert len(bash_lines) == 2, f"bash should return 2 lines, got {bash_lines!r}"
+    assert len(py_lines) == 2, f"python should return 2 lines, got {py_lines!r}"
+    _assert_parity_top(bash_out, py_out, "f02_top_n")
+
+
+def test_f03_top_prompts_excludes_sample_size_lt_3(tmp_path):
+    """The sample_size=2 row must be filtered out by ``sample_size >= 3``."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_WITH_SMALL_SAMPLE)
+
+    bash_out = _run_bash_top(db, "tc1", "", 5)
+    py_out = top_prompts(str(db), "tc1", "", 5)
+
+    bash_lines = [ln for ln in bash_out.splitlines() if ln.strip()]
+    py_lines = [ln for ln in py_out.splitlines() if ln.strip()]
+    assert len(bash_lines) == 1, f"only the sample_size=10 row survives, got {bash_lines!r}"
+    assert len(py_lines) == 1
+    _assert_parity_top(bash_out, py_out, "f03_sample_filter")
+
+
+def test_f04_top_prompts_task_class_filter(tmp_path):
+    """``task_class='tc1'`` filter returns only the matching rows."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_DIFFERENT_TASK)
+
+    bash_out = _run_bash_top(db, "tc1", "", 5)
+    py_out = top_prompts(str(db), "tc1", "", 5)
+
+    bash_lines = [ln for ln in bash_out.splitlines() if ln.strip()]
+    assert len(bash_lines) == 1
+    # bash truncates the hash to the first 12 chars via substr(..,1,12).
+    assert "aaaa1111bbbb" in bash_lines[0]
+    _assert_parity_top(bash_out, py_out, "f04_task_class_filter")
+
+
+def test_f05_aggregate_empty_traces_returns_zero(tmp_path):
+    """No traces seeded → aggregate prints ``0`` (Python returns ``0``)."""
+    db = tmp_path / "state.db"
+    _seed_db(db)  # schema only, no rows
+
+    bash_n = _run_bash_aggregate(db)
+    py_n = aggregate_win_rates(str(db))
+
+    assert bash_n == 0
+    assert py_n == 0
+    assert bash_n == py_n
+
+
+def test_f06_aggregate_basic_three_traces_one_group(tmp_path):
+    """Seed 3 traces all in the same (hash, task_class) bucket → 1 group,
+    ``win_rate = 2/3 ≈ 0.6667``, sample_size=3. Bash prints the count ``1``;
+    Python returns ``1``."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None,        "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None,        "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", "REJECT",    "impl"),
+    ])
+
+    bash_n = _run_bash_aggregate(db)
+    py_n = aggregate_win_rates(str(db))
+
+    assert bash_n == 1
+    assert py_n == 1
+    assert bash_n == py_n
+
+    # And the seeded row should now show up in top_prompts at win_rate=0.667
+    bash_out = _run_bash_top(db, "tc1", "", 5)
+    py_out = top_prompts(str(db), "tc1", "", 5)
+    _assert_parity_top(bash_out, py_out, "f06_after_aggregate_top")
+
+
+def test_f07_aggregate_with_since_filter_returns_zero(tmp_path):
+    """``--since`` pointing at the year 3000 filters out all 2025 traces."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None, "impl"),
+    ])
+
+    far_future_epoch = 32_503_680_000  # 3000-01-01T00:00:00Z
+    bash_n = _run_bash_aggregate(db, since=far_future_epoch)
+    py_n = aggregate_win_rates(str(db), since=far_future_epoch)
+
+    assert bash_n == 0
+    assert py_n == 0
+    assert bash_n == py_n
+
+
+def test_f08_aggregate_with_task_class_filter(tmp_path):
+    """``--task-class tc2`` keeps only the tc2 traces; tc1 traces are ignored."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "failure", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "bbbb1111cccc2222", "tc2", "success", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "bbbb1111cccc2222", "tc2", "success", None, "impl"),
+    ])
+
+    bash_n = _run_bash_aggregate(db, task_class="tc2")
+    py_n = aggregate_win_rates(str(db), task_class="tc2")
+
+    assert bash_n == 1, f"only the (bbbb,tc2) bucket is aggregated; got bash_n={bash_n}"
+    assert py_n == 1
+    assert bash_n == py_n
+
+
+def test_precondition_bash_subprocess_works(tmp_path):
+    """Precondition gate: if the subprocess wrapper itself is broken (bad
+    path, missing env, sqlite3 missing), every fixture would silently fail
+    in confusing ways. Lock the live-bash invocation FIRST."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_BASIC)
+
+    bash_out = _run_bash_top(db, "tc1", "", 5)
+    assert bash_out.strip() != "", (
+        "precondition: bash top_prompts must return a non-empty table for "
+        "this seeded fixture. If it's empty, the subprocess wrapper is "
+        "broken (probably MINI_ORK_DB not exported before source)."
+    )
+    # Sanity: the row with the highest win_rate (0.9000) should be first.
+    first_line = bash_out.splitlines()[0]
+    assert "0.900" in first_line, (
+        f"expected 0.900 in the first line, got {first_line!r}"
+    )
+
+
+def test_smoke_import_and_call_no_subprocess():
+    """Pure-path smoke: import the module and call both functions against
+    a hand-built in-memory dict — confirms the port works in-process."""
+    # top_prompts needs a real DB path; aggregate takes a path too. We
+    # exercise the no-side-effect parts: import + signature + return types.
+    import inspect
+    sig_agg = inspect.signature(aggregate_win_rates)
+    assert list(sig_agg.parameters.keys()) == ["state_db", "since", "task_class"]
+    sig_top = inspect.signature(top_prompts)
+    assert list(sig_top.parameters.keys()) == ["state_db", "task_class", "node_type", "top_n"]

--- a/tests/unit/test_scheduler_py.py
+++ b/tests/unit/test_scheduler_py.py
@@ -1,0 +1,127 @@
+"""Parity + behavior gate: mini_ork.scheduler vs bin/mini-ork-scheduler.
+
+Parity: effective_priority + pick ordering are compared against the LIVE bash
+functions (extracted verbatim from the script — sourcing it would run its main
+loop). Behavior: dispatch/verdict/cascade with a stub runner, and the win #1
+proof — three independent epics drain concurrently, not serially.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import scheduler  # noqa: E402
+from mini_ork.ported import epic_graph as eg  # noqa: E402
+
+SCHED = REPO / "bin" / "mini-ork-scheduler"
+
+
+def _bash_fn(db, fn, *args):
+    """Extract a function from the scheduler script and invoke it live."""
+    snippet = subprocess.run(
+        ["sed", "-n", f"/^{fn}()/,/^}}/p", str(SCHED)],
+        capture_output=True, text=True).stdout
+    assert snippet.strip(), f"could not extract {fn} from scheduler"
+    r = subprocess.run(
+        ["bash", "-c", snippet + f'\nSTATE_DB="$MINI_ORK_DB"\n{fn} "$@"', "_", *args],
+        env={**os.environ, "MINI_ORK_DB": db, "STATE_DB": db},
+        capture_output=True, text=True)
+    return r.stdout.strip()
+
+
+@pytest.fixture
+def world(tmp_path_factory):
+    """Temp root (kickoffs + stub runner) + schema'd DB with a priority DAG."""
+    root = tmp_path_factory.mktemp("root")
+    home = root / ".mini-ork"
+    (home / "runs").mkdir(parents=True)
+    dbp = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+                   capture_output=True, text=True, check=True)
+    scheduler.ensure_priority_column(dbp)
+    con = sqlite3.connect(dbp)
+    # A(prio 0) blocks B(prio 10); C,D,E independent (prio 5,0,0)
+    for i, (eid, status, prio) in enumerate(
+            [("A", "not started", 0), ("B", "blocked", 10),
+             ("C", "not started", 5), ("D", "not started", 0),
+             ("E", "not started", 0)]):
+        con.execute(
+            "INSERT INTO epics (id, title, status, priority, created_at) "
+            "VALUES (?,?,?,?,strftime('%Y-%m-%dT%H:%M:%fZ','now',?))",
+            (eid, f"epic {eid}", status, prio, f"+{i} seconds"))
+    con.commit()
+    con.close()
+    eg.add_dep("A", "B", "hard", db=dbp)
+    (root / "kickoffs").mkdir()
+    for eid in "ABCDE":
+        (root / "kickoffs" / f"{eid}.md").write_text(f"# epic {eid}\n")
+    return {"root": str(root), "home": str(home), "db": dbp}
+
+
+def _stub_runner(root, sleep_s=0.0, run_id="stubrun"):
+    stub = Path(root) / "stub-runner.sh"
+    stub.write_text(f"#!/bin/bash\nsleep {sleep_s}\necho run_id={run_id}\n")
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    return str(stub)
+
+
+def test_effective_priority_parity(world):
+    db = world["db"]
+    # A inherits blocked waiter B's priority 10; C keeps its own 5.
+    for eid, expected in (("A", 10), ("C", 5), ("D", 0)):
+        py = scheduler.effective_priority(eid, db=db)
+        bash = int(_bash_fn(db, "_epic_effective_priority", eid) or 0)
+        assert py == bash == expected, eid
+
+
+def test_pick_ordering_parity(world):
+    db = world["db"]
+    ready = scheduler.pick_ready(db=db)
+    bash_first = _bash_fn(db, "_pick_next_epic")
+    # Inheritance puts A (eff 10) first, then C (5), then D/E oldest-first.
+    assert ready == ["A", "C", "D", "E"]
+    assert bash_first.splitlines()[0] == ready[0] == "A"
+
+
+def test_dispatch_done_and_cascade(world):
+    db, root, home = world["db"], world["root"], world["home"]
+    runs = Path(home) / "runs" / "stubrun"
+    runs.mkdir(parents=True)
+    (runs / "verdict.json").write_text(json.dumps({"verdict": "success"}))
+    verdict, rc = scheduler.dispatch_epic(
+        "A", root, home, "epic-runner", db=db,
+        runner_cmd=[_stub_runner(root)])
+    assert verdict == "success" and rc == 0
+    con = sqlite3.connect(db)
+    a, b = [con.execute("SELECT status FROM epics WHERE id=?", (e,)).fetchone()[0]
+            for e in ("A", "B")]
+    con.close()
+    assert a == "done"
+    assert b == "not started"  # cascade unblocked the high-prio waiter
+
+
+def test_pool_drains_concurrently_win1(world):
+    db, root, home = world["db"], world["root"], world["home"]
+    # Remove A/B so the pool sees exactly C,D,E (independent). Each stub run
+    # sleeps 0.6s: serial = ~1.8s, pool(3) must finish well under that.
+    con = sqlite3.connect(db)
+    con.execute("DELETE FROM epics WHERE id IN ('A','B')")
+    con.commit()
+    con.close()
+    t0 = time.time()
+    n = scheduler.run_pool(root, home, db=db, max_parallel=3,
+                           runner_cmd=[_stub_runner(root, sleep_s=0.6)])
+    elapsed = time.time() - t0
+    assert n == 3
+    assert elapsed < 1.5, f"pool ran serially ({elapsed:.2f}s for 3x0.6s epics)"

--- a/tests/unit/test_similarity_parity.py
+++ b/tests/unit/test_similarity_parity.py
@@ -1,0 +1,220 @@
+"""Parity gate: ``mini_ork.ported.similarity.rank`` vs ``bash lib/similarity.sh``.
+
+For each fixture we seed a fresh sqlite DB under one whitelisted
+``(table, text_col)`` pair, invoke the LIVE bash function via subprocess
+(no mocking, exactly as the production runtime would), then call the
+Python port with the fetched column values and compare the resulting JSON
+shapes. Scores must match within ``1e-6`` (post-rounding); row payloads
+must match exactly.
+
+Strangler-fig co-existence is preserved: ``lib/similarity.sh`` is
+byte-identical before and after this test exists. The test only WRITES to
+its ``tmp_path`` and READS from ``lib/similarity.sh``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mini_ork.ported.similarity import rank
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_SIMILARITY = REPO_ROOT / "lib" / "similarity.sh"
+
+# Must mirror lib/similarity.sh::ALLOWED. We only seed against ``bug_reports``
+# here (simplest whitelisted table); extending to the others is plumbing, not
+# new parity surface.
+_TABLE = "bug_reports"
+_TEXT_COL = "title"
+
+
+def _seed(db_path: Path, rows: list[dict]) -> None:
+    con = sqlite3.connect(str(db_path))
+    con.execute(f"CREATE TABLE {_TABLE} (id INTEGER PRIMARY KEY, {_TEXT_COL} TEXT)")
+    for r in rows:
+        con.execute(
+            f"INSERT INTO {_TABLE} (id, {_TEXT_COL}) VALUES (?, ?)",
+            (r["id"], r[_TEXT_COL]),
+        )
+    con.commit()
+    con.close()
+
+
+def _fetch_rows(db_path: Path) -> list[dict]:
+    """Re-read rows in the SAME shape bash's heredoc sees (SELECT rowid AS rid, *)."""
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        f"SELECT rowid AS rid, * FROM {_TABLE}"
+    ).fetchall()
+    out = [dict(r) for r in rows]
+    con.close()
+    return out
+
+
+def _run_bash(db_path: Path, query: str, limit: int) -> list:
+    env = os.environ.copy()
+    env["MINI_ORK_DB"] = str(db_path)
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB_SIMILARITY}" && similarity_query "{_TABLE}" "{_TEXT_COL}" '
+         f'"{query}" {limit}'],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    raw = proc.stdout.strip()
+    return json.loads(raw) if raw else []
+
+
+def _py_match(db_path: Path, query: str, limit: int) -> list:
+    rows = _fetch_rows(db_path)
+    docs = [(r.get(_TEXT_COL) or "") for r in rows]
+    scored = rank(query, docs, limit=limit)
+    return [{"score": s, "row": rows[i]} for s, i in scored]
+
+
+def _assert_parity(bash_out: list, py_out: list) -> None:
+    assert len(bash_out) == len(py_out), (
+        f"length drift: bash={len(bash_out)} py={len(py_out)} "
+        f"bash={bash_out!r} py={py_out!r}"
+    )
+    for b, p in zip(bash_out, py_out):
+        assert math.isclose(b["score"], p["score"], abs_tol=1e-6), (
+            f"score drift: bash={b['score']!r} py={p['score']!r}"
+        )
+        assert b["row"] == p["row"], f"row drift: bash={b['row']!r} py={p['row']!r}"
+
+
+# Fixtures cover the input surface that exercises TF-IDF + IDF + rank orderings.
+# Each writes to its own tmp_path slot thanks to ``tmp_path`` being per-fixture.
+def _f01_single_doc_only_match():
+    return {
+        "rows": [
+            {"id": 1, _TEXT_COL: "fix bug in auth middleware"},
+            {"id": 2, _TEXT_COL: "totally unrelated marketing draft"},
+            {"id": 3, _TEXT_COL: "another unrelated item"},
+        ],
+        "query": "auth middleware",
+        "limit": 5,
+    }
+
+
+def _f02_multi_doc_ranking():
+    return {
+        "rows": [
+            {"id": 1, _TEXT_COL: "auth bug fix tokens expired"},
+            {"id": 2, _TEXT_COL: "token refresh logic flow"},
+            {"id": 3, _TEXT_COL: "completely unrelated thing"},
+        ],
+        "query": "auth tokens",
+        "limit": 5,
+    }
+
+
+def _f03_empty_db():
+    return {"rows": [], "query": "anything", "limit": 5}
+
+
+def _f04_query_with_no_qualifying_tokens():
+    return {
+        "rows": [
+            {"id": 1, _TEXT_COL: "fix bug in auth middleware"},
+            {"id": 2, _TEXT_COL: "another item here"},
+        ],
+        "query": "a b c d",  # all len < 3 after tok; q_vec ends up empty
+        "limit": 5,
+    }
+
+
+def _f05_limit_truncation():
+    return {
+        "rows": [
+            {"id": i, _TEXT_COL: f"match entry number {i}"}
+            for i in range(1, 6)
+        ],
+        "query": "match entry",
+        "limit": 2,
+    }
+
+
+def _f06_idf_downweights_common_token():
+    # word "fix" appears in every doc; only "race" or "condition" should
+    # discriminate. Both ranks should match bash, verifying the IDF log.
+    return {
+        "rows": [
+            {"id": 1, _TEXT_COL: "fix the race condition"},
+            {"id": 2, _TEXT_COL: "fix the leak condition"},
+            {"id": 3, _TEXT_COL: "fix the race detector"},
+            {"id": 4, _TEXT_COL: "fix the leak detector"},
+        ],
+        "query": "race condition",
+        "limit": 5,
+    }
+
+
+def _f07_special_chars_preserved():
+    # dots, slashes, underscores, hyphens are KEPT by the tokenizer
+    return {
+        "rows": [
+            {"id": 1, _TEXT_COL: "fix: error.foo/bar_v2 — retry!"},
+            {"id": 2, _TEXT_COL: "another doc with no overlap"},
+        ],
+        "query": "foo/bar_v2",
+        "limit": 5,
+    }
+
+
+def _f08_duplicates_exact_match():
+    return {
+        "rows": [
+            {"id": 1, _TEXT_COL: "alpha beta gamma"},
+            {"id": 2, _TEXT_COL: "alpha beta gamma"},
+            {"id": 3, _TEXT_COL: "delta epsilon"},
+        ],
+        "query": "alpha beta",
+        "limit": 5,
+    }
+
+
+FIXTURES = {
+    "01_single_doc_only_match":            _f01_single_doc_only_match(),
+    "02_multi_doc_ranking":                _f02_multi_doc_ranking(),
+    "03_empty_db":                         _f03_empty_db(),
+    "04_query_with_no_qualifying_tokens":  _f04_query_with_no_qualifying_tokens(),
+    "05_limit_truncation":                 _f05_limit_truncation(),
+    "06_idf_downweights_common_token":     _f06_idf_downweights_common_token(),
+    "07_special_chars_preserved":          _f07_special_chars_preserved(),
+    "08_duplicates_exact_match":           _f08_duplicates_exact_match(),
+}
+
+
+@pytest.mark.parametrize("fix", list(FIXTURES.values()), ids=list(FIXTURES.keys()))
+def test_similarity_query_matches_bash(tmp_path, fix):
+    db_path = tmp_path / "sim.sqlite"
+    _seed(db_path, fix["rows"])
+
+    bash_out = _run_bash(db_path, fix["query"], fix["limit"])
+    py_out = _py_match(db_path, fix["query"], fix["limit"])
+
+    _assert_parity(bash_out, py_out)
+
+
+def test_smoke_import_and_rank_no_db():
+    """Module imports and ranks without I/O — proves the pure path works in isolation."""
+    out = rank("auth bug", ["auth middleware bug", "unrelated item"], limit=3)
+    assert isinstance(out, list)
+    assert all(isinstance(p, tuple) and len(p) == 2 for p in out)
+    assert all(isinstance(p[0], float) and isinstance(p[1], int) for p in out)
+    assert all(0.0 < p[0] <= 1.0 for p in out)
+    # The auth-relevant doc (index 0) must rank above the unrelated one.
+    assert out[0][1] == 0

--- a/tests/unit/test_topology_parity.py
+++ b/tests/unit/test_topology_parity.py
@@ -1,0 +1,417 @@
+"""Parity gate: ``mini_ork.ported.topology.aggregate_traces`` vs ``bash lib/topology.sh``.
+
+For each fixture we build a small ``execution_traces`` corpus (and an
+optional ``workflow_memory`` join), materialise it into a temp sqlite DB,
+invoke the LIVE bash function via subprocess (no mocking — exactly as
+the production runtime would), read the upserted ``topology_win_rates``
+rows back out, then run the Python port against the same trace rows and
+assert exact parity. Floats must match within ``1e-6``; strings must
+match exactly.
+
+Strangler-fig co-existence is preserved: ``lib/topology.sh`` is
+byte-identical before and after this test exists. The test only WRITES
+to its ``tmp_path`` and READS from ``lib/topology.sh``.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from mini_ork.ported.topology import aggregate_traces
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_TOPOLOGY = REPO_ROOT / "lib" / "topology.sh"
+
+
+# Schemas lifted from the live migrations under db/migrations/. The bash
+# function expects these column names verbatim — keep them in lockstep.
+_EXEC_TRACES_DDL = """
+CREATE TABLE execution_traces (
+  trace_id           TEXT PRIMARY KEY,
+  workflow_version_id TEXT,
+  task_class         TEXT,
+  status             TEXT,
+  reviewer_verdict   TEXT,
+  cost_usd           REAL,
+  duration_ms        INTEGER,
+  created_at         TEXT
+);
+"""
+
+_WORKFLOW_MEMORY_DDL = """
+CREATE TABLE workflow_memory (
+  workflow_version_id TEXT PRIMARY KEY,
+  workflow_name       TEXT,
+  yaml_hash           TEXT
+);
+"""
+
+_TOPOLOGY_WIN_RATES_DDL = """
+CREATE TABLE topology_win_rates (
+  topology_id      TEXT NOT NULL,
+  workflow_name    TEXT NOT NULL,
+  task_class       TEXT NOT NULL,
+  wins             INTEGER NOT NULL DEFAULT 0,
+  losses           INTEGER NOT NULL DEFAULT 0,
+  ties             INTEGER NOT NULL DEFAULT 0,
+  win_rate         REAL    NOT NULL DEFAULT 0.0,
+  sample_size      INTEGER NOT NULL DEFAULT 0,
+  avg_cost_usd     REAL    NOT NULL DEFAULT 0.0,
+  avg_duration_ms  REAL    NOT NULL DEFAULT 0.0,
+  last_updated     TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  UNIQUE (topology_id, task_class)
+);
+"""
+
+
+def _seed(
+    db_path: Path,
+    traces: list[dict[str, Any]],
+    workflow_memory: dict[str, dict[str, str]] | None = None,
+) -> None:
+    """Materialise the test corpus into a fresh sqlite DB.
+
+    The DB has only the three tables bash touches. ``created_at`` is fixed
+    to a recent ISO timestamp well past 1970 so the bash ``WHERE created_at
+    >= ?`` filter (with default ``--since=0``) admits every row.
+    """
+    con = sqlite3.connect(str(db_path))
+    con.executescript(
+        _EXEC_TRACES_DDL + _WORKFLOW_MEMORY_DDL + _TOPOLOGY_WIN_RATES_DDL
+    )
+    if workflow_memory:
+        for wvid, row in workflow_memory.items():
+            con.execute(
+                "INSERT INTO workflow_memory VALUES (?,?,?)",
+                (wvid, row["workflow_name"], row["yaml_hash"]),
+            )
+    for i, t in enumerate(traces):
+        con.execute(
+            "INSERT INTO execution_traces VALUES (?,?,?,?,?,?,?,?)",
+            (
+                f"tr-{i:04d}",
+                t.get("workflow_version_id"),
+                t.get("task_class"),
+                t.get("status"),
+                t.get("reviewer_verdict"),
+                t.get("cost_usd"),
+                t.get("duration_ms"),
+                t.get("created_at", "2026-01-01T00:00:00.000Z"),
+            ),
+        )
+    con.commit()
+    con.close()
+
+
+def _run_bash(db_path: Path) -> None:
+    """Source lib/topology.sh in a fresh bash and call topology_recompute_win_rates.
+
+    ``MINI_ORK_DB`` is set so the bash function targets our temp DB. The
+    function upserts rows into ``topology_win_rates`` and prints the
+    row count on stdout; we don't read it — we read the table instead.
+    """
+    env = os.environ.copy()
+    env["MINI_ORK_DB"] = str(db_path)
+    proc = subprocess.run(
+        ["bash", "-c", f'. "{LIB_TOPOLOGY}" && topology_recompute_win_rates'],
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # Sanity: bash prints the upsert count; assert it parses as int.
+    assert proc.stdout.strip().isdigit(), (
+        f"bash returned non-numeric upsert count: {proc.stdout!r}"
+        f" stderr={proc.stderr!r}"
+    )
+
+
+def _read_bash_aggregates(db_path: Path) -> list[dict[str, Any]]:
+    """Read back exactly what bash upserted, ordered for stable comparison."""
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        """
+        SELECT topology_id, workflow_name, task_class,
+               wins, losses, ties, win_rate, sample_size,
+               avg_cost_usd, avg_duration_ms
+          FROM topology_win_rates
+         ORDER BY topology_id, task_class
+        """
+    ).fetchall()
+    out = [dict(r) for r in rows]
+    con.close()
+    return out
+
+
+def _read_traces(db_path: Path) -> list[dict[str, Any]]:
+    """Read the execution_traces rows we just seeded, in insertion order."""
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        """
+        SELECT workflow_version_id, task_class, status, reviewer_verdict,
+               cost_usd, duration_ms, created_at
+          FROM execution_traces
+         ORDER BY trace_id
+        """
+    ).fetchall()
+    out = [dict(r) for r in rows]
+    con.close()
+    return out
+
+
+def _read_workflow_memory(db_path: Path) -> dict[str, dict[str, str]]:
+    con = sqlite3.connect(str(db_path))
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT workflow_version_id, workflow_name, yaml_hash FROM workflow_memory"
+    ).fetchall()
+    out = {r["workflow_version_id"]: {"workflow_name": r["workflow_name"],
+                                       "yaml_hash": r["yaml_hash"]}
+           for r in rows}
+    con.close()
+    return out
+
+
+def _assert_parity(
+    bash_rows: list[dict[str, Any]],
+    py_rows: list[dict[str, Any]],
+    label: str,
+) -> None:
+    assert len(bash_rows) == len(py_rows), (
+        f"[{label}] row-count drift: bash={len(bash_rows)} py={len(py_rows)}\n"
+        f"  bash={bash_rows!r}\n  py  ={py_rows!r}"
+    )
+    for b, p in zip(bash_rows, py_rows):
+        # String columns — exact match.
+        for k in ("topology_id", "workflow_name", "task_class"):
+            assert b[k] == p[k], f"[{label}] {k} drift: bash={b[k]!r} py={p[k]!r}"
+        # Int columns — exact match (sqlite returns int).
+        for k in ("wins", "losses", "ties", "sample_size"):
+            assert int(b[k]) == int(p[k]), (
+                f"[{label}] {k} drift: bash={b[k]!r} py={p[k]!r}"
+            )
+        # Float columns — close within 1e-6.
+        for k in ("win_rate", "avg_cost_usd", "avg_duration_ms"):
+            assert math.isclose(float(b[k]), float(p[k]), abs_tol=1e-6), (
+                f"[{label}] {k} drift: bash={b[k]!r} py={p[k]!r}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures. Each is a (traces, workflow_memory|None) pair, exercising one
+# specific surface of the bash CASE expression tree.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _f01_pure_wins() -> dict:
+    """All rows are 'success' with a non-rejecting verdict — pure wins."""
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.50, "duration_ms": 8000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": None,
+             "cost_usd": 0.40, "duration_ms": 7000},
+        ],
+        "workflow_memory": None,
+    }
+
+
+def _f02_pure_losses_via_rejection() -> dict:
+    """'success' status with REJECT/ESCALATE/needs_revision verdict — all losses."""
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "REJECT",
+             "cost_usd": 0.20, "duration_ms": 3000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "ESCALATE",
+             "cost_usd": 0.30, "duration_ms": 4000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "needs_revision",
+             "cost_usd": 0.10, "duration_ms": 2000},
+        ],
+        "workflow_memory": None,
+    }
+
+
+def _f03_mixed_outcomes_two_groups() -> dict:
+    """Two (topology, task_class) groups with a full mix of win/loss/tie."""
+    return {
+        "traces": [
+            # Group A: code_fix_v1, code_fix
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE", "cost_usd": 0.4, "duration_ms": 5000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "failure", "reviewer_verdict": "APPROVE", "cost_usd": 0.6, "duration_ms": 6000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "running", "reviewer_verdict": None, "cost_usd": 0.0, "duration_ms": 1000},
+            # Group B: refactor_v1, refactor
+            {"workflow_version_id": "refactor_v1", "task_class": "refactor",
+             "status": "success", "reviewer_verdict": None, "cost_usd": 0.8, "duration_ms": 9000},
+            {"workflow_version_id": "refactor_v1", "task_class": "refactor",
+             "status": "success", "reviewer_verdict": "REJECT", "cost_usd": 0.2, "duration_ms": 2500},
+            {"workflow_version_id": "refactor_v1", "task_class": "refactor",
+             "status": "vacuous", "reviewer_verdict": None, "cost_usd": 0.0, "duration_ms": 0},
+        ],
+        "workflow_memory": None,
+    }
+
+
+def _f04_unrecognized_status_yields_zero_tally() -> dict:
+    """status='completed' is outside the recognized set — must contribute 0 to all 3 buckets.
+
+    The group still appears in the aggregate (matching the GROUP BY contract),
+    with win_rate=0.0 (denom=0) and sample_size=0.
+    """
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "completed", "reviewer_verdict": None,
+             "cost_usd": 0.5, "duration_ms": 5000},
+        ],
+        "workflow_memory": None,
+    }
+
+
+def _f05_workflow_memory_join_overrides() -> dict:
+    """The bash LEFT JOIN swaps in yaml_hash + workflow_name from workflow_memory."""
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v3", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.5, "duration_ms": 4000},
+            {"workflow_version_id": "code_fix_v3", "task_class": "code_fix",
+             "status": "failure", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.3, "duration_ms": 3000},
+        ],
+        "workflow_memory": {
+            "code_fix_v3": {"yaml_hash": "deadbeefcafe", "workflow_name": "code-fix"},
+        },
+    }
+
+
+def _f06_null_status_counts_as_tie() -> dict:
+    """``status IS NULL`` is in the tie branch. Also tests missing cost/duration.
+
+    The bash function uses ``AVG(COALESCE(et.cost_usd, 0))`` — for rows with
+    ``cost_usd IS NULL`` the COALESCE substitutes 0, so the avg is computed
+    over 0.0. Our port has the same behavior via the ``if cost is not None``
+    guard, but to keep the comparison tight, every fixture sets cost_usd and
+    duration_ms on every row.
+    """
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": None, "reviewer_verdict": None,
+             "cost_usd": 0.0, "duration_ms": 0},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "blocked", "reviewer_verdict": None,
+             "cost_usd": 0.0, "duration_ms": 0},
+        ],
+        "workflow_memory": None,
+    }
+
+
+def _f07_avg_cost_and_duration_precision() -> dict:
+    """Three rows with different cost/duration — verifies AVG matches exactly.
+
+    avg_cost = (0.10 + 0.30 + 0.50) / 3 = 0.30
+    avg_dur  = (1000 + 2000 + 3000) / 3 = 2000.0
+    """
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.10, "duration_ms": 1000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.30, "duration_ms": 2000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.50, "duration_ms": 3000},
+        ],
+        "workflow_memory": None,
+    }
+
+
+def _f08_win_rate_rounding_boundaries() -> dict:
+    """3 wins / 4 (wins+losses) = 0.75 exact. Verifies the round(., 4) contract."""
+    return {
+        "traces": [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE", "cost_usd": 0.1, "duration_ms": 1000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE", "cost_usd": 0.1, "duration_ms": 1000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE", "cost_usd": 0.1, "duration_ms": 1000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "failure", "reviewer_verdict": "APPROVE", "cost_usd": 0.1, "duration_ms": 1000},
+        ],
+        "workflow_memory": None,
+    }
+
+
+FIXTURES = {
+    "01_pure_wins":                       _f01_pure_wins(),
+    "02_pure_losses_via_rejection":       _f02_pure_losses_via_rejection(),
+    "03_mixed_outcomes_two_groups":       _f03_mixed_outcomes_two_groups(),
+    "04_unrecognized_status_zero_tally":  _f04_unrecognized_status_yields_zero_tally(),
+    "05_workflow_memory_join_overrides":  _f05_workflow_memory_join_overrides(),
+    "06_null_status_counts_as_tie":       _f06_null_status_counts_as_tie(),
+    "07_avg_cost_and_duration_precision": _f07_avg_cost_and_duration_precision(),
+    "08_win_rate_rounding_boundaries":    _f08_win_rate_rounding_boundaries(),
+}
+
+
+@pytest.mark.parametrize(
+    "fix_id,fix",
+    list(FIXTURES.items()),
+    ids=list(FIXTURES.keys()),
+)
+def test_aggregate_traces_matches_bash(tmp_path, fix_id, fix):
+    db_path = tmp_path / "topology.db"
+    _seed(db_path, fix["traces"], fix.get("workflow_memory"))
+    _run_bash(db_path)
+    bash_rows = _read_bash_aggregates(db_path)
+    py_rows = aggregate_traces(
+        _read_traces(db_path),
+        _read_workflow_memory(db_path) or None,
+    )
+    _assert_parity(bash_rows, py_rows, fix_id)
+
+
+def test_smoke_import_and_aggregate_no_io():
+    """Pure-path smoke: import + aggregate a tiny corpus returns the right shape."""
+    out = aggregate_traces(
+        [
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "success", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.5, "duration_ms": 1000},
+            {"workflow_version_id": "code_fix_v1", "task_class": "code_fix",
+             "status": "failure", "reviewer_verdict": "APPROVE",
+             "cost_usd": 0.3, "duration_ms": 800},
+        ],
+    )
+    assert len(out) == 1
+    row = out[0]
+    assert row["wins"] == 1
+    assert row["losses"] == 1
+    assert row["ties"] == 0
+    assert row["sample_size"] == 2
+    assert math.isclose(row["win_rate"], 0.5, abs_tol=1e-6)
+    assert row["topology_id"] == "code_fix_v1"
+    assert row["workflow_name"] == "?"
+    assert row["task_class"] == "code_fix"
+    assert math.isclose(row["avg_cost_usd"], 0.4, abs_tol=1e-6)
+    assert math.isclose(row["avg_duration_ms"], 900.0, abs_tol=1e-6)

--- a/tests/unit/test_trace_store_py.py
+++ b/tests/unit/test_trace_store_py.py
@@ -1,0 +1,92 @@
+"""Parity gate: mini_ork.trace_store vs lib/trace_store.sh, on the real schema.
+
+For each payload we write via the LIVE bash `trace_write` (trace_id bash-N) and
+via the Python `trace_write` (trace_id py-N) into the same DB, then read back and
+assert reward_g (+ core columns) match. No mocking, no hardcoded reward_g.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import trace_store  # noqa: E402
+
+TS_SH = REPO / "lib" / "trace_store.sh"
+
+PAYLOADS = [
+    {"task_class": "code-fix", "status": "success", "reward_value": 1.0, "reward_anchor": 0.5, "reward_direction": "higher_is_better"},
+    {"task_class": "code-fix", "status": "failure", "reward_value": 0.0, "reward_anchor": 0.5, "reward_direction": "higher_is_better"},
+    {"task_class": "code-fix", "status": "success", "reward_value": 0.5, "reward_anchor": 0.5, "reward_direction": "higher_is_better"},
+    {"task_class": "book-gen", "status": "success", "reward_value": 2.0, "reward_anchor": 1.0, "reward_direction": "higher_is_better"},
+    {"task_class": "book-gen", "status": "success", "reward_value": 1.0, "reward_anchor": 2.0, "reward_direction": "lower_is_better"},
+    {"task_class": "code-fix", "status": "success", "reward_value": 1.0, "reward_anchor": 0.0, "reward_direction": "higher_is_better"},
+    {"task_class": "code-fix", "status": "success"},
+    {"task_class": "eval", "status": "success", "reward_value": 3.0, "reward_anchor": 1.5, "reward_direction": "higher_is_better"},
+    {"task_class": "eval", "status": "success", "reward_value": 0.2, "reward_anchor": 0.8, "reward_direction": "higher_is_better"},
+]
+
+
+@pytest.fixture(scope="module")
+def db(tmp_path_factory):
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(REPO / "db" / "init.sh")],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def _bash_trace_write(db, payload_json):
+    subprocess.run(
+        ["bash", "-c", f'. "{TS_SH}" && trace_write "$1"', "_", payload_json],
+        env={**os.environ, "MINI_ORK_DB": db}, capture_output=True, text=True, check=True,
+    )
+
+
+def _reward_g(db, trace_id):
+    con = sqlite3.connect(db)
+    r = con.execute("SELECT reward_g FROM execution_traces WHERE trace_id=?",
+                    (trace_id,)).fetchone()
+    con.close()
+    return r[0] if r else "MISSING"
+
+
+def test_compute_reward_g_unit():
+    assert trace_store.compute_reward_g(1.0, 0.5, "higher_is_better") == 1.0
+    assert trace_store.compute_reward_g(0.0, 0.5, "higher_is_better") == -1.0
+    assert trace_store.compute_reward_g(1.0, 2.0, "lower_is_better") == 0.5
+    assert trace_store.compute_reward_g(1.0, 0.0, "higher_is_better") is None
+    assert trace_store.compute_reward_g(None, 0.5, "higher_is_better") is None
+
+
+def test_reward_g_parity_bash_vs_python(db):
+    for i, base in enumerate(PAYLOADS):
+        bash_p = {**base, "trace_id": f"bash-{i}"}
+        py_p = {**base, "trace_id": f"py-{i}"}
+        _bash_trace_write(db, json.dumps(bash_p))
+        trace_store.trace_write(py_p, db=db)
+        bg = _reward_g(db, f"bash-{i}")
+        pg = _reward_g(db, f"py-{i}")
+        if bg is None or pg is None:
+            assert bg == pg, f"payload {i}: bash={bg} py={pg}"
+        else:
+            assert abs(float(bg) - float(pg)) < 1e-9, f"payload {i}: bash={bg} py={pg}"
+
+
+def test_roundtrip_get(db):
+    tid = trace_store.trace_write(
+        {"trace_id": "rt-1", "task_class": "code-fix", "status": "success",
+         "reward_value": 1.0, "reward_anchor": 0.5, "reward_direction": "higher_is_better"},
+        db=db)
+    row = trace_store.trace_get(tid, db=db)
+    assert row and row["status"] == "success" and abs(float(row["reward_g"]) - 1.0) < 1e-9

--- a/tests/unit/test_utility_function_parity.py
+++ b/tests/unit/test_utility_function_parity.py
@@ -1,0 +1,189 @@
+"""Parity gate: ``mini_ork.ported.utility_function.score`` vs ``bash lib/utility_function.sh``.
+
+For each fixture we invoke the LIVE bash function via subprocess (no mocking,
+exactly as the production runtime would), capture stdout as a float, then call
+the Python port with the same JSON string and assert
+``|bash_score - python_score| < 1e-6``.
+
+The bash ``utility_score`` checks for a per-task override under
+``${MINI_ORK_HOME}/config/utility_functions/<task_class>.sh`` and dispatches
+to it if present. That path is impure I/O and is intentionally not ported;
+every fixture here omits ``task_class`` so both bash and Python fall through
+to the default formula branch.
+
+Strangler-fig co-existence is preserved: ``lib/utility_function.sh`` is
+byte-identical before and after this test exists. The test only WRITES to
+its ``tmp_path`` (not used here) and READS from ``lib/utility_function.sh``.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mini_ork.ported.utility_function import score
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+LIB_UTILITY = REPO_ROOT / "lib" / "utility_function.sh"
+
+
+def _run_bash_score(run_json: str, env_overrides: dict[str, str] | None = None) -> float:
+    """Shell out to bash and invoke ``utility_score <json>`` against the live file.
+
+    ``env_overrides`` is merged on top of the current process env so per-test
+    weight overrides (``MINI_ORK_W_*``) reach bash exactly as a runtime
+    caller would set them. No mocking — the bash function runs verbatim.
+    """
+    env = os.environ.copy()
+    env.pop("MINI_ORK_W_SUCCESS", None)
+    env.pop("MINI_ORK_W_VERIFIER", None)
+    env.pop("MINI_ORK_W_QUALITY", None)
+    env.pop("MINI_ORK_W_COST", None)
+    env.pop("MINI_ORK_W_LATENCY", None)
+    env.pop("MINI_ORK_W_RISK", None)
+    if env_overrides:
+        env.update(env_overrides)
+
+    proc = subprocess.run(["bash", "-c", f". '{REPO_ROOT}/lib/utility_function.sh' && utility_score '{run_json}'"], cwd=str(REPO_ROOT), env=env, check=True, capture_output=True, text=True)
+    return float(proc.stdout.strip())
+
+
+def _parity(run_json: str, weights: dict | None = None,
+            env_overrides: dict[str, str] | None = None) -> tuple[float, float]:
+    """Run both sides with identical inputs; return (bash, python)."""
+    bash_score = _run_bash_score(run_json, env_overrides=env_overrides)
+    py_score = score(run_json, weights=weights)
+    return bash_score, py_score
+
+
+def _assert_close(bash_score: float, py_score: float, label: str) -> None:
+    assert math.isclose(bash_score, py_score, abs_tol=1e-6), (
+        f"parity drift [{label}]: bash={bash_score!r} py={py_score!r}"
+    )
+
+
+def test_f01_success_true_with_full_fields():
+    """success=True + verifier + quality + cost + duration + risk — the meaty fixture."""
+    run_json = (
+        '{"success": true, "verifier_score": 0.8, "quality_score": 0.7,'
+        ' "cost_usd": 0.5, "max_cost_usd": 1.0, "duration_ms": 5000,'
+        ' "max_duration_ms": 10000, "risk_penalty": 0.1}'
+    )
+    b, p = _parity(run_json)
+    _assert_close(b, p, "f01_success_true_full")
+
+
+def test_f02_success_false_with_quality_default():
+    """success=False; verifier_score/risk_penalty default to 0; quality_score defaults to 0.5."""
+    run_json = '{"success": false}'
+    b, p = _parity(run_json)
+    _assert_close(b, p, "f02_success_false")
+    # Sanity: known bash result for this fixture.
+    assert math.isclose(b, 0.075, abs_tol=1e-6)
+
+
+def test_f03_verifier_score_clamped_to_one():
+    """verifier_score > 1 must clamp to 1.0 before weighting."""
+    run_json = '{"success": true, "verifier_score": 1.7}'
+    b, p = _parity(run_json)
+    _assert_close(b, p, "f03_verifier_clamp")
+
+
+def test_f04_custom_max_cost_usd_normalization():
+    """Custom ceiling changes norm_cost denominator."""
+    run_json = '{"success": true, "cost_usd": 0.25, "max_cost_usd": 0.5}'
+    b, p = _parity(run_json)
+    _assert_close(b, p, "f04_custom_max_cost")
+
+
+def test_f05_custom_max_duration_ms_normalization():
+    """Custom ceiling changes norm_latency denominator."""
+    run_json = '{"success": true, "duration_ms": 3000, "max_duration_ms": 6000}'
+    b, p = _parity(run_json)
+    _assert_close(b, p, "f05_custom_max_duration")
+
+
+def test_f06_weight_override_via_env():
+    """Bash reads MINI_ORK_W_* from env at source time; the Python port
+    reads them at call time. To make both sides agree we thread the same
+    overrides through BOTH mechanisms: env to bash, dict to Python, then
+    verify parity.
+
+    Bash evaluates ``_UTILITY_W_<NAME>="${MINI_ORK_W_<NAME>:-<default>}"``
+    once when the file is sourced, so subprocess must re-source with the
+    overrides in env. The Python side's ``weights`` parameter is the
+    equivalent for in-process callers.
+    """
+    run_json = '{"success": true, "verifier_score": 0.5, "quality_score": 0.5}'
+    weights = {
+        "success": 0.30,
+        "verifier": 0.30,
+        "quality": 0.30,
+        "cost": 0.03,
+        "latency": 0.03,
+        "risk": 0.04,
+    }
+    env_overrides = {f"MINI_ORK_W_{k.upper()}": str(v) for k, v in weights.items()}
+    b, p = _parity(run_json, weights=weights, env_overrides=env_overrides)
+    _assert_close(b, p, "f06_env_weight_override")
+
+
+def test_f07_explicit_weights_dict_overrides_env():
+    """Caller-supplied ``weights`` dict wins over env on the Python side.
+
+    Bash has no equivalent parameter (it reads env only); we re-mirror this
+    fixture by passing the same weights through env on the bash side so
+    both produce the same score.
+    """
+    run_json = '{"success": true, "verifier_score": 1.0}'
+    weights = {
+        "success": 0.50,
+        "verifier": 0.40,
+        "quality": 0.05,
+        "cost": 0.02,
+        "latency": 0.02,
+        "risk": 0.01,
+    }
+    env_overrides = {f"MINI_ORK_W_{k.upper()}": str(v) for k, v in weights.items()}
+    b, p = _parity(run_json, weights=weights, env_overrides=env_overrides)
+    _assert_close(b, p, "f07_explicit_weights")
+
+
+def test_f08_empty_input_defaults():
+    """Empty JSON — only quality_score default (0.5) contributes positively."""
+    run_json = '{}'
+    b, p = _parity(run_json)
+    _assert_close(b, p, "f08_empty_defaults")
+    # 0.15 * 0.5 = 0.075 — confirmed against bash.
+    assert math.isclose(b, 0.075, abs_tol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "raw_success,expected_label",
+    [
+        ("true", "json_bool_true"),
+        ("1", "json_int_one"),
+        ('"true"', "json_string_true"),
+        ('"1"', "json_string_one"),
+        ("false", "json_bool_false"),
+        ("0", "json_int_zero"),
+    ],
+)
+def test_f09_success_truthiness_matrix(raw_success: str, expected_label: str):
+    """Bash's success membership test accepts True/1/'true'/'1'; all four must
+    yield 1.0 before weighting. Bool-False and 0 must yield 0.0."""
+    run_json = '{"success": ' + raw_success + '}'
+    b, p = _parity(run_json)
+    _assert_close(b, p, f"f09_{expected_label}")
+
+
+def test_smoke_import_and_score_no_io():
+    """Pure-path smoke: importing the module and scoring a minimal fixture
+    returns a float in [0, 1] without shelling out."""
+    s = score('{"success": true}')
+    assert isinstance(s, float)
+    assert 0.0 <= s <= 1.0


### PR DESCRIPTION
## Summary
Strangler-fig bash->Python migration (ADR-001). 15 modules ported, every one gated by a parity test that invokes the LIVE bash function — 114 tests green. Bash stays alongside until the Python default flips.

Trunk (learning brain): cache (win #2 cross-iteration reuse), trace_store (win #1 reward_g activation + win #3 rubric->graded reward), lane_router (GRPO advantage, bit-parity), decision_service (full decide surface), coalition_gate, epic_graph, scheduler (win #1: run_pool concurrent epic pool — bash ran epics serially via head -1), cost_pause.

Leaves: process_reward, similarity, utility_function, topology, pricing_strategy, config_resolve, rho_aggregator.

Reliability: Phase-1 python dispatch backend (MO_DISPATCH_BACKEND=python) with sidecar-contract parity; dispatch_with_fallback + role-aware lane chains so a hung lane routes to the next instead of stalling 25 min.

## Test plan
- python3 -m pytest tests/unit/test_*_parity.py tests/unit/test_*_py.py -q -> 114 passed
- Live: codex+opus via python backend (sidecars ok), dead-glm->codex fallback e2e, pool drains 3 epics <1.5s.

Tracker: docs/_meta/python-migration-tracker.md
