### PR TITLE
fix(dispatch): secrets propagation to python backend + cwd-guard test env leak

### DIFF
--- a/lib/llm-dispatch.sh
+++ b/lib/llm-dispatch.sh
@@ -761,6 +761,16 @@ mo_llm_dispatch() {
     if [ -n "${MO_DISPATCH_CHAIN:-}" ] && [ "${MO_DISPATCH_CHAIN%%,*}" = "$model" ]; then
       _model_arg="$MO_DISPATCH_CHAIN"
     fi
+    # Source secrets BEFORE delegating — the python layer reads API keys from
+    # os.environ and (unlike the bash path below) never sources
+    # secrets.local.sh itself. Without this every gateway lane fails preflight
+    # with "key not set" whenever the caller relied on MINI_ORK_SECRETS
+    # (2026-07-03 migration batch: 10/10 runs dead on this).
+    local _py_secrets="${MINI_ORK_SECRETS:-${MINI_ORK_HOME:-.mini-ork}/config/secrets.local.sh}"
+    if [ -f "$_py_secrets" ]; then
+      set -a; # shellcheck disable=SC1090
+      source "$_py_secrets" 2>/dev/null || true; set +a
+    fi
     printf '%s' "$prompt" | PYTHONPATH="${MINI_ORK_ROOT}${PYTHONPATH:+:$PYTHONPATH}" \
       python3 -m mini_ork.dispatch "$_model_arg" --out "$out_file" --timeout "$timeout_s"
     return $?

--- a/tests/test_dispatch_cwd_py.py
+++ b/tests/test_dispatch_cwd_py.py
@@ -38,7 +38,12 @@ def test_resolve_target_cwd_precedence(tmp_path, monkeypatch):
     )
 
 
-def test_cwd_inside_framework_is_rejected(tmp_path):
+def test_cwd_inside_framework_is_rejected(tmp_path, monkeypatch):
+    # Clear the opt-in if it leaked in from the CALLER's environment — a
+    # framework-edit run (MO_ALLOW_FRAMEWORK_CWD=1) invoking the whole test
+    # suite via verifiers/test.sh would otherwise flip this guard to ok=True
+    # and poison the suite gate for every run (2026-07-03 migration batch).
+    monkeypatch.delenv("MO_ALLOW_FRAMEWORK_CWD", raising=False)
     framework = tmp_path / "mini-ork"
     (framework / "sub").mkdir(parents=True)
     g = cwd_guard(str(framework / "sub"), root=framework)


### PR DESCRIPTION
Fixes the two structural env bugs that made the parallel migration batch fail 10/10 (secrets never reached the python dispatch layer; MO_ALLOW_FRAMEWORK_CWD leak flipped the cwd-guard test in the whole-suite gate). Verified: suite green with the opt-in leaked; minimax passes preflight with only MINI_ORK_SECRETS set.
