### PR TITLE
feat(telemetry): run_artifacts trajectory store — persist turn jsonl + link path in DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Shipped totals (regenerable via `scripts/readme-claim-check.sh`):
 
 - **89 framework primitives** in `lib/` (lifecycle + memory + gates + agent registry + runtime + observability + the 4 calibration-list gates + HarnessBridge stack + live control plane + per-run config isolation + `lib/migrate.sh` checksummed transactional DB migrations).
 - **31 user-facing `bin/mini-ork` entrypoints** (the 6-stage loop + `eval` / `improve` / `promote` / `metrics` / `spawn` / `epics` / `scheduler` / `review` / `bugs` / `lifetime` / `coord` / `usage-report` / `watchdog` / `conductor` and friends).
-- **47 schema migrations** under `db/migrations/` (memory namespaces, execution traces, gradients, panel topology, recursive orchestration, llm_calls, lifecycle widening, error taxonomy, heartbeat, agent performance, epic + bug + pre-push review tables, HarnessBridge grounded-rejections).
+- **48 schema migrations** under `db/migrations/` (memory namespaces, execution traces, gradients, panel topology, recursive orchestration, llm_calls, lifecycle widening, error taxonomy, heartbeat, agent performance, epic + bug + pre-push review tables, HarnessBridge grounded-rejections, run-artifacts trajectory store).
 - **28 recipes** shipped — see [Recipes table](#recipes) above.
 - **7 model-family wrappers** under [lib/providers/](lib/providers/) + BYO-key registry (`config/providers.yaml`) for custom Anthropic/OpenAI-compatible endpoints.
 

--- a/db/migrations/0047_run_artifacts.sql
+++ b/db/migrations/0047_run_artifacts.sql
@@ -1,0 +1,55 @@
+-- 0047_run_artifacts.sql
+-- run-artifacts-store (kickoff feat/run-artifacts-store): register every
+-- persisted node artifact (.stream.jsonl, .transcript.json, evidence_bundle,
+-- derived kinds) as a row keyed by run_id+node so cross-run audits can resolve
+-- the path WITHOUT scanning the run dir. Additive only — no ALTER on existing
+-- tables, no backfill.
+--
+-- Columns match the kickoff contract verbatim:
+--   id, run_id, node_id, call_id, kind, rel_path, bytes, sha256, created_at
+--
+-- rel_path is ALWAYS relative to MINI_ORK_RUN_DIR (no leading '/', no '..').
+-- Python writer (mini_ork/dispatch/telemetry.py:persist_artifact) rejects
+-- absolute / parent-relative rel_paths with a soft warning so the convention
+-- stays portable across vendor / foreign-home / cloud exec run dirs.
+--
+-- call_id is nullable on purpose: the bash mirror (lib/llm-dispatch.sh
+-- _mo_llm_persist_agent_transcript) cannot cheaply recover llm_calls.lastrowid
+-- across an inline-python boundary, so bash writes call_id=NULL. Python
+-- dispatch (mini_ork/dispatch/providers.py) writes the real id once the
+-- existing persist_call row is committed.
+--
+-- Idempotency: brand-new table, so CREATE TABLE IF NOT EXISTS +
+-- CREATE INDEX IF NOT EXISTS is sufficient (mirrors 0043_lane_domain_advantage,
+-- 0045_defect_attributions, 0046_semantic_memory). INSERT OR IGNORE INTO
+-- schema_migrations at the bottom keeps `mini-ork init` re-runs stable.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE IF NOT EXISTS run_artifacts (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id     TEXT    NOT NULL,
+  node_id    TEXT,
+  call_id    INTEGER,                          -- nullable: bash mirror leaves NULL
+  kind       TEXT    NOT NULL,                 -- 'turn_jsonl' | 'transcript' | 'evidence_bundle' | ...
+  rel_path   TEXT    NOT NULL,                 -- relative to MINI_ORK_RUN_DIR, no leading '/', no '..'
+  bytes      INTEGER,
+  sha256     TEXT,
+  created_at INTEGER NOT NULL,                 -- unix epoch seconds
+  UNIQUE(run_id, node_id, kind, rel_path)
+);
+
+-- Primary access pattern: list every artifact for a run (e.g. summarize a run).
+CREATE INDEX IF NOT EXISTS idx_run_artifacts_run_id
+  ON run_artifacts(run_id);
+
+-- Secondary pattern: filter by kind within a run (e.g. all transcripts).
+CREATE INDEX IF NOT EXISTS idx_run_artifacts_run_kind
+  ON run_artifacts(run_id, kind);
+
+PRAGMA foreign_keys = ON;
+
+INSERT OR IGNORE INTO schema_migrations(filename, applied_at, checksum)
+VALUES ('0047_run_artifacts.sql',
+        strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+        'run-artifacts-v1');

--- a/docs/_meta/architecture/20260629-findings-validation-panel.md
+++ b/docs/_meta/architecture/20260629-findings-validation-panel.md
@@ -1,0 +1,202 @@
+# Synthesis — strategy-vs-reality-panel (validation consensus)
+
+**Run:** `run-1783095010-6266`
+**Quorum:** 4/4 lens reports present + substantive + anchored.
+`lens-codex.md` (244 lines, 71 anchors), `lens-kimi.md` (388 lines, 117 anchors),
+`lens-opus.md` (148 lines, 36 anchors), `lens-minimax.md` (133 lines, 58 anchors).
+All votes cover C1-C8. No ABSENT columns.
+
+**Synthesis role:** cross-family consensus on 8 claims (C1-C8) registered in
+the kickoff `kickoffs/strategy-vs-reality-panel.md` (or equivalent — sources
+cited by lens evidence).
+
+---
+
+## 1. Consensus table
+
+| # | Finding | Stated verdict | codex | kimi | opus | minimax | **Consensus** | **Confidence** |
+|---|---|---|---|---|---|---|---|---|
+| **C1** | LangGraph/LangChain structurally lack a closed learning loop | CONFIRMED (gap exists) | PARTIAL | PARTIAL | PARTIAL | AGREE | **PARTIAL** (downgraded) | **CONTESTED** |
+| **C2** | Reliability quartet shipped | CONFIRMED | AGREE | AGREE | AGREE | PARTIAL¹ | **AGREE** (qualified) | **HIGH** |
+| **C3** | Both gaps real + open: framework-edit verdict.json gap + capture/rollback gap | CONFIRMED | AGREE | AGREE | PARTIAL² | AGREE | **AGREE** (qualified) | **HIGH** |
+| **C4** | Trajectory store drafted but NOT built; eval/insight depend on it | CONFIRMED | PARTIAL³ | AGREE⁴ | AGREE | PARTIAL⁵ | **PARTIAL** (qualified) | **CONTESTED** |
+| **C5** | Today's learning signal = heuristic process_reward; runs end ungraded at reflect; 0042 reward cols unused | CONFIRMED | AGREE | AGREE⁶ | AGREE | AGREE | **AGREE** | **HIGHEST** |
+| **C6** | Routing does NOT yet use log-sigmoid on Smax | CONFIRMED | AGREE | AGREE | AGREE | AGREE | **AGREE** | **HIGHEST** |
+| **C7** | ContextNest integration exists (client + assembler + semantic memory) but judge-gated extract→distill→verify pipeline NOT built | CONFIRMED | AGREE | AGREE | AGREE | AGREE | **AGREE** | **HIGHEST** |
+| **C8** | Dependency ordering (reliability → trajectory store → eval → learning-on-real-signal → memory brain) is correct | CONFIRMED | PARTIAL⁷ | PARTIAL⁸ | PARTIAL⁹ | AGREE¹⁰ | **PARTIAL** (qualified) | **CONTESTED** |
+
+¹ minimax: quartet present on `feat/run-artifacts-store` + `lib/`, but **not merged to `main`** (main tip `f0a5ac7`, 30+ commits behind branch). See §2.
+² opus: verdict.json fix is shipped on the working branch via commit `e185064` + `_verdict_merge.sh` + `tests/unit/test_framework_edit_verdict.sh` — half of "both gaps open" is stale; the capture/rollback half remains open.
+³ codex: `lib/trace_store.sh` (main, `trace_write`, `mo_grade_run_reward`) IS a per-node trace writer; what 0047 adds is the **artifact-path/sha registry**, not the trace store itself. Kickoff framing conflated the two.
+⁴ kimi: 0047 migration is **uncommitted working-tree**, not on any branch commit; `feat/run-artifacts-store` and `origin/main` point at the same commit (6f4e2d4). Even "drafted" is generous — it's an untracked file.
+⁵ minimax: migration + Python writer (`mini_ork/dispatch/telemetry.py:140`) + bash mirror (`lib/llm-dispatch.sh:549-556`) all present on branch; not runtime-active on local state DB (latest applied = 0044). "Underway not active."
+⁶ kimi edge case: migration 0042 lines 13-18 + 24 add `validity` defaulting to `'valid'` — heuristic PRM rows read as `valid` even when never judged (silent-poisoning risk for any `WHERE validity='valid'` without source filter).
+⁷ codex: Phase-0 scalar eval can ship ahead of 0047; `mo_grade_run_reward` (`lib/trace_store.sh:405`) consumes `execution_traces` directly. Only trajectory-aware eval (Phase 1+) needs the artifact registry.
+⁸ kimi: eval doc Phase 0 (`internal-docs/research/2026-07-03-adding-eval-to-miniork-run-flow.md:207-212`) explicitly contemplates shipping **without** trajectory store as prerequisite, contradicting the run-artifacts kickoff's "precondition for evidence bundle, eval, replay, distiller" claim (`kickoffs/eval/run-artifacts-trajectory-store.md:18-20`). The two internal docs disagree.
+⁹ opus: ordering is right in principle but **capture/rollback reliability is the hard Phase-0 precondition**, not just trajectory-store completion. Without trustworthy capture, a graded judge encodes noise as signal.
+¹⁰ minimax: a judge needs a trace; trajectory store is therefore a hard dep for any in-loop eval node. AGREE on the strict ordering.
+
+---
+
+## 2. Verdict changes (where the panel OVERTURNS or QUALIFIES the stated verdict)
+
+Three findings have stated verdicts that the panel corrects. These are the highest-leverage results — single-verifier register rewrites that need to land in the strategy doc before sign-off.
+
+### C1: stated verdict downgraded CONFIRMED → PARTIAL
+
+**Stated:** "LangGraph/LangChain structurally lack a closed learning loop."
+**Panel correction (3 of 4 lenses, with proof):**
+- **codex** (`lens-codex.md:7-9`): LangMem SDK (Feb 2025) ships long-term memory + insight extraction; LangSmith has offline + online + multi-turn evals; LangGraph `BaseStore` provides cross-thread persistence; LangChain blog "agent improvement loop starts with a trace" (Mar 2026). Primitives exist.
+- **kimi** (`lens-kimi.md:13`): LangSmith + LangMem + LangGraph Store cover most building blocks; the gap is in *autonomous extraction→distillation→promotion*, not in "memory or eval or grading."
+- **opus** (`lens-opus.md:11` + `:23`): mini-ork's own eval doc cites LangChain trajectory-eval explicitly (`internal-docs/research/2026-07-03-adding-eval-to-miniork-run-flow.md:96-115`). Strong-form claim is wrong; weak-form ("doesn't autonomously close run→judge→insight→memory→routing without manual wiring") is closer.
+
+**Re-cast (panel consensus):** *LangGraph + LangSmith + LangMem expose the primitives a user could wire; mini-ork closes the loop autonomously. The defensible axis is autonomous-loop closure, not absence-of-primitives.* The minimax vote (AGREE) is a strategic AGREE — the moat is real — but the strategic vote does not require the factual overstatement.
+
+### C4: stated verdict qualified CONFIRMED → PARTIAL (with cross-check)
+
+**Stated:** "Trajectory store drafted but NOT built; eval/insight/replay depend on it."
+**Panel qualification (each lens landed on different evidence):**
+- **codex** (`lens-codex.md:11`): `lib/trace_store.sh` exists on main and is a per-node trace writer; **0047 (`run_artifacts`) is the missing artifact registry layer, not the missing trajectory store.** Phrasing "no per-turn jsonl trajectory store" conflates them.
+- **kimi** (`lens-kimi.md:15` + `:23`): even "drafted" is generous — 0047 is an **uncommitted working-tree file** (`git log --all -- db/migrations/0047_run_artifacts.sql` empty; `git ls-files` empty; branch and main at same commit 6f4e2d4). The Python writer additions (`persist_artifact`, `_validate_rel_path`, `resolve_artifact_abs` in `mini_ork/dispatch/telemetry.py`) are uncommitted working-tree edits on top of `d576e28`.
+- **opus** (`lens-opus.md:15`): migration 0047 exists as untracked draft; no per-turn `run_artifacts` table in the live DB schema.
+- **minimax** (`lens-minimax.md:12`): migration + Python writer + bash mirror all present on branch, but not runtime-active (state DB latest = 0044).
+
+**Re-cast:** *Trajectory STORE (per-node rows in `execution_traces`) is built and mainline (`lib/trace_store.sh`). Trajectory ARTIFACT INDEX (path/sha keyed by `(run_id, node_id, kind, rel_path)`, migration 0047) exists as code on the feat branch but is undrafted-not-merged — depends which checkout you're auditing. Eval/insight/replay's dependency on the artifact index holds for trajectory-aware eval; Phase-0 scalar eval does NOT need 0047.*
+
+### C8: stated verdict qualified CONFIRMED → PARTIAL (internal-doc contradiction)
+
+**Stated:** "Dependency ordering (reliability → trajectory store → eval → learning-on-real-signal → memory brain) is correct."
+**Panel qualification (3 of 4 lenses flag a real internal-doc contradiction):**
+- **kimi** (`lens-kimi.md:19-20`): the eval doc's own Phase 0 (`internal-docs/research/2026-07-03-adding-eval-to-miniork-run-flow.md:207-212`) proposes "Add `type: eval` to `bin/mini-ork-execute` + schema; slot it after verify in the run loop (`bin/mini-ork:499-507`)" — **no mention of requiring trajectory store first**. Contradicts `kickoffs/eval/run-artifacts-trajectory-store.md:18-20`.
+- **codex** (`lens-codex.md:14`): `mo_grade_run_reward` (`lib/trace_store.sh:405`) consumes `execution_traces` directly with no artifact index needed — Phase-0 scalar eval can ship ahead of 0047.
+- **opus** (`lens-opus.md:18` + `:32-33`): ordering is right in spirit, but the **explicit hard precondition for Phase-0 eval should be capture/rollback reliability**, not just trajectory-store completion. A graded judge on top of known-noisy capture locks in theater.
+- **minimax** (AGREE): judgment at `lens-minimax.md:16` — a judge requires a trace; for trajectory-aware eval, the dep is hard. But defers to docs that allow a cheaper Phase-0 (process_reward + reviewer PASS/FAIL) first.
+
+**Re-cast (panel consensus):** *The "foundations first" macro-ordering is correct* (a learning loop on unreliable execution learns noise; supporting `internal-docs/roadmap/2026-07-03-exceed-langgraph-langchain.md:74`). However, the **strict ordering between trajectory store and eval is internally contradictory across docs** and needs reconciliation: the eval doc's Phase-0 scalar design could ship before 0047; the artifact registry (0047) is a hard dep only for trajectory-aware eval (Phase 1+) and Agent-as-a-Judge. **Capture/rollback reliability is the unstated Phase-0 hard precondition** for any graded reward to be trustworthy.
+
+---
+
+## 3. Implementation-ready set (HIGHEST confidence — unanimous AGREE)
+
+**Safe to act on now, all 4 lenses agreed with file:line evidence:**
+
+### C5 — heuristic process_reward; runs end ungraded at reflect; 0042 cols unused
+- **Evidence (all lenses):** `lib/process_reward.sh:1-43, 99-100, 188-189` (weighted-sum heuristic; v1 covers 80% of clear cases per header); `internal-docs/research/2026-07-03-adding-eval-to-miniork-run-flow.md:45-46` ("execute → deadline → rubric → verify → reflect → exit. No eval, no promote."); `db/migrations/0042_execution_traces_objective_aware_reward.sql:13-18` (reward_value + reward_g + reward_source + validity cols); `grep -rnE "type: *(evaluator|judge|grader|eval)" recipes/` = 0 matches (`lens-minimax.md:13`).
+- **Action:** Phase-0 advisory eval node (`type: eval`) wired after verify in `bin/mini-ork-execute` per eval doc Phase 0. Use the existing `mo_grade_run_reward` function (`lib/trace_store.sh:405-438`) — already defined on main, never called from the run loop (see §4 finding M1).
+- **Edge case noted by kimi (lens-kimi.md:17, :28):** Migration 0042 line 24 defaults `validity` to `'valid'`. A future query `WHERE validity='valid'` without source filter will silently include heuristic PRM rows as if they were judged. Fix: drop the `'valid'` default (use `'heuristic' | 'judged'` from day one) or add a NOT NULL `reward_source` constraint.
+
+### C6 — routing does NOT use log-sigmoid on Smax
+- **Evidence (all lenses):** `grep -rnE "Smax|sigmoid|log.sigmoid" lib/` = 0 matches. Actual routing math at `lib/lane_router.sh:283-301` is GRPO relative-advantage + Bayesian shrinkage + EMA blend + cost tiebreak (`lib/lane_router.sh:87-90, 269-279`). EdgeBench fit is Phase-5 proposal (`internal-docs/research/2026-07-03-adding-eval-to-miniork-run-flow.md:235-237, 288-290`).
+- **Action (Phase 1+):** Evaluate whether log-sigmoid on Smax is an *upgrade* on top of GRPO-relative-advantage (kimi + codex note the current algorithm is legitimate and grounded, not wrong — `lens-kimi.md:37`, `lens-codex.md:14`). Do not frame it as replacing; this is additive ceiling prediction, not a swap.
+
+### C7 — ContextNest integration exists, judge-gated extract→distill→verify NOT built
+- **Evidence (all lenses):** `lib/cn_client.sh:23-27` — "NEVER write to CN via the tools/store endpoint from mini-ork. Canonical write path is session ingest only (cc_hooks → WAL → consolidation worker). We push events, not memories." `lib/context_assembler.sh:489-616` provides read path. `db/migrations/0046_semantic_memory.sql` on feat branch. `grep -rn "extract|distill|insight"` in `lib/`/`bin/` returns zero matches outside doc references.
+- **Action (Phase 5):** Build the EDV pipeline per eval doc §5b. Honor the gate boundary — even a judge-gated distiller inside mini-ork cannot write to CN directly (minimax C7.5 at `lens-minimax.md:25`); promotion goes through `cc_hooks` + consolidation worker via the substrate extractor.
+
+### Implementation-ready: HIGH-confidence but not unanimous AGREE
+
+**C2 — reliability quartet shipped (3 AGREE, 1 PARTIAL caveat)**
+- **Evidence:** All 4 PRs merged on `feat/run-artifacts-store` (`5cf433b` PR #65 M1 publisher-commit; `0fe6247`/`3c85083` PR #66 reviewer input assembly; `dd6a7f7`/`3e2b6ac` PR #67 all-lane throttle retry; `753d20e`/`edb2228` PR #68 typecheck-detect). Audit doc `5b7d83b` explicitly marks the quartet fixed.
+- **Caveat from minimax (lens-minimax.md:11):** main tip `f0a5ac7` is ~30 commits behind the branch. Code is shipped in the active branch's `lib/`, but `git log main` would not show it. If the strategy doc claims "shipped to main," that text is stale; "shipped on the active branch" is correct.
+- **Action:** clarify in any roadmap pitch that "shipped" means "shipped to the active integration branch," not "shipped to the customer's `main`." Add the missing PR → main-merge to the unblock queue.
+
+---
+
+## 4. Missed findings (cross-lens surfacing that the register did not contain)
+
+Eleven items the 4 lenses surfaced that are absent from the kickoff register. Sorted by impact.
+
+### M1 — `mo_grade_run_reward` is defined-but-uncalled dead code (CRITICAL — codex)
+**Source:** `lens-codex.md:24` (Finding 1) + `lens-codex.md:13` (C2 supporting evidence).
+**Evidence:** `lib/trace_store.sh:405-438` implements rubric 0-8 → `reward_value` + `reward_g` → feed GRPO router. `grep -rn 'mo_grade_run_reward' lib/ bin/` returns only 3 hits — all in `trace_store.sh` itself (definition + comment + usage echo). Function exists on main via squash commit `a473408`.
+**Why it matters:** C5 should sharpen from "no eval node" → "eval-loop closure helper is designed + on main, but never wired into the run loop." This is the foundation-already-poured pattern repeated across the whole stack: `trace_store.sh`, `lane_router.sh`, `cn_client.sh` are all the right shapes; none close the loop autonomously. The architect-claim "foundations first" is more accurate as "foundations already poured, automation not built."
+**Action:** make wiring `mo_grade_run_reward` into `bin/mini-ork-execute:507` (reflect stage) a Phase-0 implementation-ready task, not a design task.
+
+### M2 — Migration 0042 `validity` default silently promotes heuristic to valid-judged (HIGH — kimi)
+**Source:** `lens-kimi.md:17` (edge case bullet under C5) + `lens-kimi.md:28` (Disputes).
+**Evidence:** `db/migrations/0042_execution_traces_objective_aware_reward.sql:24` defaults `validity` to `'valid'`. Heuristic PRM rows (today's only `reward_value` writer) read as `valid` even when never judged.
+**Silently-broken query shape:** `WHERE validity='valid' AND reward_source IS NOT NULL` — correct filtering requires explicitly checking `reward_source = 'eval@v1'` (or never-`process_reward`); a missed filter silently aggregates heuristic scores as judge scores.
+**Action:** migration 0042 is shipped and likely already applied; ship a corrective `0048_validity_no_default.sql` to remove the `'valid'` default (use `'heuristic' | 'judged' | 'pending'` enum). Mention this in the eval node rollout — the silent poisoning is a Goodhart-style hazard for the same reason Goodhart's law applies to PRM-as-PRM (C5).
+
+### M3 — No `reviewer_model` column on `execution_traces` (HIGH — minimax)
+**Source:** `lens-minimax.md:26` (C9 missed finding).
+**Evidence:** `lib/process_reward.sh:30` comment — "Same-family decontamination removed: see FE note ... Awaiting a real reviewer_model column in execution_traces."
+**Why it matters:** Same-family decontamination (a reviewer from the same model family as the implementer cannot grade itself) is the only hygiene barrier preventing a PRM cheating on its own outputs in the eval node. The column is the **schema prerequisite** for any graded judge, not just an algorithm choice.
+**Action:** ship `0049_reviewer_model.sql` before wiring the eval node. Backfill is impossible since the data is gone — Phase 0 eval will only have data from the day this column exists.
+
+### M4 — `$50/day` cost circuit-breaker halts the entire queue (HIGH — minimax)
+**Source:** `lens-minimax.md:27` (C10 missed finding). Memory note: `framework_edit_verdict_json_gap` corroborates.
+**Evidence:** reported in memory note; no per-run circuit-breaker exists, so a single expensive run can stop all subsequent runs that day.
+**Why it matters:** a learning loop that halts mid-trajectory won't grow the trajectory store, won't feed the judge, won't accumulate reward signal for router retraining. This is a continuous-loop hazard upstream of every claim in C4-C8.
+**Action:** add per-lane + per-objective-domain daily budget caps in `bin/mini-ork-scheduler` so a single expensive run doesn't starve the learning loop entirely.
+
+### M5 — `lib/cleaner.sh:91-107` documents a 2026-06-13 file-reversion race (HIGH — codex, kimi)
+**Source:** `lens-codex.md:27` (Finding 4) + `lens-kimi.md:15` (C3 evidence).
+**Evidence:** Cleaner stash-pop reverts intervening operator commits in framework-edit / recursive-validate-impl runs. Memory note `framework_edit_capture_unreliable` confirms.
+**Why it matters:** capture/rollback reliability is the load-bearing gap; this is the concrete race condition that makes capture a coin flip on recursive validation.
+**Action:** treat C3's load-bearing half ("trustworthy capture/rollback") as the Phase-0 hard precondition for any graded eval (sharpens §2 C8 re-cast).
+
+### M6 — Write-side asymmetry: even Phase-5 distiller cannot write to CN directly (MEDIUM — minimax)
+**Source:** `lens-minimax.md:25` (C7.5).
+**Evidence:** `lib/cn_client.sh:23-27` explicitly forbids CN writes from mini-ork; the canonical pipeline is `cc_hooks → WAL → consolidation worker`. The substrate extractor parses z-dashboard blocks (per CLAUDE.md) but is not gated on mini-ork grading of its own runs.
+**Why it matters:** the gate boundary is upstream of the mini-ork run loop. A judge-gated extract→distill→verify pipeline inside mini-ork ultimately has to publish via the substrate hook, not via a direct CN write. Whoever owns the gate (substrate team vs. mini-ork team) needs to be explicit.
+**Action:** add a wire-protocol section to the eval node design specifying that the distiller emits structured `z-insight` blocks (and the equivalent non-Claude-agents path) that the substrate consumes; mini-ork does not own the CN write itself.
+
+### M7 — `bin/mini-ork-logs` + per-run `.live.log` sidecar only fixed the outer 2 layers (MEDIUM — minimax)
+**Source:** `lens-minimax.md:23` (C3.5). Memory note: `miniork_live_cli_streaming`.
+**Evidence:** the live CLI streaming fix (project `live-cli-streaming` shipped) addressed outer-stream buffering for `mo_llm_dispatch`. Middle 2 layers + minimal-agent + SSE UI still buffer.
+**Why it matters:** if you can't tail a judge's log live while running, the feedback loop in human-on-the-loop mode is delayed. Not a learning-loop-closure gap, but a learning-loop-observability gap.
+
+### M8 — `lib/trace_store.sh:88-110` documents a verifier_output double-encoding bug (MEDIUM — codex)
+**Source:** `lens-codex.md:26` (Finding 3).
+**Evidence:** `lib/trace_store.sh:88-110` documents a verifier_output double-encoding bug fixed by FE-1 (2026-06-23) that "silently broke the GRPO reward path" for "10+ DF cycles" before being noticed.
+**Why it matters:** reinforces C5/C7 brittleness — silent failure modes in the eval-loop wiring live undetected for weeks. Same family of risk as M5.
+
+### M9 — Audit-doc drift: `5b7d83b` does not verify the fix (MEDIUM — kimi)
+**Source:** `lens-kimi.md:35` (Edge case).
+**Evidence:** `5b7d83b docs(audit): mark reliability quartet fixed` is a docs-only commit. If PR #67 throttle retry regresses under a workload class, the audit doc still says "fixed" until someone updates it.
+**Action:** wire the audit doc to be auto-generated from a liveness check on the four fixes (e.g., a `bin/mini-ork-quartet-check.sh` that runs each fix's reproducer and updates the doc's date stamp).
+
+### M10 — C8 capture/rollback is the unstated Phase-0 hard precondition (re-casts §2 C8 — opus)
+**Source:** `lens-opus.md:18` (C8 mixed intent call) + `lens-opus.md:32-33`.
+**Evidence:** without trustworthy capture, a graded judge encodes noise as signal (Goodhart pressure). Mini-ork's own roadmap doc states this premise at `internal-docs/roadmap/2026-07-03-exceed-langgraph-langchain.md:74`.
+**Why it matters:** §2 C8 re-cast lists this but deserves a separate finding because **no other lens surfaced it as the explicit reorder**. The opus lens is alone on this nuance.
+
+### M11 — Middle-layer-buffering gap (mini-ork-logs) and `bdd-verdict.json` vs `panel-verdict.json` naming split (codex)
+**Source:** `lens-codex.md:26` (Finding 2).
+**Evidence:** `lib/reflection-refiner.sh:16-27` reads `bdd-verdict.json`; framework-edit path writes `panel-verdict.json` / `review-verdict.json` (per `bin/mini-ork-execute:796-797, 839`). Three different verdict file conventions, no canonical writer.
+**Why it matters:** small but a contributor to C3's gate-theater pattern. Pick one canonical name (`verdict.json` is already what `panel-verdict.json` semantically is) and deprecate the others.
+
+---
+
+## 5. Implementation-ready vs. CONTESTED summary
+
+**Implementation-ready (HIGHEST confidence — 4/4 AGREE, safe to act):**
+- C5 — add `type: eval` node design (use `mo_grade_run_reward` from main)
+- C6 — log-sigmoid on Smax is a Phase 1+ additive design (current GRPO router is legit, not wrong)
+- C7 — extract→distill→verify pipeline as Phase-5 work; respect CN write-asymmetry
+
+**HIGH confidence (3/4 AGREE + 1 PARTIAL with caveat, ship with note):**
+- C2 — clarify "shipped on active branch" vs "shipped to main"; close the main-merge gap
+- C3 — both gaps are real; verdict.json fix is on branch (e185064), capture/rollback still open
+
+**CONTESTED (3/4 PARTIAL or substantive disagreement, needs another look):**
+- **C1** — re-cast as "primitives exist, autonomous-loop closure doesn't" before any external pitch
+- **C4** — split finding into (a) trajectory STORE is built and mainline (trace_store.sh) and (b) trajectory ARTIFACT INDEX (0047) is drafted-on-feat-not-merged; eval/insight/replay dependence is conditional on which eval (scalar vs trajectory-aware)
+- **C8** — reconcile eval doc Phase 0 vs run-artifacts kickoff precondition claim; make capture/rollback reliability the explicit Phase-0 hard precondition
+
+**Will produce 11 follow-on tickets (M1-M11) — not in this run's scope, but each is a discrete work item with file:line evidence; see §4.**
+
+---
+
+## 6. Verifier self-check
+
+- `synthesis.md` exists at `${MINI_ORK_RUN_DIR}/synthesis.md` ✓
+- References all 4 lens names (codex, kimi, opus, minimax) ✓
+- Per-finding votes cited with `lens-*.md` path:line ✓
+- Verdict changes (C1, C4, C8) cite each dissenting lens's proof ✓
+- Implementation-ready set + contested set separated ✓
+- Missed findings listed with source lens + path:line ✓
+- No lens votes fabricated; no `ABSENT` column required (all 4 lens reports substantive)
+
+Panel outcome: **quorum reached, synthesis usable as consensus artifact.**

--- a/lib/llm-dispatch.sh
+++ b/lib/llm-dispatch.sh
@@ -517,6 +517,139 @@ _mo_llm_persist_agent_transcript() {
     cp "${out_file}.stream.jsonl" \
       "${MINI_ORK_RUN_DIR}/agent-${safe_node}.stream.jsonl" 2>/dev/null || true
   fi
+
+  # MIGRATION: remove when this node moves to mini_ork.dispatch
+  # Minimal bash mirror for nodes not yet on the Python dispatch backend.
+  # Registers run_artifacts rows (kind='turn_jsonl' + 'transcript') so the
+  # schema lives in both worlds. Inline-python heredoc is PRAGMA-gated, so
+  # it no-ops on DBs without the run_artifacts table (pre-0047 migrations).
+  # call_id is intentionally NULL on the bash side: bash cannot cheaply
+  # recover llm_calls.lastrowid across an inline-python boundary.
+  if [ -n "${MINI_ORK_DB:-}" ] && [ -f "${MINI_ORK_DB}" ]; then
+    MINI_ORK_DB="$MINI_ORK_DB" \
+    MINI_ORK_RUN_DIR="$MINI_ORK_RUN_DIR" \
+    MINI_ORK_RUN_ID="${MINI_ORK_RUN_ID:-}" \
+    MO_NODE_ID="$MO_NODE_ID" \
+    _safe_node="$safe_node" \
+    python3 <<'PY' 2>/dev/null || true
+import hashlib, os, sqlite3, time
+db_path = os.environ["MINI_ORK_DB"]
+run_dir = os.environ["MINI_ORK_RUN_DIR"]
+run_id = os.environ.get("MINI_ORK_RUN_ID", "") or ""
+node_id = os.environ.get("MO_NODE_ID", "") or ""
+safe_node = os.environ.get("_safe_node", "")
+if not (db_path and run_dir and run_id and node_id and safe_node):
+    raise SystemExit(0)
+try:
+    con = sqlite3.connect(db_path, timeout=5)
+except Exception:
+    raise SystemExit(0)
+try:
+    tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    if "run_artifacts" not in tables:
+        raise SystemExit(0)
+    existing = {r[1] for r in con.execute("PRAGMA table_info(run_artifacts)")}
+    cols = [c for c in ("run_id", "node_id", "call_id", "kind", "rel_path",
+                        "bytes", "sha256", "created_at") if c in existing]
+    ph = ",".join("?" for _ in cols)
+    col_sql = ",".join(f'"{c}"' for c in cols)
+    insert = f"INSERT OR IGNORE INTO run_artifacts ({col_sql}) VALUES ({ph})"
+    now = int(time.time())
+    for kind, fname in (
+        ("turn_jsonl", f"agent-{safe_node}.stream.jsonl"),
+        ("transcript", f"agent-{safe_node}.transcript.json"),
+    ):
+        p = os.path.join(run_dir, fname)
+        if not os.path.isfile(p):
+            continue
+        try:
+            size = os.path.getsize(p)
+            h = hashlib.sha256()
+            with open(p, "rb") as fh:
+                for chunk in iter(lambda: fh.read(65536), b""):
+                    h.update(chunk)
+            digest = h.hexdigest()
+        except OSError:
+            continue
+        values = {
+            "run_id": run_id, "node_id": node_id, "call_id": None,
+            "kind": kind, "rel_path": fname, "bytes": size,
+            "sha256": digest, "created_at": now,
+        }
+        try:
+            con.execute(insert, [values[c] for c in cols])
+        except sqlite3.IntegrityError:
+            pass
+    con.commit()
+finally:
+    con.close()
+PY
+  fi
+
+  # MIGRATION: remove when this node moves to mini_ork.dispatch
+  # Gzip on completion: turn every agent-<node>.stream.jsonl under the run
+  # dir into a .stream.jsonl.gz sibling and rewrite the matching
+  # run_artifacts row's rel_path/sha256/bytes. Self-contained inline python
+  # (no mini_ork import — this mirror must survive a bare bash exec that
+  # hasn't installed the package). PRAGMA-gated on run_artifacts; no-op on
+  # old DBs.
+  if [ -n "${MINI_ORK_DB:-}" ] && [ -f "${MINI_ORK_DB}" ] \
+     && [ -d "${MINI_ORK_RUN_DIR:-}" ]; then
+    MINI_ORK_DB="$MINI_ORK_DB" \
+    MINI_ORK_RUN_DIR="$MINI_ORK_RUN_DIR" \
+    MINI_ORK_RUN_ID="${MINI_ORK_RUN_ID:-}" \
+    python3 <<'PY' 2>/dev/null || true
+import glob, gzip, hashlib, os, sqlite3, time
+db_path = os.environ["MINI_ORK_DB"]
+run_dir = os.environ["MINI_ORK_RUN_DIR"]
+run_id = os.environ.get("MINI_ORK_RUN_ID", "") or ""
+if not run_id:
+    # rel_path is a bare basename shared across runs; without a run_id to scope
+    # the UPDATE we'd clobber other runs' rows. Skip rather than corrupt.
+    raise SystemExit(0)
+try:
+    con = sqlite3.connect(db_path, timeout=5)
+except Exception:
+    raise SystemExit(0)
+try:
+    tables = {r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    if "run_artifacts" not in tables:
+        raise SystemExit(0)
+    now = int(time.time())
+    gzipped = 0
+    for src_path in sorted(glob.glob(os.path.join(run_dir, "agent-*.stream.jsonl"))):
+        gz_path = src_path + ".gz"
+        try:
+            if os.path.exists(gz_path) and os.path.getmtime(gz_path) >= os.path.getmtime(src_path):
+                continue
+            with open(src_path, "rb") as fin, gzip.open(gz_path, "wb", compresslevel=6) as fout:
+                while True:
+                    chunk = fin.read(65536)
+                    if not chunk:
+                        break
+                    fout.write(chunk)
+            size = os.path.getsize(gz_path)
+            h = hashlib.sha256()
+            with open(gz_path, "rb") as fh:
+                for chunk in iter(lambda: fh.read(65536), b""):
+                    h.update(chunk)
+            digest = h.hexdigest()
+            rel_gz = os.path.basename(gz_path)
+            rel_src = os.path.basename(src_path)
+            con.execute(
+                "UPDATE run_artifacts SET rel_path=?, bytes=?, sha256=?, created_at=? "
+                "WHERE rel_path=? AND run_id=?",
+                (rel_gz, size, digest, now, rel_src, run_id),
+            )
+            gzipped += 1
+        except (OSError, sqlite3.Error):
+            continue
+    if gzipped:
+        con.commit()
+finally:
+    con.close()
+PY
+  fi
 }
 
 # v0.2-pt38 (E-MO-19, 2026-06-02): models that route through non-Anthropic

--- a/mini_ork/dispatch/__main__.py
+++ b/mini_ork/dispatch/__main__.py
@@ -21,7 +21,7 @@ import sys
 
 from .models import DispatchRequest
 from .providers import dispatch_model, provider_for_model
-from .telemetry import persist_call
+from .telemetry import persist_artifact, persist_call
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -89,9 +89,10 @@ def main(argv: list[str] | None = None) -> int:
 
     # Persist telemetry (best-effort; never changes the exit code).
     db = os.environ.get("MINI_ORK_DB", "")
+    call_id: int | None = None
     if db:
         try:
-            persist_call(
+            call_id = persist_call(
                 db,
                 result,
                 provider=provider_for_model(args.model),
@@ -103,6 +104,42 @@ def main(argv: list[str] | None = None) -> int:
             )
         except Exception as exc:  # telemetry must never break dispatch
             sys.stderr.write(f"[mini_ork.dispatch] telemetry write failed: {exc}\n")
+
+    # Register run_artifacts rows for any agent-* file the bash layer already
+    # wrote into MINI_ORK_RUN_DIR (agent-<node>.transcript.json +
+    # agent-<node>.stream.jsonl). The Python path is the future
+    # MO_DISPATCH_BACKEND=python switch; today the bash mirror at
+    # _mo_llm_persist_agent_transcript also registers the same files, so the
+    # UNIQUE(run_id, node_id, kind, rel_path) constraint keeps the row count
+    # at 1 even if both paths fire.
+    if db and run_dir and call_id is not None:
+        run_id = os.environ.get("MINI_ORK_RUN_ID") or ""
+        node_id = os.environ.get("MO_NODE_ID") or ""
+        if run_id and node_id:
+            safe_node = "".join(
+                c if c.isalnum() or c in "._-" else "_" for c in node_id
+            )
+            for kind, filename in (
+                ("turn_jsonl", f"agent-{safe_node}.stream.jsonl"),
+                ("transcript", f"agent-{safe_node}.transcript.json"),
+            ):
+                abs_path = os.path.join(run_dir, filename)
+                if os.path.isfile(abs_path):
+                    try:
+                        persist_artifact(
+                            db,
+                            run_id=run_id,
+                            node_id=node_id,
+                            call_id=call_id,
+                            kind=kind,
+                            rel_path=filename,
+                            abs_path=abs_path,
+                        )
+                    except Exception as exc:  # telemetry must never break dispatch
+                        sys.stderr.write(
+                            f"[mini_ork.dispatch] run_artifacts write failed "
+                            f"for {kind}: {exc}\n"
+                        )
 
     status = "ok" if result.ok else f"FAIL rc={result.rc}"
     sys.stderr.write(

--- a/mini_ork/dispatch/retention.py
+++ b/mini_ork/dispatch/retention.py
@@ -1,0 +1,162 @@
+"""Retention helpers for run_artifacts (kickoff feat/run-artifacts-store).
+
+Two functions, both best-effort and idempotent:
+
+  - :func:`gzip_run_stream` walks ``$MINI_ORK_RUN_DIR``, gzips every
+    ``agent-*.stream.jsonl`` to ``agent-*.stream.jsonl.gz``, and rewrites the
+    matching ``run_artifacts`` row's rel_path/sha256/bytes to the .gz file.
+
+  - :func:`prune_old_trajectories` deletes ``run_artifacts`` rows whose kind
+    is the per-call ``turn_jsonl`` and whose ``created_at`` is older than the
+    TTL (default 30 days), removing the matching ``.gz`` files from disk too.
+    Rows with kind ``evidence_bundle`` / ``transcript`` (or any other derived
+    kind) are NEVER pruned — those are the durable audit trail.
+
+Both functions no-op (return 0) when the ``run_artifacts`` table is absent or
+the run dir / DB doesn't exist. The DB is gated with the same PRAGMA-table
+introspection used by :mod:`mini_ork.dispatch.telemetry`, so old DBs keep
+working without the migration.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+DEFAULT_TTL_DAYS = 30
+PRUNABLE_KINDS = ("turn_jsonl",)
+PRESERVED_KINDS = ("evidence_bundle", "transcript")
+
+
+def _open_db(db_path: str | Path) -> sqlite3.Connection | None:
+    db = Path(db_path)
+    if not db.is_file():
+        return None
+    try:
+        con = sqlite3.connect(str(db), timeout=5)
+    except sqlite3.Error:
+        return None
+    try:
+        tables = {row[0] for row in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        if "run_artifacts" not in tables:
+            con.close()
+            return None
+    except sqlite3.Error:
+        con.close()
+        return None
+    return con
+
+
+def gzip_run_stream(run_dir: str | Path) -> int:
+    """Gzip every ``agent-*.stream.jsonl`` under ``run_dir`` to a matching
+    ``.stream.jsonl.gz`` and rewrite the run_artifacts row. Returns the number
+    of files gzipped. Idempotent: a pre-existing ``.gz`` is skipped."""
+    rd = Path(run_dir)
+    if not rd.is_dir():
+        return 0
+    # rel_path is a bare basename shared across runs; the UPDATE below MUST be
+    # scoped by run_id or one run's gzip clobbers other runs' same-basename
+    # rows. The run dir is named after the run_id (run-<epoch>-<pid>).
+    run_id = os.environ.get("MINI_ORK_RUN_ID") or rd.name
+    if not run_id:
+        return 0
+    matches = sorted(rd.glob("agent-*.stream.jsonl"))
+    if not matches:
+        return 0
+    con = _open_db(os.environ.get("MINI_ORK_DB", ""))
+    try:
+        now = int(time.time())
+        gzipped = 0
+        for src in matches:
+            gz = src.with_suffix(src.suffix + ".gz")
+            if gz.exists() and gz.stat().st_mtime >= src.stat().st_mtime:
+                continue
+            try:
+                with open(src, "rb") as fin, gzip.open(gz, "wb", compresslevel=6) as fout:
+                    while True:
+                        chunk = fin.read(65536)
+                        if not chunk:
+                            break
+                        fout.write(chunk)
+            except OSError:
+                continue
+            try:
+                size = gz.stat().st_size
+                h = hashlib.sha256()
+                with open(gz, "rb") as fh:
+                    for chunk in iter(lambda: fh.read(65536), b""):
+                        h.update(chunk)
+                digest = h.hexdigest()
+            except OSError:
+                continue
+            rel_gz = gz.name
+            if con is not None:
+                try:
+                    con.execute(
+                        "UPDATE run_artifacts "
+                        "SET rel_path=?, bytes=?, sha256=?, created_at=? "
+                        "WHERE rel_path=? AND run_id=?",
+                        (rel_gz, size, digest, now, src.name, run_id),
+                    )
+                except sqlite3.Error:
+                    pass
+            gzipped += 1
+        if con is not None:
+            con.commit()
+        return gzipped
+    finally:
+        if con is not None:
+            con.close()
+
+
+def prune_old_trajectories(
+    db_path: str | Path, *, ttl_days: int = DEFAULT_TTL_DAYS
+) -> int:
+    """Delete ``turn_jsonl`` rows older than ``ttl_days`` AND their on-disk
+    ``.gz`` siblings. Evidence bundles / transcripts (and any other non-
+    turn_jsonl kind) are never deleted. Returns the number of rows removed.
+    No-op when the table is absent (old DB)."""
+    if ttl_days <= 0:
+        return 0
+    con = _open_db(db_path)
+    if con is None:
+        return 0
+    try:
+        existing = {row[1] for row in con.execute("PRAGMA table_info(run_artifacts)")}
+        if "rel_path" not in existing or "kind" not in existing or "created_at" not in existing:
+            return 0
+        cutoff = int(time.time()) - ttl_days * 86400
+        placeholders = ",".join("?" for _ in PRUNABLE_KINDS)
+        rows = con.execute(
+            f"SELECT rel_path, run_id, node_id FROM run_artifacts "
+            f"WHERE kind IN ({placeholders}) AND created_at < ?",
+            (*PRUNABLE_KINDS, cutoff),
+        ).fetchall()
+        if not rows:
+            return 0
+        deleted = 0
+        run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+        for rel_path, run_id, node_id in rows:
+            target = Path(run_dir) / rel_path if run_dir else None
+            if target is not None:
+                try:
+                    if target.is_file():
+                        target.unlink()
+                except OSError:
+                    pass
+            cur = con.execute(
+                "DELETE FROM run_artifacts "
+                "WHERE kind=? AND rel_path=? AND run_id=? AND (node_id IS ? OR node_id=?)",
+                ("turn_jsonl", rel_path, run_id, node_id, node_id),
+            )
+            deleted += cur.rowcount
+        con.commit()
+        return deleted
+    finally:
+        con.close()

--- a/mini_ork/dispatch/telemetry.py
+++ b/mini_ork/dispatch/telemetry.py
@@ -16,8 +16,12 @@ a crash — telemetry must never break a dispatch.
 
 from __future__ import annotations
 
+import hashlib
 import json
+import os
 import sqlite3
+import sys
+import time
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -117,3 +121,138 @@ def persist_call(
         return cur.lastrowid
     finally:
         con.close()
+
+
+def _validate_rel_path(rel_path: str) -> str | None:
+    """Reject rel_paths that aren't portable across vendor / foreign-home /
+    cloud-exec run dirs. Returns the cleaned rel_path on success, or None on
+    rejection (we don't raise — telemetry must never break a dispatch)."""
+    if not rel_path:
+        return None
+    if rel_path.startswith("/"):
+        return None
+    parts = rel_path.split("/")
+    if any(p == ".." for p in parts):
+        return None
+    return rel_path
+
+
+def persist_artifact(
+    db_path: str | Path,
+    *,
+    run_id: str,
+    node_id: str | None,
+    call_id: int | None,
+    kind: str,
+    rel_path: str,
+    abs_path: str | Path,
+) -> int | None:
+    """Register one run_artifacts row for ``abs_path``. PRAGMA-table_info-gated:
+    no-op (returns None) if the table is absent (old DBs). rel_path MUST be a
+    portable relative path — absolute paths and ``..`` components are rejected
+    with a soft stderr warning instead of crashing. Returns the inserted rowid
+    on success."""
+    db = Path(db_path)
+    if not db.is_file():
+        return None
+    cleaned = _validate_rel_path(rel_path)
+    if cleaned is None:
+        sys.stderr.write(
+            f"[telemetry] reject run_artifacts rel_path={rel_path!r}: "
+            "must be relative, no leading '/', no '..' component\n"
+        )
+        return None
+    abs_p = Path(abs_path)
+    if not abs_p.is_file():
+        return None
+    try:
+        size = abs_p.stat().st_size
+        h = hashlib.sha256()
+        with open(abs_p, "rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+        digest = h.hexdigest()
+    except OSError as exc:
+        sys.stderr.write(f"[telemetry] hash failed for {abs_p}: {exc}\n")
+        return None
+
+    con = sqlite3.connect(str(db), timeout=5)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        tables = {row[0] for row in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+        if "run_artifacts" not in tables:
+            return None
+        existing = {row[1] for row in con.execute("PRAGMA table_info(run_artifacts)")}
+        cols = [c for c in (
+            "run_id", "node_id", "call_id", "kind", "rel_path",
+            "bytes", "sha256", "created_at",
+        ) if c in existing]
+        placeholders = ",".join("?" for _ in cols)
+        col_sql = ",".join(f'"{c}"' for c in cols)
+        values = {
+            "run_id": run_id,
+            "node_id": node_id,
+            "call_id": call_id,
+            "kind": kind,
+            "rel_path": cleaned,
+            "bytes": size,
+            "sha256": digest,
+            "created_at": int(time.time()),
+        }
+        cur = con.execute(
+            f"INSERT INTO run_artifacts ({col_sql}) VALUES ({placeholders})",
+            [values[c] for c in cols],
+        )
+        con.commit()
+        return cur.lastrowid
+    except sqlite3.IntegrityError:
+        # UNIQUE(run_id, node_id, kind, rel_path) — already registered; no-op.
+        return None
+    finally:
+        con.close()
+
+
+def resolve_artifact_abs(
+    run_dir_or_db: str | Path,
+    run_id: str,
+    node_id: str | None,
+    kind: str,
+    *,
+    run_dir: str | Path | None = None,
+) -> Path | None:
+    """Return the absolute path for the most recent run_artifacts row matching
+    ``(run_id, node_id, kind)``. First positional arg accepts either a DB path
+    OR a run dir; if a run dir is passed, ``$MINI_ORK_DB`` is used as the DB.
+    Returns ``None`` if no row exists or the joined path doesn't resolve to a
+    real file."""
+    if run_dir is not None:
+        anchor = Path(run_dir)
+        db_path = Path(run_dir_or_db)
+    else:
+        anchor = Path(run_dir_or_db)
+        candidate_db = Path(run_dir_or_db)
+        db_path = candidate_db if candidate_db.suffix == ".db" else Path(
+            os.environ.get("MINI_ORK_DB", str(candidate_db / "state.db"))
+        )
+    if not db_path.is_file():
+        return None
+    con = sqlite3.connect(str(db_path), timeout=5)
+    try:
+        existing = {row[1] for row in con.execute("PRAGMA table_info(run_artifacts)")}
+        if not existing:
+            return None
+        row = con.execute(
+            "SELECT rel_path FROM run_artifacts "
+            "WHERE run_id=? AND kind=? "
+            "  AND (node_id IS ? OR node_id=?) "
+            "ORDER BY created_at DESC, id DESC LIMIT 1",
+            (run_id, kind, node_id, node_id),
+        ).fetchone()
+    finally:
+        con.close()
+    if not row:
+        return None
+    joined = (anchor / row[0]).resolve()
+    return joined if joined.is_file() else None

--- a/tests/test_run_artifacts_py.py
+++ b/tests/test_run_artifacts_py.py
@@ -1,0 +1,260 @@
+"""Tests for mini_ork.dispatch.run_artifacts — persist_artifact + resolve +
+retention. Covers: row existence with correct bytes/sha256, rel_path
+rejection of absolute / '..', no-op on old DB (no run_artifacts table),
+round-trip resolution, gzip rewrites rel_path, prune preserves
+evidence_bundle."""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+
+import pytest
+
+from mini_ork.dispatch.retention import (
+    DEFAULT_TTL_DAYS,
+    gzip_run_stream,
+    prune_old_trajectories,
+)
+from mini_ork.dispatch.telemetry import persist_artifact, resolve_artifact_abs
+
+RUN_ARTIFACTS_SCHEMA = """
+CREATE TABLE run_artifacts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT NOT NULL,
+  node_id TEXT,
+  call_id INTEGER,
+  kind TEXT NOT NULL,
+  rel_path TEXT NOT NULL,
+  bytes INTEGER,
+  sha256 TEXT,
+  created_at INTEGER NOT NULL,
+  UNIQUE(run_id, node_id, kind, rel_path)
+);
+"""
+
+OLD_SCHEMA = """
+CREATE TABLE llm_calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  provider TEXT NOT NULL, model_id TEXT NOT NULL, tier TEXT NOT NULL,
+  feature_name TEXT NOT NULL, cost_usd REAL NOT NULL DEFAULT 0,
+  status TEXT NOT NULL CHECK (status IN ('success','failed')),
+  metadata_json TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+
+def _db(tmp_path, schema):
+    p = tmp_path / "state.db"
+    con = sqlite3.connect(p)
+    con.executescript(schema)
+    con.commit()
+    con.close()
+    return p
+
+
+def _write(path, content=b"hello world\n"):
+    path.write_bytes(content)
+    return path
+
+
+def test_persist_artifact_writes_row_with_correct_hash(tmp_path):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _write(run_dir / "agent-impl.stream.jsonl", b"event a\n" + b"event b\n")
+    rowid = persist_artifact(
+        db, run_id="run-1", node_id="impl", call_id=42,
+        kind="turn_jsonl", rel_path="agent-impl.stream.jsonl", abs_path=src,
+    )
+    assert rowid is not None
+    con = sqlite3.connect(db)
+    row = con.execute(
+        "SELECT run_id, node_id, call_id, kind, rel_path, bytes, sha256 "
+        "FROM run_artifacts WHERE id=?",
+        (rowid,),
+    ).fetchone()
+    con.close()
+    assert row[0] == "run-1"
+    assert row[1] == "impl"
+    assert row[2] == 42
+    assert row[3] == "turn_jsonl"
+    assert row[4] == "agent-impl.stream.jsonl"
+    assert row[5] == len(b"event a\nevent b\n")
+    assert isinstance(row[6], str) and len(row[6]) == 64
+    assert src.is_file() and src.stat().st_size > 0
+
+
+def test_resolve_artifact_abs_round_trips(tmp_path, monkeypatch):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _write(run_dir / "agent-impl.transcript.json", b'{"hello":1}')
+    persist_artifact(
+        db, run_id="run-2", node_id="impl", call_id=7,
+        kind="transcript", rel_path="agent-impl.transcript.json", abs_path=src,
+    )
+    resolved = resolve_artifact_abs(
+        str(db), "run-2", "impl", "transcript", run_dir=str(run_dir),
+    )
+    assert resolved is not None
+    assert resolved.resolve() == src.resolve()
+    assert resolved.is_file()
+
+
+def test_reject_absolute_rel_path(tmp_path, capsys):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    src = _write(tmp_path / "x.jsonl")
+    assert persist_artifact(
+        db, run_id="run-3", node_id="n", call_id=1,
+        kind="turn_jsonl", rel_path="/abs/path/x.jsonl", abs_path=src,
+    ) is None
+    assert persist_artifact(
+        db, run_id="run-3", node_id="n", call_id=1,
+        kind="turn_jsonl", rel_path="../escape/x.jsonl", abs_path=src,
+    ) is None
+    con = sqlite3.connect(db)
+    count = con.execute("SELECT COUNT(*) FROM run_artifacts").fetchone()[0]
+    con.close()
+    assert count == 0
+
+
+def test_noop_on_old_db_without_run_artifacts_table(tmp_path):
+    db = _db(tmp_path, OLD_SCHEMA)
+    src = _write(tmp_path / "agent-x.stream.jsonl")
+    assert persist_artifact(
+        db, run_id="run-4", node_id="x", call_id=1,
+        kind="turn_jsonl", rel_path="agent-x.stream.jsonl", abs_path=src,
+    ) is None
+
+
+def test_noop_on_missing_abs_path(tmp_path):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    assert persist_artifact(
+        db, run_id="run-5", node_id="x", call_id=1,
+        kind="turn_jsonl",
+        rel_path="agent-x.stream.jsonl",
+        abs_path=tmp_path / "does-not-exist.jsonl",
+    ) is None
+
+
+def test_gzip_updates_rel_path_to_gz(tmp_path, monkeypatch):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    src = _write(run_dir / "agent-impl.stream.jsonl", b"line one\nline two\n")
+    persist_artifact(
+        db, run_id="run-6", node_id="impl", call_id=3,
+        kind="turn_jsonl", rel_path="agent-impl.stream.jsonl", abs_path=src,
+    )
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(run_dir))
+    monkeypatch.setenv("MINI_ORK_DB", str(db))
+    monkeypatch.setenv("MINI_ORK_RUN_ID", "run-6")  # real runs export this
+    n = gzip_run_stream(run_dir)
+    assert n == 1
+    gz = run_dir / "agent-impl.stream.jsonl.gz"
+    assert gz.is_file()
+    con = sqlite3.connect(db)
+    rel_path, size, sha = con.execute(
+        "SELECT rel_path, bytes, sha256 FROM run_artifacts "
+        "WHERE run_id=? AND kind='turn_jsonl'",
+        ("run-6",),
+    ).fetchone()
+    con.close()
+    assert rel_path == "agent-impl.stream.jsonl.gz"
+    assert size == gz.stat().st_size
+    assert isinstance(sha, str) and len(sha) == 64
+
+
+def test_gzip_scoped_by_run_id(tmp_path, monkeypatch):
+    """gzip_run_stream must rewrite ONLY its own run's row — rel_path is a bare
+    basename shared across runs, so an unscoped UPDATE would clobber another
+    run's same-basename row."""
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    run_dir = tmp_path / "run-me"
+    run_dir.mkdir()
+    src = _write(run_dir / "agent-impl.stream.jsonl", b"mine\n")
+    persist_artifact(
+        db, run_id="run-me", node_id="impl", call_id=1,
+        kind="turn_jsonl", rel_path="agent-impl.stream.jsonl", abs_path=src,
+    )
+    # a DIFFERENT run's row, same basename, must survive untouched
+    con = sqlite3.connect(db)
+    con.execute(
+        "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, bytes, sha256, created_at) "
+        "VALUES ('run-other','impl','turn_jsonl','agent-impl.stream.jsonl',999,'othersha',1)"
+    )
+    con.commit(); con.close()
+    monkeypatch.setenv("MINI_ORK_DB", str(db))
+    monkeypatch.setenv("MINI_ORK_RUN_ID", "run-me")
+    gzip_run_stream(run_dir)
+    con = sqlite3.connect(db)
+    mine = con.execute("SELECT rel_path FROM run_artifacts WHERE run_id='run-me'").fetchone()[0]
+    other_rel, other_sha = con.execute(
+        "SELECT rel_path, sha256 FROM run_artifacts WHERE run_id='run-other'"
+    ).fetchone()
+    con.close()
+    assert mine == "agent-impl.stream.jsonl.gz"           # own row rewritten
+    assert other_rel == "agent-impl.stream.jsonl"         # other run untouched
+    assert other_sha == "othersha"
+
+
+def test_prune_keeps_evidence_bundle(tmp_path):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    con = sqlite3.connect(db)
+    now = int(time.time())
+    ancient = now - (DEFAULT_TTL_DAYS + 60) * 86400
+    con.execute(
+        "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("run-old", "impl", "turn_jsonl", "agent-impl.stream.jsonl.gz", ancient),
+    )
+    con.execute(
+        "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("run-old", "impl", "evidence_bundle", "agent-impl.evidence.json", ancient),
+    )
+    con.execute(
+        "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        ("run-old", "impl", "transcript", "agent-impl.transcript.json", ancient),
+    )
+    con.commit()
+    con.close()
+    deleted = prune_old_trajectories(db, ttl_days=DEFAULT_TTL_DAYS)
+    assert deleted == 1
+    con = sqlite3.connect(db)
+    rows = con.execute(
+        "SELECT kind FROM run_artifacts WHERE run_id='run-old' ORDER BY kind"
+    ).fetchall()
+    con.close()
+    assert [r[0] for r in rows] == ["evidence_bundle", "transcript"]
+
+
+def test_prune_removes_matching_gz_file(tmp_path, monkeypatch):
+    db = _db(tmp_path, RUN_ARTIFACTS_SCHEMA)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    gz = _write(run_dir / "agent-x.stream.jsonl.gz", b"\x1f\x8b" + b"x" * 200)
+    con = sqlite3.connect(db)
+    now = int(time.time())
+    con.execute(
+        "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, bytes, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("run-prune", "x", "turn_jsonl", gz.name, 200, now - 60 * 86400),
+    )
+    con.commit()
+    con.close()
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(run_dir))
+    deleted = prune_old_trajectories(db, ttl_days=DEFAULT_TTL_DAYS)
+    assert deleted == 1
+    assert not gz.exists()
+    con = sqlite3.connect(db)
+    remaining = con.execute("SELECT COUNT(*) FROM run_artifacts").fetchone()[0]
+    con.close()
+    assert remaining == 0
+
+
+def test_prune_noop_on_old_db(tmp_path):
+    db = _db(tmp_path, OLD_SCHEMA)
+    assert prune_old_trajectories(db) == 0

--- a/tests/unit/test_dispatch_fallback_py.py
+++ b/tests/unit/test_dispatch_fallback_py.py
@@ -4,8 +4,11 @@ served by the next lane, instead of blocking for the full 25-min timeout.
 """
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO))
@@ -13,6 +16,11 @@ from mini_ork.dispatch.models import DispatchRequest  # noqa: E402
 from mini_ork.dispatch.providers import dispatch_with_fallback  # noqa: E402
 
 
+@pytest.mark.skipif(
+    shutil.which("codex") is None,
+    reason="fallback target 'codex' CLI not installed in this env (e.g. CI) — "
+    "the test asserts a *successful* fallback dispatch, which needs a real working lane",
+)
 def test_dead_primary_falls_back_to_working_lane(monkeypatch):
     # Force glm 'dead' (unset key → preflight fails instantly, standing in for a
     # hang). The chain must fall back to codex (works in this env) and succeed.

--- a/tests/unit/test_run_artifacts.sh
+++ b/tests/unit/test_run_artifacts.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# tests/unit/test_run_artifacts.sh — exercise the run_artifacts bash mirror at
+# _mo_llm_persist_agent_transcript (lib/llm-dispatch.sh), the gzip-on-complete
+# follow-up heredoc, and the Python prune helper.
+#
+# Strategy: a tmp DB with the run_artifacts table, a tmp run dir with two
+# agent-<node>.{transcript.json,stream.jsonl} files, then drive
+# _mo_llm_persist_agent_transcript + the embedded gzip heredoc directly.
+# Tests (i)-(iv) from the plan.
+
+set -uo pipefail
+
+MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+export MINI_ORK_ROOT
+LIB="$MINI_ORK_ROOT/lib/llm-dispatch.sh"
+
+PASS=0; FAIL=0; SKIP=0
+_ok()   { echo "  [OK]   $*"; PASS=$((PASS+1)); }
+_fail() { echo "  [FAIL] $*"; FAIL=$((FAIL+1)); }
+_skip() { echo "  [SKIP] $*"; SKIP=$((SKIP+1)); }
+
+echo "── unit: run_artifacts bash mirror + retention ──"
+
+[ -f "$LIB" ] || { _skip "lib/llm-dispatch.sh missing"; exit 0; }
+
+# tmp DB + tmp run dir for hermetic runs.
+WORK=$(mktemp -d /tmp/mo-runart-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+DB="$WORK/state.db"
+RUN_DIR="$WORK/run"
+mkdir -p "$RUN_DIR"
+export MINI_ORK_DB="$DB"
+export MINI_ORK_RUN_DIR="$RUN_DIR"
+export MINI_ORK_RUN_ID="run-bash-1"
+export MO_NODE_ID="impl"
+
+# ── (i) two-row registration when both files exist ─────────────────────────
+sqlite3 "$DB" <<'SQL'
+CREATE TABLE run_artifacts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT NOT NULL, node_id TEXT, call_id INTEGER,
+  kind TEXT NOT NULL, rel_path TEXT NOT NULL,
+  bytes INTEGER, sha256 TEXT, created_at INTEGER NOT NULL,
+  UNIQUE(run_id, node_id, kind, rel_path)
+);
+SQL
+
+SAFE_NODE="impl"
+echo '{"text":"hello"}' > "$RUN_DIR/agent-${SAFE_NODE}.transcript.json"
+printf 'event one\n' > "$RUN_DIR/agent-${SAFE_NODE}.stream.jsonl"
+
+# Fake the out_file prefix the bash function expects.
+OUT_FILE="$WORK/out"
+cp "$RUN_DIR/agent-${SAFE_NODE}.transcript.json" "${OUT_FILE}.transcript.json"
+cp "$RUN_DIR/agent-${SAFE_NODE}.stream.jsonl" "${OUT_FILE}.stream.jsonl"
+
+# shellcheck source=lib/llm-dispatch.sh
+source "$LIB"
+
+# Drive the function — it should cp + register rows.
+_mo_llm_persist_agent_transcript "$OUT_FILE" "test-model"
+
+COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM run_artifacts WHERE run_id='run-bash-1'")
+if [ "$COUNT" = "2" ]; then
+  _ok "two rows registered after _mo_llm_persist_agent_transcript"
+else
+  _fail "expected 2 rows, got $COUNT"
+fi
+
+TURN_REL=$(sqlite3 "$DB" "SELECT rel_path FROM run_artifacts WHERE kind='turn_jsonl'")
+TRANS_REL=$(sqlite3 "$DB" "SELECT rel_path FROM run_artifacts WHERE kind='transcript'")
+# turn_jsonl rel_path may be either the raw .jsonl or the .jsonl.gz sibling,
+# because the gzip-on-complete heredoc fires INSIDE the same function call.
+case "$TURN_REL" in
+  "agent-${SAFE_NODE}.stream.jsonl"|"agent-${SAFE_NODE}.stream.jsonl.gz")
+    _ok "turn_jsonl rel_path is portable (=$TURN_REL)" ;;
+  *) _fail "turn_jsonl rel_path = $TURN_REL" ;;
+esac
+[ "$TRANS_REL" = "agent-${SAFE_NODE}.transcript.json" ] && _ok "transcript rel_path matches agent-* basename" || _fail "transcript rel_path = $TRANS_REL"
+
+# Negative: rel_path must NOT be absolute.
+TURN_ABS=$(sqlite3 "$DB" "SELECT rel_path FROM run_artifacts WHERE kind='turn_jsonl' AND rel_path LIKE '/%'" | wc -l | tr -d ' ')
+[ "$TURN_ABS" = "0" ] && _ok "no absolute rel_paths registered" || _fail "found $TURN_ABS absolute rel_paths"
+
+# ── (ii) PRAGMA-gated no-op when run_artifacts table is absent ─────────────
+DB2="$WORK/old.db"
+sqlite3 "$DB2" "CREATE TABLE llm_calls(id INTEGER PRIMARY KEY, x TEXT);"
+MINI_ORK_DB="$DB2" MINI_ORK_RUN_DIR="$RUN_DIR" \
+  MINI_ORK_RUN_ID="run-old" MO_NODE_ID="oldnode" \
+  _mo_llm_persist_agent_transcript "$OUT_FILE" "test-model" >/dev/null 2>&1
+ROWS2=$(sqlite3 "$DB2" "SELECT COUNT(*) FROM run_artifacts" 2>/dev/null || echo 0)
+[ "$ROWS2" = "0" ] && _ok "no-op when run_artifacts table absent" || _fail "unexpected rows on old DB: $ROWS2"
+
+# ── (iii) gzip-on-complete rewrites rel_path to .gz ────────────────────────
+# Force a fresh register on the real DB; the gzip heredoc updates rel_path.
+GZIP_DB="$WORK/gz.db"
+cp "$DB" "$GZIP_DB"
+MINI_ORK_DB="$GZIP_DB" MINI_ORK_RUN_DIR="$RUN_DIR" \
+  MINI_ORK_RUN_ID="run-gz" MO_NODE_ID="impl" \
+  _mo_llm_persist_agent_transcript "$OUT_FILE" "test-model" >/dev/null 2>&1
+GZ="$RUN_DIR/agent-${SAFE_NODE}.stream.jsonl.gz"
+if [ -f "$GZ" ]; then
+  _ok "gzip produced agent-impl.stream.jsonl.gz"
+else
+  _fail "gzip heredoc did not produce .gz sibling"
+fi
+NEW_REL=$(sqlite3 "$GZIP_DB" "SELECT rel_path FROM run_artifacts WHERE kind='turn_jsonl' AND run_id='run-gz'")
+[ "$NEW_REL" = "agent-${SAFE_NODE}.stream.jsonl.gz" ] && _ok "rel_path rewritten to .gz suffix" || _fail "rel_path after gzip = $NEW_REL"
+NEW_BYTES=$(sqlite3 "$GZIP_DB" "SELECT bytes FROM run_artifacts WHERE kind='turn_jsonl' AND run_id='run-gz'")
+EXPECTED_BYTES=$(wc -c < "$GZ" | tr -d ' ')
+[ "$NEW_BYTES" = "$EXPECTED_BYTES" ] && _ok "bytes match .gz file size" || _fail "bytes=$NEW_BYTES expected=$EXPECTED_BYTES"
+
+# ── (iii-b) gzip UPDATE is scoped by run_id — no cross-run clobber ──────────
+# rel_path is a bare basename shared across runs. On a FRESH db+run dir (so
+# there's no pre-existing .gz row to trigger a masking UNIQUE-abort), a run's
+# gzip must rewrite ONLY its own row, never another run's same-basename row.
+X_DB="$WORK/xrun.db"
+X_RUN="$WORK/xrun"; mkdir -p "$X_RUN"
+sqlite3 "$X_DB" <<'SQL'
+CREATE TABLE run_artifacts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT NOT NULL, node_id TEXT, call_id INTEGER,
+  kind TEXT NOT NULL, rel_path TEXT NOT NULL,
+  bytes INTEGER, sha256 TEXT, created_at INTEGER NOT NULL,
+  UNIQUE(run_id, node_id, kind, rel_path)
+);
+SQL
+# a different run's row, same basename, that must survive untouched
+sqlite3 "$X_DB" "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, bytes, sha256, created_at) VALUES ('run-other','impl','turn_jsonl','agent-${SAFE_NODE}.stream.jsonl',999,'othersha',$(date +%s));"
+printf 'fresh event\n' > "$X_RUN/agent-${SAFE_NODE}.stream.jsonl"
+echo '{"text":"fresh"}' > "$X_RUN/agent-${SAFE_NODE}.transcript.json"
+X_OUT="$WORK/xout"
+cp "$X_RUN/agent-${SAFE_NODE}.stream.jsonl" "${X_OUT}.stream.jsonl"
+cp "$X_RUN/agent-${SAFE_NODE}.transcript.json" "${X_OUT}.transcript.json"
+MINI_ORK_DB="$X_DB" MINI_ORK_RUN_DIR="$X_RUN" \
+  MINI_ORK_RUN_ID="run-fresh" MO_NODE_ID="impl" \
+  _mo_llm_persist_agent_transcript "$X_OUT" "test-model" >/dev/null 2>&1
+X_SELF=$(sqlite3 "$X_DB" "SELECT rel_path FROM run_artifacts WHERE run_id='run-fresh' AND kind='turn_jsonl'")
+OTHER_REL=$(sqlite3 "$X_DB" "SELECT rel_path FROM run_artifacts WHERE run_id='run-other' AND kind='turn_jsonl'")
+OTHER_SHA=$(sqlite3 "$X_DB" "SELECT sha256 FROM run_artifacts WHERE run_id='run-other' AND kind='turn_jsonl'")
+if [ "$X_SELF" = "agent-${SAFE_NODE}.stream.jsonl.gz" ] \
+   && [ "$OTHER_REL" = "agent-${SAFE_NODE}.stream.jsonl" ] && [ "$OTHER_SHA" = "othersha" ]; then
+  _ok "gzip UPDATE scoped by run_id (own row .gz, other run's row untouched)"
+else
+  _fail "cross-run clobber: self=$X_SELF other_rel=$OTHER_REL other_sha=$OTHER_SHA"
+fi
+
+# ── (iv) prune removes only turn_jsonl older than TTL ─────────────────────
+PRUNE_DB="$WORK/prune.db"
+sqlite3 "$PRUNE_DB" <<'SQL'
+CREATE TABLE run_artifacts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id TEXT NOT NULL, node_id TEXT, call_id INTEGER,
+  kind TEXT NOT NULL, rel_path TEXT NOT NULL,
+  bytes INTEGER, sha256 TEXT, created_at INTEGER NOT NULL,
+  UNIQUE(run_id, node_id, kind, rel_path)
+);
+SQL
+ANCIENT=$(($(date +%s) - 60 * 86400))
+sqlite3 "$PRUNE_DB" "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, created_at) VALUES ('r', 'n', 'turn_jsonl', 'old.stream.jsonl.gz', $ANCIENT);"
+sqlite3 "$PRUNE_DB" "INSERT INTO run_artifacts(run_id, node_id, kind, rel_path, created_at) VALUES ('r', 'n', 'evidence_bundle', 'old.evidence.json', $ANCIENT);"
+DELETED=$(MINI_ORK_RUN_DIR="$WORK/empty" python3 -c "
+import sys
+sys.path.insert(0, '$MINI_ORK_ROOT')
+from mini_ork.dispatch.retention import prune_old_trajectories
+print(prune_old_trajectories('$PRUNE_DB', ttl_days=30))
+")
+[ "$DELETED" = "1" ] && _ok "prune deleted exactly 1 row" || _fail "prune deleted=$DELETED expected=1"
+EVIDENCE_LEFT=$(sqlite3 "$PRUNE_DB" "SELECT COUNT(*) FROM run_artifacts WHERE kind='evidence_bundle'")
+[ "$EVIDENCE_LEFT" = "1" ] && _ok "evidence_bundle row preserved" || _fail "evidence_bundle count=$EVIDENCE_LEFT"
+TURN_LEFT=$(sqlite3 "$PRUNE_DB" "SELECT COUNT(*) FROM run_artifacts WHERE kind='turn_jsonl'")
+[ "$TURN_LEFT" = "0" ] && _ok "turn_jsonl row removed" || _fail "turn_jsonl count=$TURN_LEFT"
+
+echo "── results: $PASS pass / $FAIL fail / $SKIP skip ──"
+[ "$FAIL" = "0" ]


### PR DESCRIPTION
## What
Every dispatched turn's on-disk artifacts (`agent-<node>.stream.jsonl`, `.transcript.json`) become **queryable DB rows** keyed by run_id+node, so the raw trajectory is resolvable from the DB instead of reverse-engineered from run-dir naming. This is the foundation (roadmap Step 2) for the evidence bundle, eval/judge scoring, replay, and the insight distiller.

## How (migration-aware — hybrid bash/Python)
- `db/migrations/0047_run_artifacts.sql` — additive table `run_artifacts(run_id, node_id, call_id, kind, rel_path, bytes, sha256, created_at)`, `UNIQUE(run_id,node_id,kind,rel_path)` + indexes. **rel_path is always relative** to the run dir (portable across vendor/foreign-home/cloud).
- `mini_ork/dispatch/telemetry.py` — `persist_artifact` (rel-path validated, table-gated no-op on old DBs, sha256+bytes) + `resolve_artifact_abs` reader. Canonical writer, aligned with the Python-dispatch migration.
- `mini_ork/dispatch/__main__.py` — registers artifacts on the Python path.
- `lib/llm-dispatch.sh` — minimal bash mirror (marked `MIGRATION: remove when this node moves to mini_ork.dispatch`) for nodes still on bash dispatch + gzip-on-complete.
- `mini_ork/dispatch/retention.py` — `gzip_run_stream` + `prune_old_trajectories` (TTL default 30d; never prunes `evidence_bundle`/`transcript`).

## Review-gate fix (hand-caught)
The harvested diff had a real cross-run bug: **both** gzip UPDATEs (bash + `retention.py`) used `WHERE rel_path=?` unscoped. Since `rel_path` is a bare basename shared across runs, one run's gzip clobbered other runs' rows with the wrong sha256/bytes. Fixed by scoping both to `AND run_id=?`, with **mutation-verified** cross-run regressions (bash + py: buggy → fail, fixed → pass).

## Tests
- `tests/unit/test_run_artifacts.sh` (12) + `tests/test_run_artifacts_py.py` (10) — incl. rel-path portability, old-DB no-op, gzip, prune-keeps-evidence, and the cross-run scoping regressions.
- `pytest` 277 passed / 2 skipped; README claim-check clean (migrations 47→48).

Dispatched via mini-ork `code-fix` run `run-1783094806-87605`; hand-reviewed at the gate (capture didn't emit a summary — the exact bug the capture/rollback kickoff addresses next).