### PR TITLE
fix(dispatch): restore --permission-mode bypassPermissions on claude worker lanes

### DIFF
--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -205,9 +205,16 @@ def resolve_provider(
         return ProviderSpec(model, command)
 
     # Claude family: env-pin from the wrapper, then run claude with JSON output.
+    # `--permission-mode bypassPermissions` is LOAD-BEARING: without it, `claude
+    # --print` runs in the default permission mode and auto-denies every Write/
+    # Edit/Bash-redirect in non-interactive mode, so an implementer/worker lane
+    # can read but never write files — the port silently produces nothing. The
+    # bash path (lib/llm-dispatch.sh:938, lib/lane-helpers.sh:244) always passes
+    # it; the Python port dropped it (2026-07-04 migration batch, 3rd killer).
     return ProviderSpec(
         model=model,
-        command=("claude", "--print", "--output-format", "json"),
+        command=("claude", "--print", "--permission-mode", "bypassPermissions",
+                 "--output-format", "json"),
         parse_usage=parse_claude_usage,
         parse_cost=claude_cost,
         parse_text=claude_result_text,

--- a/tests/test_dispatch_py.py
+++ b/tests/test_dispatch_py.py
@@ -197,3 +197,17 @@ def test_resolve_claude_lane_uses_claude_command():
     assert spec.command[0] == "claude"
     assert spec.parse_text is claude_result_text
     assert spec.parse_usage is parse_claude_usage
+
+
+def test_claude_lane_passes_bypass_permissions():
+    """Regression guard for the 3rd migration-batch killer: a claude-family
+    worker MUST run with `--permission-mode bypassPermissions`, or `claude
+    --print` auto-denies file writes in non-interactive mode and the
+    implementer produces nothing. Parity with lib/llm-dispatch.sh:938."""
+    for lane in ("glm", "minimax", "kimi", "sonnet", "opus"):
+        cmd = resolve_provider(lane).command
+        assert "--permission-mode" in cmd and "bypassPermissions" in cmd, lane
+        assert cmd[cmd.index("--permission-mode") + 1] == "bypassPermissions", lane
+    # codex/gemini are wrapper-executables with their own permission handling —
+    # they must NOT be handed claude's --permission-mode flag.
+    assert "--permission-mode" not in resolve_provider("codex").command


### PR DESCRIPTION
Third and final migration-batch killer. Python dispatch port dropped the `--permission-mode bypassPermissions` flag the bash path always passed → `claude --print` worker lanes auto-denied all file writes → every autonomous port produced nothing. Restores parity + regression test. codex/gemini correctly excluded.