### PR TITLE
Python migration: workflow_lifecycle

### DIFF
--- a/mini_ork/ported/workflow_lifecycle.py
+++ b/mini_ork/ported/workflow_lifecycle.py
@@ -1,0 +1,109 @@
+"""Workflow memory/candidate persistence — Python port of lib/workflow_lifecycle.sh.
+
+ensure_baseline: one 'promoted' workflow_memory row per recipe (yaml_blob from
+recipes/<recipe>/workflow.yaml), idempotent, returns workflow_version_id.
+candidate_store: persist a group_propose candidate into workflow_candidates
+(auto-creating the FK baseline), returns candidate_id. Faithful to the bash,
+including the task_class->recipe-dir underscore/hyphen convention.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import uuid
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if not env:
+        raise RuntimeError("MINI_ORK_DB unset")
+    return env
+
+
+def _root(root: str | None) -> str:
+    return root or os.environ.get("MINI_ORK_ROOT", ".")
+
+
+def ensure_baseline(recipe: str, task_class: str | None = None,
+                    db: str | None = None, root: str | None = None) -> str:
+    """Idempotently create the baseline workflow_memory row; return version_id.
+    Raises FileNotFoundError when the recipe has no workflow.yaml (bash exits 1)."""
+    root = _root(root)
+    yaml_path = os.path.join(root, "recipes", recipe, "workflow.yaml")
+    if not os.path.isfile(yaml_path):
+        raise FileNotFoundError(f"no workflow.yaml at {yaml_path}")
+    yaml_blob = open(yaml_path, encoding="utf-8").read()
+    yaml_hash = hashlib.sha256(yaml_blob.encode("utf-8")).hexdigest()
+    version_id = f"{recipe}_v0.1.0"
+
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    try:
+        if con.execute("SELECT workflow_version_id FROM workflow_memory "
+                       "WHERE workflow_version_id = ?", (version_id,)).fetchone():
+            return version_id
+        con.execute(
+            "INSERT INTO workflow_memory (workflow_version_id, workflow_name, "
+            "base_version_id, yaml_hash, yaml_blob, mutations, status) "
+            "VALUES (?, ?, NULL, ?, ?, '[]', 'promoted')",
+            (version_id, recipe, yaml_hash, yaml_blob))
+        con.commit()
+        return version_id
+    finally:
+        con.close()
+
+
+def candidate_store(payload: dict | str, db: str | None = None,
+                    root: str | None = None) -> str:
+    """Persist a group_propose candidate; auto-creates the baseline FK row.
+    Returns candidate_id. Raises ValueError/FileNotFoundError on bad input
+    (bash writes stderr + exits 1)."""
+    root = _root(root)
+    p = json.loads(payload) if isinstance(payload, str) else payload
+    if not isinstance(p, dict):
+        raise ValueError(f"expected object, got {type(p).__name__}")
+
+    task_class = p.get("task_class") or "generic"
+    recipe = task_class.replace("_", "-")
+    recipe_dir = os.path.join(root, "recipes", recipe)
+    if not os.path.isdir(recipe_dir):
+        recipe = task_class
+        recipe_dir = os.path.join(root, "recipes", recipe)
+    if not os.path.isdir(recipe_dir):
+        raise FileNotFoundError(f"no recipes/ dir for task_class={task_class}")
+
+    yaml_path = os.path.join(recipe_dir, "workflow.yaml")
+    if not os.path.isfile(yaml_path):
+        raise FileNotFoundError(f"no workflow.yaml at {yaml_path}")
+    yaml_blob = open(yaml_path, encoding="utf-8").read()
+    yaml_hash = hashlib.sha256(yaml_blob.encode("utf-8")).hexdigest()
+    version_id = f"{recipe}_v0.1.0"
+
+    candidate_id = p.get("candidate_id") or f"wc-{uuid.uuid4().hex[:12]}"
+    mutations = (json.dumps([p.get("mutation_applied", {})])
+                 if p.get("mutation_applied") else "[]")
+
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    try:
+        if not con.execute("SELECT workflow_version_id FROM workflow_memory "
+                           "WHERE workflow_version_id = ?", (version_id,)).fetchone():
+            con.execute(
+                "INSERT INTO workflow_memory (workflow_version_id, workflow_name, "
+                "base_version_id, yaml_hash, yaml_blob, mutations, status) "
+                "VALUES (?, ?, NULL, ?, ?, '[]', 'promoted')",
+                (version_id, recipe, yaml_hash, yaml_blob))
+        con.execute(
+            "INSERT INTO workflow_candidates (candidate_id, base_workflow_version_id, "
+            "mutations, status, utility_delta, created_by) "
+            "VALUES (?, ?, ?, 'candidate', 0.0, 'evolution_engine') "
+            "ON CONFLICT(candidate_id) DO NOTHING",
+            (candidate_id, version_id, mutations))
+        con.commit()
+        return candidate_id
+    finally:
+        con.close()

--- a/tests/unit/test_workflow_lifecycle_py.py
+++ b/tests/unit/test_workflow_lifecycle_py.py
@@ -1,0 +1,86 @@
+"""Parity gate: mini_ork.ported.workflow_lifecycle vs lib/workflow_lifecycle.sh.
+
+Same operations through LIVE bash and the Python port on separate DB copies of
+the real schema, against a real recipe (code-fix); resulting workflow_memory /
+workflow_candidates rows must match.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import workflow_lifecycle as wl  # noqa: E402
+
+WL_SH = REPO / "lib" / "workflow_lifecycle.sh"
+
+
+def _bash(db, fn, *args):
+    r = subprocess.run(
+        ["bash", "-c", f'. "{WL_SH}" && {fn} "$@"', "_", *args],
+        env={**os.environ, "MINI_ORK_DB": db, "MINI_ORK_ROOT": str(REPO)},
+        capture_output=True, text=True)
+    return r.stdout.strip(), r.returncode
+
+
+@pytest.fixture
+def dbs(tmp_path_factory):
+    home = tmp_path_factory.mktemp("home")
+    base = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": base},
+                   capture_output=True, text=True, check=True)
+    import shutil
+    b, p = base + ".bash", base + ".py"
+    shutil.copy(base, b)
+    shutil.copy(base, p)
+    return b, p
+
+
+def _rows(db, sql):
+    con = sqlite3.connect(db)
+    rows = con.execute(sql).fetchall()
+    con.close()
+    return rows
+
+
+def test_ensure_baseline_parity_and_idempotence(dbs):
+    db_bash, db_py = dbs
+    out_bash, rc = _bash(db_bash, "workflow_memory_ensure_baseline", "code-fix")
+    vid_py = wl.ensure_baseline("code-fix", db=db_py, root=str(REPO))
+    assert rc == 0 and out_bash == vid_py == "code-fix_v0.1.0"
+    # Idempotent second call
+    assert wl.ensure_baseline("code-fix", db=db_py, root=str(REPO)) == vid_py
+    q = ("SELECT workflow_version_id, workflow_name, yaml_hash, status "
+         "FROM workflow_memory")
+    assert _rows(db_bash, q) == _rows(db_py, q)
+
+
+def test_candidate_store_parity(dbs):
+    db_bash, db_py = dbs
+    cand = json.dumps({"task_class": "code_fix", "candidate_id": "wc-parity1",
+                       "mutation_applied": {"op": "swap_lane", "node": "reviewer"}})
+    out_bash, rc = _bash(db_bash, "workflow_candidate_store", cand)
+    cid_py = wl.candidate_store(cand, db=db_py, root=str(REPO))
+    assert rc == 0 and out_bash == cid_py == "wc-parity1"
+    q = ("SELECT candidate_id, base_workflow_version_id, mutations, status, "
+         "utility_delta, created_by FROM workflow_candidates")
+    assert _rows(db_bash, q) == _rows(db_py, q)
+    # underscore->hyphen recipe resolution created the baseline FK row
+    assert _rows(db_py, "SELECT workflow_version_id FROM workflow_memory") == \
+        [("code-fix_v0.1.0",)]
+
+
+def test_missing_recipe_errors(dbs):
+    _, db_py = dbs
+    with pytest.raises(FileNotFoundError):
+        wl.ensure_baseline("no-such-recipe", db=db_py, root=str(REPO))
+    with pytest.raises(FileNotFoundError):
+        wl.candidate_store({"task_class": "no_such_recipe"}, db=db_py, root=str(REPO))


### PR DESCRIPTION
Ports workflow_lifecycle to Python: ensure_baseline + candidate_store, row-level parity vs live bash on the real schema (3 tests). Module 17 of the migration.
