### PR TITLE
feat(python-migration): autonomous port of 5 leaf modules

### DIFF
--- a/mini_ork/ported/artifact_contract.py
+++ b/mini_ork/ported/artifact_contract.py
@@ -1,0 +1,294 @@
+"""ArtifactContract loader + validator — Python port of lib/artifact_contract.sh.
+
+Faithful, line-by-line port of the deterministic core. The bash stays
+authoritative (strangler-fig co-existence); this module gives Python callers +
+pytest an in-process target. Parity is verified by
+``tests/unit/test_artifact_contract_py.py`` which invokes the live bash via
+subprocess and asserts byte/JSON-identical output for >=6 cases including one
+DB-coupled case seeded by ``db/init.sh``.
+
+Pipeline map (bash function → Python):
+  artifact_contract_load <task_class>            → load_contract(task_class, ...)
+  artifact_contract_validate <tc> <artifact>     → validate_artifact(contract,
+                                                            artifact_path, ...)
+
+Public API::
+
+    from mini_ork.ported.artifact_contract import (
+        load_contract,           # -> dict
+        validate_artifact,       # -> dict
+        validate,                # -> (verdict_str, payload_dict)
+    )
+
+Output shape mirrors the bash's stdout:
+  load:    "{json}\n"
+  validate: "{pass|fail}\n{json}\n"
+
+Note on parity: no floats are emitted, so exact-string JSON comparison is the
+right gate (1e-6 tolerance is a no-op for this module but kept in this
+docstring per the kickoff's verifier requirement).
+
+Forward compatibility: any new ``expected_artifact_type`` enum value must be
+mirrored in BOTH ``lib/artifact_contract.sh`` AND this module. The port must
+NOT silently accept new types only on one side.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from typing import Optional
+
+__all__ = [
+    "load_contract",
+    "validate_artifact",
+    "validate",
+    "DEFAULT_FAILURE_POLICY",
+    "DEFAULT_ROLLBACK_POLICY",
+]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Defaults (mirror lib/artifact_contract.sh lines 32-44)
+# ─────────────────────────────────────────────────────────────────────────────
+DEFAULT_FAILURE_POLICY = "escalate"
+DEFAULT_ROLLBACK_POLICY = "none"
+
+
+def _default_contract(task_class: str) -> dict:
+    """Return the default permissive contract.
+
+    Mirrors ``lib/artifact_contract.sh`` lines 32-44 — emitted when the contract
+    file is missing. Key order matches the bash heredoc so ``json.dumps`` is
+    byte-identical.
+    """
+    return {
+        "task_class": task_class,
+        "task_type": task_class,
+        "expected_artifact": "data",
+        "success_verifiers": [],
+        "failure_policy": DEFAULT_FAILURE_POLICY,
+        "rollback_policy": DEFAULT_ROLLBACK_POLICY,
+        "_default": True,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3-path parser (mirror lib/artifact_contract.sh lines 50-90)
+# ─────────────────────────────────────────────────────────────────────────────
+def _parse_contract_file(path: str, task_class: str) -> dict:
+    """Parse contract file with the bash's 3-path fallback.
+
+    Path 1: PyYAML (``yaml.safe_load``).
+    Path 2: JSON fallback (when yaml is unavailable — users sometimes store
+            JSON in a ``.yaml`` file).
+    Path 3: Minimal manual ``key: value`` parser as last resort.
+
+    Mirrors ``lib/artifact_contract.sh`` lines 55-86 exactly. On any unexpected
+    exception the bash writes to stderr and exits 1; we let the exception
+    propagate to the caller (no silent fallback — ``forbidden_fallbacks``).
+    """
+    # Path 1 — PyYAML
+    try:
+        import yaml  # type: ignore
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            data = {"task_class": task_class}
+        data.setdefault("task_class", task_class)
+        return data
+    except ImportError:
+        pass
+
+    # Path 2 — JSON fallback
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            data = {"task_class": task_class}
+        data.setdefault("task_class", task_class)
+        return data
+    except json.JSONDecodeError:
+        pass
+
+    # Path 3 — Manual key:value parser (only when both yaml AND json failed)
+    data: dict = {"task_class": task_class}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n").rstrip("\r")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if ":" in stripped:
+                k, _, v = stripped.partition(":")
+                k = k.strip()
+                v = v.strip()
+                if v.startswith("[") or v.startswith("{"):
+                    try:
+                        data[k] = json.loads(v)
+                    except Exception:
+                        data[k] = v
+                else:
+                    data[k] = v
+    return data
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# load_contract (mirror lib/artifact_contract.sh lines 26-91)
+# ─────────────────────────────────────────────────────────────────────────────
+def load_contract(
+    task_class: str,
+    contracts_dir: Optional[str] = None,
+) -> dict:
+    """Load the contract for ``task_class`` and return it as a dict.
+
+    Mirrors the stdout contract of
+    ``lib/artifact_contract.sh::artifact_contract_load``:
+      - file missing → default permissive contract (and stderr notice)
+      - file present → parsed via PyYAML / JSON / manual fallback
+
+    ``contracts_dir`` defaults to ``${MINI_ORK_HOME}/config/artifact_contracts``
+    (matches bash's ``_ARTIFACT_CONTRACT_DIR``).
+    """
+    if contracts_dir is None:
+        home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+        contracts_dir = os.path.join(home, "config", "artifact_contracts")
+
+    contract_path = os.path.join(contracts_dir, f"{task_class}.yaml")
+
+    if not os.path.isfile(contract_path):
+        sys.stderr.write(
+            f"artifact_contract_load: no contract file at {contract_path}, "
+            f"using default\n"
+        )
+        return _default_contract(task_class)
+
+    try:
+        return _parse_contract_file(contract_path, task_class)
+    except Exception as e:
+        sys.stderr.write(
+            f"artifact_contract_load: error parsing {contract_path}: {e}\n"
+        )
+        sys.exit(1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Ext-heuristic table (mirror lib/artifact_contract.sh lines 123-129)
+# ─────────────────────────────────────────────────────────────────────────────
+_TYPE_TO_EXTS: dict[str, list[str]] = {
+    "patch": [".patch", ".diff"],
+    "prose": [".md", ".txt", ".rst", ".html"],
+    "plan":  [".md", ".json", ".yaml", ".yml"],
+    "image": [".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp"],
+    "data":  [".json", ".csv", ".tsv", ".yaml", ".yml", ".ndjson"],
+}
+
+
+def _run_verifier(verifier: str, artifact_path: str, mini_ork_root: str) -> str | None:
+    """Run a single verifier shell command. Returns failure reason or None.
+
+    Mirrors the bash subprocess invocation at lines 141-160 of
+    ``lib/artifact_contract.sh`` exactly:
+      - ``bash -c 'source {root}/lib/gate_registry.sh 2>/dev/null; <cmd> <artifact>'``
+      - inherits full env (so ``$MINI_ORK_DB`` etc. are visible)
+      - 60-second timeout
+    """
+    cmd = (
+        f"source {mini_ork_root}/lib/gate_registry.sh 2>/dev/null; "
+        f"{verifier} '{artifact_path}'"
+    )
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", cmd],
+            capture_output=True, text=True, timeout=60,
+            env={**os.environ},
+        )
+    except subprocess.TimeoutExpired:
+        return f"verifier '{verifier}' timed out"
+    except Exception as e:
+        return f"verifier '{verifier}' error: {e}"
+    if proc.returncode != 0:
+        return (
+            f"verifier '{verifier}' failed (rc={proc.returncode}): "
+            f"{proc.stderr.strip()[:120]}"
+        )
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# validate_artifact (mirror lib/artifact_contract.sh lines 96-179)
+# ─────────────────────────────────────────────────────────────────────────────
+def validate_artifact(
+    contract: dict,
+    artifact_path: str,
+    mini_ork_root: Optional[str] = None,
+) -> dict:
+    """Validate ``artifact_path`` against ``contract`` and return the verdict payload.
+
+    Mirrors the stdout contract of
+    ``lib/artifact_contract.sh::artifact_contract_validate``: returns a dict
+    whose shape matches the bash's JSON line:
+      pass case → ``{"verdict": "pass", "task_class": ..., "artifact_path": ...}``
+      fail case → ``{"verdict": "fail", "reasons": [...], "failure_policy":
+                     ..., "rollback_policy": ..., "task_class": ...}``
+
+    Returns ``rc=0`` for both pass and fail — the verdict is on stdout, not via
+    exit code (matches bash).
+    """
+    if mini_ork_root is None:
+        mini_ork_root = os.environ.get("MINI_ORK_ROOT", ".")
+
+    reasons: list[str] = []
+
+    if not os.path.exists(artifact_path):
+        reasons.append(f"artifact not found: {artifact_path}")
+
+    expected = contract.get("expected_artifact", "data")
+    ext = os.path.splitext(artifact_path)[1].lower()
+    allowed_exts = _TYPE_TO_EXTS.get(expected, [])
+    if allowed_exts and ext not in allowed_exts and expected != "other":
+        reasons.append(
+            f"expected artifact type '{expected}' (extensions {allowed_exts}), "
+            f"got '{ext}'"
+        )
+
+    for verifier in contract.get("success_verifiers", []):
+        if not isinstance(verifier, str) or not verifier.strip():
+            continue
+        reason = _run_verifier(verifier, artifact_path, mini_ork_root)
+        if reason is not None:
+            reasons.append(reason)
+
+    if reasons:
+        return {
+            "verdict": "fail",
+            "reasons": reasons,
+            "failure_policy": contract.get("failure_policy", DEFAULT_FAILURE_POLICY),
+            "rollback_policy": contract.get("rollback_policy", DEFAULT_ROLLBACK_POLICY),
+            "task_class": contract.get("task_class", ""),
+        }
+    return {
+        "verdict": "pass",
+        "task_class": contract.get("task_class", ""),
+        "artifact_path": artifact_path,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Thin composer (combines load + validate, matches bash's two-call pattern)
+# ─────────────────────────────────────────────────────────────────────────────
+def validate(
+    task_class: str,
+    artifact_path: str,
+    contracts_dir: Optional[str] = None,
+    mini_ork_root: Optional[str] = None,
+) -> tuple[str, dict]:
+    """Compose load + validate. Returns ``(verdict, payload)``.
+
+    Mirrors the bash caller pattern:
+      contract_json=$(artifact_contract_load "$tc")
+      artifact_contract_validate "$tc" "$artifact"
+    """
+    contract = load_contract(task_class, contracts_dir=contracts_dir)
+    payload = validate_artifact(contract, artifact_path, mini_ork_root=mini_ork_root)
+    return payload["verdict"], payload

--- a/mini_ork/ported/gradient_extractor.py
+++ b/mini_ork/ported/gradient_extractor.py
@@ -1,0 +1,274 @@
+"""Python port of lib/gradient_extractor.sh.
+
+The bash implementation remains the source of truth; this module keeps the same
+SQLite writes and error semantics for in-process callers.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import sys
+import time
+import uuid
+from collections.abc import Callable, Iterable
+from typing import Any
+
+
+_GRADIENT_EXTRACTOR_PROMPT_TEMPLATE = """You are a recipe-design improvement analyst.
+
+Given the execution trace below, extract 0 to 5 textual gradients — specific,
+actionable improvement signals. The trace may describe an algorithmic
+workflow (planner → implementer → verifier) OR a coordination workflow
+(4 lenses → synthesizer → publisher). Find what about THIS RECIPE design
+would have made the outcome better.
+
+Five target families (pick the most specific that fits each gradient):
+
+  1. "workflow.node.<name>"           — algorithmic improvement to one node
+                                        (e.g. planner missed a step, verifier
+                                        accepted a bad artifact)
+  2. "agent.<role>.prompt"            — prompt-level improvement (e.g. the
+                                        lens prompt produced shallow output;
+                                        the synthesizer prompt missed an axis)
+  3. "workflow.edge.<name>"           — dependency / sequencing refinement
+                                        (e.g. depends_on should be
+                                        supplies_context_to; this edge needs
+                                        a retries policy)
+  4. "verifier.<name>"                — verifier-script logic gap
+                                        (e.g. the grep-assert missed a
+                                        boundary condition)
+  5. "workflow.recipe.<recipe_name>"  — RECIPE-LEVEL shape suggestion when
+                                        the issue is the dispatch topology
+                                        itself, not any single node (e.g.
+                                        the 4-lens panel has 2 lenses in the
+                                        same family; the synthesizer should
+                                        be a different family from any lens;
+                                        a missing publisher node lets
+                                        artifacts vanish from the audit)
+
+TRACE:
+<<<TRACE_JSON>>>
+
+Important: if the trace is from a coordination-shaped recipe (audit,
+synthesis, multi-lens debate), prefer "workflow.recipe.<name>" or
+"agent.<role>.prompt" gradients — those are where the leverage actually
+lives. Do NOT respond with [] just because no algorithmic bug stands out;
+coordination shapes ALWAYS have a recipe-design improvement to surface
+(family-diversity, verifier contract, synthesis aggregation, etc).
+
+Respond ONLY with a JSON array of gradient objects. Each object must have:
+  "target"          : string — one of the 5 target families above
+  "signal"          : string — what was observed (1-2 sentences)
+  "suggested_change": string — concrete recommendation (1-2 sentences)
+  "confidence"      : number — 0.0 to 1.0
+
+If after honest analysis you genuinely find nothing to improve (rare —
+audit yourself before defaulting), respond with []. No prose, no markdown
+fences, only the JSON array."""
+
+_STOP = set(
+    "the a an of to in on for and or is are was were be been it its this"
+    " that with not no when even though so as by from at into our we you"
+    " their".split()
+)
+
+
+def _db_path(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if not env:
+        print("MINI_ORK_DB unset", file=sys.stderr)
+        raise SystemExit(1)
+    return env
+
+
+def _connect(db: str | None) -> sqlite3.Connection:
+    con = sqlite3.connect(_db_path(db))
+    con.execute("PRAGMA busy_timeout=5000")
+    return con
+
+
+def init_schema(db: str | None = None) -> None:
+    """Ensure gradient_records exists, mirroring _gradient_ensure_table."""
+    con = _connect(db)
+    con.execute(
+        """
+        CREATE TABLE IF NOT EXISTS gradient_records (
+            gradient_id   TEXT PRIMARY KEY,
+            target        TEXT NOT NULL,
+            signal        TEXT NOT NULL,
+            suggested_change TEXT NOT NULL,
+            evidence      TEXT NOT NULL,
+            confidence    REAL NOT NULL DEFAULT 0.0
+                              CHECK(confidence BETWEEN 0.0 AND 1.0),
+            created_at    INTEGER NOT NULL,
+            task_class    TEXT
+        )
+        """
+    )
+    cols = [r[1] for r in con.execute("PRAGMA table_info(gradient_records)").fetchall()]
+    if "task_class" not in cols:
+        con.execute("ALTER TABLE gradient_records ADD COLUMN task_class TEXT")
+    con.commit()
+    con.close()
+
+
+def _tokens(s: str) -> set[str]:
+    return set(re.findall(r"[a-z0-9_]+", s.lower())) - _STOP
+
+
+def _fail(msg: str) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def store(payload: dict[str, Any] | str, db: str | None = None, dedup_sim: float | None = None) -> str:
+    """Store a gradient record, print and return its gradient_id."""
+    init_schema(db)
+    try:
+        p = json.loads(payload) if isinstance(payload, str) else dict(payload)
+    except json.JSONDecodeError as e:
+        _fail(f"gradient_store: invalid JSON: {e}")
+
+    gid = p.get("gradient_id") or f"gr-{uuid.uuid4().hex[:12]}"
+    now = int(time.time())
+    required = ("target", "signal", "suggested_change", "evidence")
+    for field in required:
+        if not p.get(field):
+            _fail(f"gradient_store: missing required field '{field}'")
+
+    con = _connect(db)
+    task_class = p.get("task_class") or ""
+    if not task_class:
+        try:
+            row = con.execute(
+                "SELECT task_class FROM execution_traces WHERE trace_id = ?",
+                (p["evidence"],),
+            ).fetchone()
+            task_class = row[0] if row and row[0] else ""
+        except sqlite3.OperationalError:
+            task_class = ""
+
+    if dedup_sim is None:
+        dedup_sim = float(os.environ.get("MO_GRADIENT_DEDUP_SIM", "0.65"))
+    if dedup_sim > 0 and not p.get("gradient_id"):
+        new_tok = _tokens(f"{p['signal']} {p['suggested_change']}")
+        try:
+            rows = con.execute(
+                "SELECT gradient_id, target, signal, suggested_change, confidence"
+                " FROM gradient_records WHERE task_class = ?",
+                (task_class,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
+        for gid_e, target_e, sig_e, chg_e, conf_e in rows:
+            if target_e == p["target"]:
+                continue
+            old_tok = _tokens(f"{sig_e} {chg_e}")
+            if not new_tok or not old_tok:
+                continue
+            sim = len(new_tok & old_tok) / min(len(new_tok), len(old_tok))
+            if sim >= dedup_sim:
+                con.execute(
+                    "UPDATE gradient_records SET confidence = ? WHERE gradient_id = ?",
+                    (max(float(conf_e or 0), float(p.get("confidence", 0.5))), gid_e),
+                )
+                con.commit()
+                con.close()
+                print(
+                    f"gradient_store: dedup sim={sim:.2f} target={p['target']}"
+                    f" absorbed into {target_e} [{gid_e}]",
+                    file=sys.stderr,
+                )
+                print(gid_e)
+                return str(gid_e)
+
+    con.execute(
+        """
+        INSERT INTO gradient_records (
+            gradient_id, target, signal, suggested_change, evidence, confidence, created_at, task_class
+        ) VALUES (?,?,?,?,?,?,?,?)
+        ON CONFLICT(gradient_id) DO UPDATE SET
+            signal=excluded.signal,
+            suggested_change=excluded.suggested_change,
+            confidence=excluded.confidence,
+            task_class=COALESCE(NULLIF(excluded.task_class,''), gradient_records.task_class)
+        """,
+        (
+            gid,
+            p["target"],
+            p["signal"],
+            p["suggested_change"],
+            p["evidence"],
+            float(p.get("confidence", 0.5)),
+            now,
+            task_class,
+        ),
+    )
+    con.commit()
+    con.close()
+    print(gid)
+    return str(gid)
+
+
+def _extract_objects_balanced(text: str) -> list[dict[str, Any]]:
+    """Brace-balanced extraction from possibly-truncated JSON array output."""
+    decoder = json.JSONDecoder()
+    objs = []
+    i = text.find("[")
+    if i < 0:
+        i = text.find("{")
+    if i < 0:
+        return objs
+    if text[i] == "[":
+        i += 1
+    n = len(text)
+    while i < n:
+        while i < n and text[i] in " \t\n\r,":
+            i += 1
+        if i >= n or text[i] == "]":
+            break
+        try:
+            obj, end = decoder.raw_decode(text, i)
+        except json.JSONDecodeError:
+            break
+        if isinstance(obj, dict):
+            objs.append(obj)
+        i = end
+    return objs
+
+
+def extract(
+    trace_id: str,
+    db: str | None = None,
+    override_fn: Callable[[str, str], Iterable[dict[str, Any]]] | None = None,
+) -> list[dict[str, Any]]:
+    """Extract gradients for a trace, print one JSON object per line."""
+    con = _connect(db)
+    con.row_factory = sqlite3.Row
+    row = con.execute("SELECT * FROM execution_traces WHERE trace_id=?", (trace_id,)).fetchone()
+    con.close()
+    if not row:
+        _fail(f"gradient_extract: trace_id {trace_id} not found")
+    trace_json = json.dumps(dict(row))
+
+    if override_fn is None:
+        fn_name = os.environ.get("MINI_ORK_GRADIENT_EXTRACTOR_FN", "")
+        candidate = globals().get(fn_name) if fn_name else None
+        if callable(candidate):
+            override_fn = candidate
+        elif fn_name:
+            _fail(f"gradient_extract: override fn {fn_name} not defined")
+
+    if override_fn is None:
+        return []
+
+    items = list(override_fn(trace_id, trace_json))
+    for item in items:
+        print(json.dumps(item))
+    return items
+

--- a/mini_ork/ported/operator_steering.py
+++ b/mini_ork/ported/operator_steering.py
@@ -1,0 +1,225 @@
+"""Operator-steering emit + consume — Python port of lib/operator_steering.sh.
+
+Faithful port of the deterministic SQLite sub-pipelines that
+``lib/operator_steering.sh`` shells out to via inline ``python3`` heredocs.
+The bash function definitions stay in place (strangler-fig co-existence);
+this module gives Python callers an in-process surface and gives
+``tests/unit/test_operator_steering_py.py`` a stable target to byte-diff
+against the live bash subprocess.
+
+Co-existence model (strangler-fig): bash ``lib/operator_steering.sh`` is the
+authoritative source. This module mirrors its sub-pipelines exactly. Parity
+is enforced by ``tests/unit/test_operator_steering_py.py`` (>=6 live-subprocess
+cases that diff row contents against the bash output; floats 1e-6).
+
+Pipeline map (bash function → Python):
+  operator_steering_emit:
+    --message / unknown-flag validation (>=2 stderr return code) → emit (raises ValueError)
+    env-resolve DB path (MINI_ORK_DB → MINI_ORK_HOME/state.db)     → _resolve_db
+    now_ms (gdate → python3 fallback → date fallback)             → _now_ms
+    expires_at = now_ms + ttl_secs * 1000                          → emit
+    INSERT … NULLIF on run_id / source, return lastrowid           → emit
+  operator_steering_fetch_for:
+    silent no-op when DB absent                                    → fetch_for (returns [])
+    SELECT … ORDER BY severity tier / confidence / created_at, LIMIT 10  → fetch_for
+    per-row JSON projection (matches bash JSONL output)            → fetch_for
+    mark-consumed UPDATE for returned ids (one statement)          → fetch_for
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+
+__all__ = [
+    "emit",
+    "fetch_for",
+]
+
+
+_VALID_ROLES = ("planner", "implementer", "reviewer", "verifier", "any")
+_VALID_SEVERITIES = ("info", "warn", "critical")
+
+
+def _resolve_db() -> str:
+    """Mirror ``_operator_steering_db`` in lib/operator_steering.sh:
+
+        echo "${MINI_ORK_DB:-${MINI_ORK_HOME:-$(pwd)/.mini-ork}/state.db}"
+
+    Three-tier precedence: explicit MINI_ORK_DB → MINI_ORK_HOME/state.db →
+    cwd/.mini-ork/state.db. Tests always set MINI_ORK_DB via subprocess
+    env= so the cwd fallback rarely fires.
+    """
+    if "MINI_ORK_DB" in os.environ and os.environ["MINI_ORK_DB"]:
+        return os.environ["MINI_ORK_DB"]
+    if "MINI_ORK_HOME" in os.environ and os.environ["MINI_ORK_HOME"]:
+        return os.path.join(os.environ["MINI_ORK_HOME"], "state.db")
+    return os.path.join(os.getcwd(), ".mini-ork", "state.db")
+
+
+def _now_ms() -> int:
+    """Mirror ``_operator_steering_now_ms`` python3 fallback.
+
+    Bash probes gdate first, then ``python3 -c 'import time; print(int(time.time() * 1000))'``,
+    then a coarse ``date +%s * 1000``. The harness test host has no gdate
+    (verified — bash subprocess falls through to its own python3 fallback),
+    so we mirror that python3 branch directly: ``int(time.time() * 1000)``.
+    """
+    return int(time.time() * 1000)
+
+
+def emit(
+    message: str,
+    run_id: str | None = None,
+    role_target: str = "any",
+    severity: str = "info",
+    source: str = "",
+    confidence: float = 0.8,
+    ttl_secs: int | None = None,
+    **kwargs: object,
+) -> int:
+    """Mirror ``operator_steering_emit`` in lib/operator_steering.sh.
+
+    Insert a steering row and return the new row id. Raises ``ValueError``
+    on validation failures (mirroring bash's ``>&2 'message required'`` /
+    ``'unknown flag'`` paths that return exit code 2). Raises
+    ``FileNotFoundError`` when ``state.db`` is missing and
+    ``sqlite3.OperationalError`` on DB errors — forbidden_fallbacks bans
+    silent recovery.
+
+    Validation order (mirrors bash):
+      1. unknown kwarg → "unknown flag: <name>" (matches bash `case *)`)
+      2. ``message`` non-empty → "--message required"
+      3. ``role_target`` in CHECK set
+      4. ``severity`` in CHECK set
+      5. DB file exists
+    """
+    if kwargs:
+        first = next(iter(kwargs))
+        raise ValueError(f"operator_steering_emit: unknown flag: {first}")
+
+    if not message:
+        raise ValueError("operator_steering_emit: --message required")
+
+    if role_target not in _VALID_ROLES:
+        raise ValueError(
+            f"operator_steering_emit: invalid role_target: {role_target!r} "
+            f"(expected one of {_VALID_ROLES})"
+        )
+    if severity not in _VALID_SEVERITIES:
+        raise ValueError(
+            f"operator_steering_emit: invalid severity: {severity!r} "
+            f"(expected one of {_VALID_SEVERITIES})"
+        )
+
+    db = _resolve_db()
+    if not os.path.isfile(db):
+        raise FileNotFoundError(f"operator_steering_emit: state.db not found: {db}")
+
+    if ttl_secs is None:
+        # Bash default mirrors ${MINI_ORK_STEERING_DEFAULT_TTL:-3600}; tests
+        # leave the env unset so the 3600 default applies to both sides.
+        ttl_secs = int(os.environ.get("MINI_ORK_STEERING_DEFAULT_TTL") or "3600")
+
+    now_ms = _now_ms()
+    expires_ms = now_ms + int(ttl_secs) * 1000
+
+    con = sqlite3.connect(db, timeout=5.0)
+    try:
+        con.execute("PRAGMA busy_timeout = 5000")
+        cur = con.execute(
+            """INSERT INTO operator_steering
+                 (run_id, role_target, severity, message, source,
+                  confidence, created_at, expires_at)
+               VALUES (NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''), ?, ?, ?)""",
+            (
+                run_id if run_id is not None else "",
+                role_target,
+                severity,
+                message,
+                source,
+                float(confidence),
+                int(now_ms),
+                int(expires_ms),
+            ),
+        )
+        con.commit()
+        # lastrowid is None only when no row was inserted; INSERT above
+        # always succeeds or raises, so it's always set here.
+        assert cur.lastrowid is not None
+        return int(cur.lastrowid)
+    finally:
+        con.close()
+
+
+def fetch_for(run_id: str, role: str = "any") -> list[dict]:
+    """Mirror ``operator_steering_fetch_for`` in lib/operator_steering.sh.
+
+    Returns up to 10 unconsumed, unexpired steering rows for the given
+    ``run_id`` + ``role`` (or ``role='any'``), each projected to the same
+    dict shape the bash JSONL emits. The matched rows are marked consumed
+    in one UPDATE so a second call returns ``[]`` — agents should not
+    see the same steering twice in a run.
+
+    Missing DB → returns ``[]`` silently to mirror bash's ``return 0``
+    no-op when ``state.db`` is absent (parity test sets ``MINI_ORK_DB``
+    to a real file, so this branch rarely fires, but it's there for
+    the kickoff's "no fallbacks" constraint: silent return on missing
+    DB IS the bash behavior, not a fallback).
+    """
+    db = _resolve_db()
+    if not os.path.isfile(db):
+        return []
+
+    now_ms = _now_ms()
+    run_id_arg = run_id or ""
+
+    con = sqlite3.connect(db, timeout=5.0)
+    try:
+        con.execute("PRAGMA busy_timeout = 5000")
+        cur = con.execute(
+            """SELECT id, run_id, role_target, severity, message, source,
+                      confidence, created_at, expires_at
+                 FROM operator_steering
+                WHERE consumed_at IS NULL
+                  AND expires_at > ?
+                  AND (run_id = ? OR run_id IS NULL)
+                  AND (role_target = ? OR role_target = 'any')
+                ORDER BY
+                  CASE severity WHEN 'critical' THEN 3 WHEN 'warn' THEN 2 ELSE 1 END DESC,
+                  confidence DESC,
+                  created_at DESC
+                LIMIT 10""",
+            (int(now_ms), run_id_arg, role),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            return []
+
+        out: list[dict] = []
+        ids: list[int] = []
+        for r in rows:
+            ids.append(int(r[0]))
+            out.append({
+                "id": int(r[0]),
+                "run_id": r[1],
+                "role_target": r[2],
+                "severity": r[3],
+                "message": r[4],
+                "source": r[5],
+                "confidence": r[6],
+                "created_at": int(r[7]),
+                "expires_at": int(r[8]),
+            })
+
+        # Mark consumed in one statement — mirrors bash's
+        # `UPDATE … SET consumed_at = ? WHERE id IN (…)`.
+        placeholders = ",".join("?" for _ in ids)
+        con.execute(
+            f"UPDATE operator_steering SET consumed_at = ? WHERE id IN ({placeholders})",
+            [int(now_ms), *ids],
+        )
+        con.commit()
+        return out
+    finally:
+        con.close()

--- a/mini_ork/ported/role_evolver.py
+++ b/mini_ork/ported/role_evolver.py
@@ -1,0 +1,346 @@
+"""Role-evolver — Python port of lib/role_evolver.sh.
+
+Faithful port of the four bash functions that compose role-evolution proposals
+from observed signals and read/update the ``role_evolver_log`` table. The bash
+wrapper in ``lib/role_evolver.sh`` is the authoritative source; this module
+mirrors its SQL semantics, output, and idempotence so parity tests can
+diff against the live bash invocation byte-for-byte (floats 1e-6).
+
+Co-existence model (strangler-fig): bash ``lib/role_evolver.sh`` stays in
+place. The Python port gives callers an in-process surface and gives the
+parity test (``tests/unit/test_role_evolver_py.py``) a stable target to
+diff against the live bash.
+
+Pipeline map (bash function → Python):
+  role_evolver_propose:
+    Signal 1 retire query (agent_performance_memory)            → _loser_lanes
+    Signal 2 split query  (bug_reports + correlated sub-select)  → _bug_clusters
+    Signal 3 rename query (gradient_records cross_class)         → _cross_class_renames
+    Idempotent INSERT (target_recipe, target_node_id, kind)     → propose
+  role_evolver_list     (printf-formatted pipe-separated rows)  → list_proposals
+  role_evolver_accept                                             → accept
+  role_evolver_reject                                             → reject
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+
+__all__ = ["propose", "list_proposals", "accept", "reject"]
+
+
+def _resolve_db(db: str | os.PathLike | None) -> str:
+    """Mirror bash line 32 precedence: MINI_ORK_DB > ${MINI_ORK_HOME:-.mini-ork}/state.db.
+
+    When the caller passes an explicit ``db`` (the test fixture and most
+    programmatic callers do), that wins. Otherwise the bash precedence
+    applies so an in-process port behaves identically when invoked with
+    the same env the bash wrapper would see.
+    """
+    if db is not None and os.fspath(db):
+        return os.fspath(db)
+    explicit = os.environ.get("MINI_ORK_DB")
+    if explicit:
+        return explicit
+    home = os.environ.get("MINI_ORK_HOME") or ".mini-ork"
+    return os.path.join(home, "state.db")
+
+
+def _open(db: str) -> sqlite3.Connection:
+    """Open the SQLite DB with the busy_timeout the bash heredoc sets.
+
+    Mirrors ``PRAGMA busy_timeout=5000`` from lib/role_evolver.sh so the port
+    doesn't deadlock against concurrent writers (e.g. the verifier running
+    init.sh against the same DB while propose() is mid-insert).
+    """
+    con = sqlite3.connect(db)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    return con
+
+
+def _loser_lanes(db: str, class_filter: str, top: int) -> list[sqlite3.Row]:
+    """Signal 1: lanes with strongly negative relative_advantage.
+
+    Mirrors lib/role_evolver.sh lines 56-65:
+
+        WHERE runs_count >= 3 AND relative_advantage <= -0.20
+              [AND task_class=?]
+        ORDER BY relative_advantage ASC LIMIT ?
+    """
+    clauses = "runs_count >= 3 AND relative_advantage <= -0.20"
+    params: tuple = (top,)
+    if class_filter:
+        clauses += " AND task_class=?"
+        params = (class_filter, top)
+    con = _open(db)
+    try:
+        return con.execute(
+            f"""
+            SELECT agent_version_id AS lane, task_class, role, model,
+                   relative_advantage, runs_count
+              FROM agent_performance_memory
+             WHERE {clauses}
+             ORDER BY relative_advantage ASC LIMIT ?
+            """,
+            params,
+        ).fetchall()
+    finally:
+        con.close()
+
+
+def _bug_clusters(db: str, top: int) -> list[sqlite3.Row]:
+    """Signal 2: high-frequency bug_reports clustered by agent_role.
+
+    Mirrors lib/role_evolver.sh lines 81-93. The correlated sub-select for
+    ``top_title`` orders by severity='critical' DESC, frequency DESC — the
+    port must keep this exact ordering or the rationale's top_title shifts.
+    """
+    con = _open(db)
+    try:
+        return con.execute(
+            """
+            SELECT agent_role, COUNT(*) AS n, MAX(frequency) AS max_freq,
+                   GROUP_CONCAT(id) AS bug_ids,
+                   (SELECT title FROM bug_reports b2
+                      WHERE b2.agent_role = b.agent_role AND b2.status='open'
+                      ORDER BY severity='critical' DESC, frequency DESC LIMIT 1
+                   ) AS top_title
+              FROM bug_reports b
+             WHERE status='open' AND severity IN ('high','critical')
+             GROUP BY agent_role
+            HAVING n >= 2
+             ORDER BY n DESC LIMIT ?
+            """,
+            (top,),
+        ).fetchall()
+    finally:
+        con.close()
+
+
+def _cross_class_renames(db: str, top: int) -> list[sqlite3.Row]:
+    """Signal 3: workflow nodes appearing in __cross_class__ gradients.
+
+    Mirrors lib/role_evolver.sh lines 112-120. ``node_name`` is extracted
+    via bash's ``split('.')[-1]`` semantics — the LAST segment of the target
+    string, which matches Python's ``rsplit('.', 1)[-1]`` and ``split('.')[-1]``
+    for non-empty inputs.
+    """
+    con = _open(db)
+    try:
+        return con.execute(
+            """
+            SELECT target, MAX(confidence) AS top_conf, COUNT(*) AS n
+              FROM gradient_records
+             WHERE task_class='__cross_class__'
+               AND target LIKE 'cross_class:workflow.node.%'
+               AND confidence >= 0.85
+             GROUP BY target
+             ORDER BY top_conf DESC, n DESC LIMIT ?
+            """,
+            (top,),
+        ).fetchall()
+    finally:
+        con.close()
+
+
+def propose(
+    db: str | os.PathLike | None = None,
+    class_filter: str = "",
+    top: int = 5,
+) -> int:
+    """Mirror lib/role_evolver.sh::role_evolver_propose.
+
+    Composes the three signals into role_evolver_log rows. Idempotent on
+    (target_recipe, target_node_id, proposal_kind) — duplicate 'open' rows
+    are skipped. Returns the count of newly-inserted proposals (an int, so
+    the bash wrapper's ``print(inserted)`` contract holds).
+    """
+    dbp = _resolve_db(db)
+
+    losers = _loser_lanes(dbp, class_filter, top)
+    bug_clusters = _bug_clusters(dbp, top)
+    cross_targets = _cross_class_renames(dbp, top)
+
+    proposals: list[dict] = []
+
+    for r in losers:
+        proposals.append({
+            "target_recipe":   r["task_class"].replace("_", "-"),
+            "target_node_id":  r["lane"],
+            "proposal_kind":   "retire",
+            "rationale":       (f"Lane {r['lane']} has relative_advantage "
+                                f"{r['relative_advantage']:.2f} over "
+                                f"{r['runs_count']} runs in {r['task_class']} — "
+                                f"consistently underperforms its peers."),
+            "evidence_json":   json.dumps({"agent_perf_rows": [r["lane"]]}),
+            "proposed_change": f"# Remove {r['lane']} from {r['task_class']} lens panel",
+        })
+
+    for r in bug_clusters:
+        if not r["agent_role"]:
+            continue
+        proposals.append({
+            "target_recipe":   "framework-edit",
+            "target_node_id":  r["agent_role"],
+            "proposal_kind":   "split",
+            "rationale":       (f"Role {r['agent_role']} accumulated {r['n']} "
+                                f"high/critical bug_reports (top title: "
+                                f"{(r['top_title'] or '')[:80]!r}). Splitting "
+                                f"into focused sub-roles may reduce surface."),
+            "evidence_json":   json.dumps({"bug_ids": (r["bug_ids"] or "").split(",")[:10]}),
+            "proposed_change": f"# Split {r['agent_role']} into {r['agent_role']}_pre and {r['agent_role']}_post",
+        })
+
+    for r in cross_targets:
+        target = r["target"]
+        node_name = target.split(".")[-1] if target else "?"
+        if not node_name or node_name == "?":
+            continue
+        proposals.append({
+            "target_recipe":   "*",
+            "target_node_id":  node_name,
+            "proposal_kind":   "rename",
+            "rationale":       (f"Node '{node_name}' surfaces as a "
+                                f"__cross_class__ gradient with confidence "
+                                f"{r['top_conf']:.2f}. Lessons generalize — "
+                                f"consider naming abstractly."),
+            "evidence_json":   json.dumps({"gradient_target": target}),
+            "proposed_change": f"# Rename node {node_name} -> <abstract noun>",
+        })
+
+    con = _open(dbp)
+    try:
+        inserted = 0
+        now = int(time.time())
+        for p in proposals:
+            exists = con.execute(
+                """
+                SELECT 1 FROM role_evolver_log
+                 WHERE target_recipe=? AND target_node_id=? AND proposal_kind=?
+                   AND status='open' LIMIT 1
+                """,
+                (p["target_recipe"], p["target_node_id"], p["proposal_kind"]),
+            ).fetchone()
+            if exists:
+                continue
+            con.execute(
+                """
+                INSERT INTO role_evolver_log
+                    (proposed_at, target_recipe, target_node_id, proposal_kind,
+                     rationale, evidence_json, proposed_change, status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 'open')
+                """,
+                (now, p["target_recipe"], p["target_node_id"], p["proposal_kind"],
+                 p["rationale"][:600], p["evidence_json"][:2000],
+                 p["proposed_change"][:600]),
+            )
+            inserted += 1
+        con.commit()
+    finally:
+        con.close()
+    return inserted
+
+
+def list_proposals(
+    db: str | os.PathLike | None = None,
+    status: str = "open",
+    limit: int = 20,
+) -> str:
+    """Mirror lib/role_evolver.sh::role_evolver_list.
+
+    The bash printf format emits pipe-separated rows of width-padded columns.
+    The Python port must reproduce the same widths so the parity test's
+    string-equality check holds:
+
+      printf('%-4d', id)                                → str(id)[:4].ljust(4)
+      printf('%-10s', status)                           → status.ljust(10)
+      printf('%-7s', proposal_kind)                     → proposal_kind.ljust(7)
+      printf('%-18s', substr(target_recipe, 1, 18))     → target_recipe[:18].ljust(18)
+      printf('%-15s', substr(target_node_id, 1, 15))    → target_node_id[:15].ljust(15)
+      substr(rationale, 1, 80)                          → rationale[:80]
+
+    Status handling mirrors bash: ``--`` prefix is stripped, ``status='all'``
+    or empty status yields no WHERE clause, anything else is bound as
+    ``WHERE status='<value>'``. The LIMIT mirrors bash's ``LIMIT 20`` (the
+    ``limit`` parameter lets the parity test exercise a smaller window).
+    """
+    dbp = _resolve_db(db)
+    # Mirror bash: ${1:---open} then ${status#--}. A leading '--' is stripped.
+    if status.startswith("--"):
+        status = status[2:]
+    clause = ""
+    params: tuple = ()
+    if status and status != "all":
+        clause = "WHERE status=?"
+        params = (status,)
+
+    con = _open(dbp)
+    try:
+        rows = con.execute(
+            f"""
+            SELECT id, status, proposal_kind, target_recipe, target_node_id,
+                   rationale
+              FROM role_evolver_log
+              {clause}
+             ORDER BY id DESC LIMIT ?
+            """,
+            (*params, limit),
+        ).fetchall()
+    finally:
+        con.close()
+
+    sep = " | "
+    out_lines = []
+    for row in rows:
+        out_lines.append(
+            str(row["id"])[:4].ljust(4) + sep
+            + (row["status"] or "").ljust(10) + sep
+            + (row["proposal_kind"] or "").ljust(7) + sep
+            + (row["target_recipe"] or "")[:18].ljust(18) + sep
+            + (row["target_node_id"] or "")[:15].ljust(15) + sep
+            + (row["rationale"] or "")[:80]
+        )
+    return "\n".join(out_lines)
+
+
+def accept(db: str | os.PathLike | None, proposal_id: int) -> None:
+    """Mirror lib/role_evolver.sh::role_evolver_accept.
+
+    Raises ValueError on falsy id (mirrors bash's ``${1:?id required}``).
+    No silent fallbacks: forbidden_fallbacks bans swallowing the missing-id
+    case, so we surface it instead of silently no-oping.
+    """
+    if not proposal_id:
+        raise ValueError("id required")
+    dbp = _resolve_db(db)
+    con = _open(dbp)
+    try:
+        con.execute(
+            "UPDATE role_evolver_log SET status='accepted' WHERE id=?;",
+            (proposal_id,),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def reject(db: str | os.PathLike | None, proposal_id: int) -> None:
+    """Mirror lib/role_evolver.sh::role_evolver_reject.
+
+    Raises ValueError on falsy id (mirrors bash's ``${1:?id required}``).
+    """
+    if not proposal_id:
+        raise ValueError("id required")
+    dbp = _resolve_db(db)
+    con = _open(dbp)
+    try:
+        con.execute(
+            "UPDATE role_evolver_log SET status='rejected' WHERE id=?;",
+            (proposal_id,),
+        )
+        con.commit()
+    finally:
+        con.close()

--- a/mini_ork/ported/spec_split.py
+++ b/mini_ork/ported/spec_split.py
@@ -1,0 +1,230 @@
+"""Visible/Hidden Spec Split — Python port of lib/spec-split.sh.
+
+Faithful port of the *deterministic* sub-pipelines of `mo_split_visible_hidden`
+(the inline Python heredoc that extracts the hidden test subset) and the
+verdict-writing half of `mo_run_hidden_suite`. The actual `npx playwright test`
+call stays in bash — it requires a live worktree + Playwright runtime and is
+out of scope for pytest. The Python port gives callers an in-process surface
+and gives parity tests a stable target to byte-diff against the live bash.
+
+Co-existence model (strangler-fig): bash `lib/spec-split.sh` is the
+authoritative source. This module mirrors its sub-pipelines exactly. Parity
+is enforced by `tests/unit/test_spec_split_py.py` (>=6 cases that invoke
+`lib/spec-split.sh` via subprocess — stubbing `mo_run_dir` and `npx` — and
+diff against the Python output byte-for-byte).
+
+Pipeline map (bash function → Python):
+  mo_split_visible_hidden:
+    missing-spec early-bail (rc=1 + error JSON)        → split_visible_hidden raises FileNotFoundError
+    Pass 1 collect imports                              → split_visible_hidden pass 1
+    Pass 2 locate test.describe wrapper + header        → split_visible_hidden pass 2
+    Pass 3 depth-counter walk + 3-line back-lookup      → split_visible_hidden pass 3
+    AUTOGEN banner + imports + header + blocks + });    → split_visible_hidden
+    spec-split-report.json {visible, hidden, ratio}     → split_visible_hidden
+  mo_run_hidden_suite:
+    decide_skip (no hidden / no ^test() → skipped=true)  → decide_skip_hidden_suite
+    jq -n verdict write (skip shape + ran shape)        → write_verdict
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+
+__all__ = [
+    "split_visible_hidden",
+    "decide_skip_hidden_suite",
+    "write_verdict",
+]
+
+
+_HIDDEN_MARKER_RE = re.compile(r"^\s*//\s*@hidden")
+_DESCRIBE_RE = re.compile(r"^\s*test\.describe\(")
+_TEST_RE = re.compile(r"^\s*test\(")
+
+
+def split_visible_hidden(visible_spec_path, iter_dir) -> dict:
+    """Mirror lib/spec-split.sh::mo_split_visible_hidden heredoc byte-for-byte.
+
+    Args:
+        visible_spec_path: path to the e2e/<EPIC>_*.spec.ts the worker sees.
+        iter_dir:          directory to write hidden_spec.ts + spec-split-report.json
+                           into (the caller computes this from `mo_run_dir "$epic"/iter-$iter`
+                           so the port stays decoupled from the dispatch runtime).
+
+    Returns:
+        Dict {visible, hidden, ratio} on success.
+        For the no-describe early-bail, returns {visible: 0, hidden: 0, error: "no describe"}.
+        Raises FileNotFoundError when visible_spec_path is missing (the bash function
+        returns rc=1 in the same case; the port surfaces a Python exception so
+        downstream code can `except FileNotFoundError` rather than parse rc codes).
+
+    Writes:
+        <iter_dir>/hidden_spec.ts — the hidden subset (or empty marker).
+        <iter_dir>/spec-split-report.json — counts + ratio.
+
+    Note: parity with the bash heredoc requires Python `re.match` (anchored at
+    start of line, NOT `re.search`) and explicit `\n` joins — both are used here.
+    """
+    visible_spec_path = pathlib.Path(visible_spec_path)
+    iter_dir = pathlib.Path(iter_dir)
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    hidden_out = iter_dir / "hidden_spec.ts"
+    report_out = iter_dir / "spec-split-report.json"
+
+    if not visible_spec_path.is_file():
+        # Bash: `jq -n '{visible: 0, hidden: 0, error: "visible spec missing"}' > report; return 1`
+        # Hidden file is NOT written in this branch — bash returns before the heredoc.
+        report_out.write_text(
+            json.dumps({"visible": 0, "hidden": 0, "error": "visible spec missing"})
+        )
+        raise FileNotFoundError(f"visible spec missing: {visible_spec_path}")
+
+    src = visible_spec_path.read_text()
+    lines = src.split("\n")
+
+    # Pass 1: collect imports (everything until first non-import / non-blank / non-//).
+    imports: list[str] = []
+    i = 0
+    while i < len(lines):
+        L = lines[i].rstrip()
+        if L.startswith("import ") or L.startswith("//") or L == "":
+            imports.append(L)
+            i += 1
+            continue
+        break
+
+    # Pass 2: locate the test.describe wrapper + beforeEach.
+    header: list[str] = []
+    j = i
+    while j < len(lines) and not _DESCRIBE_RE.match(lines[j]):
+        j += 1
+    if j == len(lines):
+        # No describe — bail with empty hidden.
+        hidden_out.write_text("// no test.describe found — no hidden spec\n")
+        report_out.write_text(json.dumps({"visible": 0, "hidden": 0, "error": "no describe"}))
+        return {"visible": 0, "hidden": 0, "error": "no describe"}
+
+    # Capture from describe to first test( occurrence — include beforeEach.
+    k = j
+    while k < len(lines) and not _TEST_RE.match(lines[k]):
+        header.append(lines[k])
+        k += 1
+
+    # Pass 3: walk tests; pick out @hidden ones.
+    hidden_blocks: list[str] = []
+    visible_count = 0
+    hidden_count = 0
+    m = k
+
+    def is_hidden(idx: int) -> bool:
+        """Look up to 3 lines BACK from idx for a @hidden marker. Blank
+        lines are transparent; the first non-blank line that isn't a
+        @hidden marker ends the search."""
+        for back in range(1, 4):
+            if idx - back < 0:
+                return False
+            if _HIDDEN_MARKER_RE.match(lines[idx - back]):
+                return True
+            if lines[idx - back].strip() == "":
+                continue
+            return False
+        return False
+
+    while m < len(lines):
+        if _TEST_RE.match(lines[m]):
+            start = m
+            depth = 0
+            end = start
+            for n in range(start, len(lines)):
+                depth += lines[n].count("{") - lines[n].count("}")
+                if depth == 0 and n > start:
+                    end = n
+                    break
+            block = "\n".join(lines[start:end + 1])
+            if is_hidden(start):
+                hidden_blocks.append(block)
+                hidden_count += 1
+            else:
+                visible_count += 1
+            m = end + 1
+        else:
+            m += 1
+
+    if hidden_count == 0:
+        hidden_out.write_text("// no @hidden scenarios in source spec\n")
+    else:
+        out: list[str] = []
+        out.append(
+            "// AUTOGEN: hidden spec — DO NOT commit to worktree.\n"
+            "// Worker MUST NOT see this file. Runs only at Phase 2 validation gate.\n"
+        )
+        out.extend(imports)
+        out.append("")
+        out.extend(header)
+        out.extend(hidden_blocks)
+        out.append("});\n")
+        hidden_out.write_text("\n".join(out))
+
+    total = visible_count + hidden_count
+    ratio = (hidden_count / total) if total > 0 else 0
+    report = {"visible": visible_count, "hidden": hidden_count, "ratio": ratio}
+    report_out.write_text(json.dumps(report))
+    return report
+
+
+def decide_skip_hidden_suite(hidden_path) -> tuple[bool, str]:
+    """Mirror lib/spec-split.sh::mo_run_hidden_suite early-bail.
+
+    Returns (True, "no @hidden scenarios") when the hidden spec file is missing
+    OR when `^test(` is not present (regex semantics — NOT grep — matching
+    bash's `grep -q '^test('`). Otherwise returns (False, "").
+
+    The caller is responsible for skipping the `npx playwright test` call and
+    writing the skip-shape verdict via `write_verdict(..., skipped=True, ...)`.
+    """
+    hidden_path = pathlib.Path(hidden_path)
+    if not hidden_path.is_file():
+        return True, "no @hidden scenarios"
+    try:
+        content = hidden_path.read_text()
+    except OSError:
+        return True, "no @hidden scenarios"
+    if not _TEST_RE.search(content):
+        return True, "no @hidden scenarios"
+    return False, ""
+
+
+def write_verdict(
+    verdict: str,
+    rc: int,
+    ran_at: str,
+    verdict_path,
+    skipped: bool = False,
+    reason: str = "",
+) -> None:
+    """Mirror lib/spec-split.sh::mo_run_hidden_suite `jq -n` verdict writes.
+
+    Two shapes, exactly matching the bash invocations:
+
+    Skip path (lib/spec-split.sh line 152):
+        jq -n '{verdict: "PASS", scenarios_run: 0, skipped: true,
+                reason: "no @hidden scenarios"}' > verdict_path
+        → {"verdict": "PASS", "scenarios_run": 0, "skipped": true, "reason": <reason>}
+
+    Run path (lib/spec-split.sh lines 172-177):
+        jq -n --arg verdict "$verdict" --argjson rc "$rc"
+              --arg ran_at "$(date -u +%FT%TZ)" \
+              '{verdict: $verdict, rc: $rc, ran_at: $ran_at, skipped: false}'
+        → {"verdict": <verdict>, "rc": <rc>, "ran_at": <ran_at>, "skipped": false}
+
+    `json.dumps` with default settings preserves dict insertion order (Python
+    3.7+), so the key order matches jq's emission.
+    """
+    if skipped:
+        payload = {"verdict": "PASS", "scenarios_run": 0, "skipped": True, "reason": reason}
+    else:
+        payload = {"verdict": verdict, "rc": rc, "ran_at": ran_at, "skipped": False}
+    # jq -n default formatting = 2-space indent + trailing newline (the
+    # trailing `\n` mirrors jq's stdout behavior under bash's `> file`).
+    pathlib.Path(verdict_path).write_text(json.dumps(payload, indent=2) + "\n")

--- a/tests/unit/test_artifact_contract_py.py
+++ b/tests/unit/test_artifact_contract_py.py
@@ -1,0 +1,358 @@
+"""Parity gate: mini_ork.ported.artifact_contract vs lib/artifact_contract.sh.
+
+Each test invokes the LIVE bash subprocess on the same inputs as the Python
+port and asserts byte/JSON-identical output. No mocks, no hardcoded expected
+outputs — expected is always derived from a control bash invocation that
+shares the inputs.
+
+>=7 cases (per the kickoff: >=6 required):
+  (1) load default contract (no file)              — JSON byte-equal
+  (2) load YAML contract (patch + request_changes) — JSON byte-equal
+  (3) load JSON-with-.yaml-extension contract      — JSON byte-equal
+  (4) validate correct-type .patch artifact       — 'pass' + JSON byte-equal
+  (5) validate wrong-type .json artifact (patch)  — 'fail' + JSON byte-equal
+  (6) validate nonexistent artifact path          — 'fail' + JSON byte-equal
+  (7) DB-coupled: contract with sqlite3 verifier,
+      temp DB seeded by db/init.sh, row-count diff — 'pass' + row diff
+
+The bash-side unit test (``bash tests/unit/test_artifact_contract.sh``) is
+run separately as a regression guard to prove the bash script was not
+disturbed.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import artifact_contract as ac  # noqa: E402
+
+SH = REPO / "lib" / "artifact_contract.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers — invoke LIVE bash via subprocess and format Python output to match
+# ─────────────────────────────────────────────────────────────────────────────
+def _bash_load(task_class: str, contracts_dir: Path) -> str:
+    """Invoke ``artifact_contract_load <tc>`` via bash subprocess, return stdout.
+
+    Compares ONLY stdout (the JSON payload) against the Python port — bash's
+    default-fallback 'using default' stderr notice is excluded by parity design.
+    """
+    r = subprocess.run(
+        ["bash", "-c", f'. "{SH}" && artifact_contract_load "$1"',
+         "_", task_class],
+        env={**os.environ, "MINI_ORK_ROOT": str(REPO),
+             "MINI_ORK_HOME": str(contracts_dir.parent.parent)},
+        capture_output=True, text=True,
+    )
+    return r.stdout
+
+
+def _bash_validate(task_class: str, artifact_path: str, contracts_dir: Path,
+                   mini_ork_root: str = str(REPO),
+                   extra_env: dict | None = None) -> str:
+    """Invoke ``artifact_contract_validate <tc> <artifact>`` via bash subprocess."""
+    env = {**os.environ, "MINI_ORK_ROOT": mini_ork_root,
+           "MINI_ORK_HOME": str(contracts_dir.parent.parent)}
+    if extra_env:
+        env.update(extra_env)
+    r = subprocess.run(
+        ["bash", "-c",
+         f'. "{SH}" && artifact_contract_validate "$1" "$2"',
+         "_", task_class, artifact_path],
+        env=env,
+        capture_output=True, text=True,
+    )
+    return r.stdout
+
+
+def _python_load_stdout(task_class: str, contracts_dir: Path) -> str:
+    """Format ``load_contract(tc)`` to bash-equivalent stdout (``json + \\n``)."""
+    contract = ac.load_contract(task_class, contracts_dir=str(contracts_dir))
+    return json.dumps(contract) + "\n"
+
+
+def _python_validate_stdout(task_class: str, artifact_path: str,
+                            contracts_dir: Path,
+                            mini_ork_root: str = str(REPO)) -> str:
+    """Format ``validate(tc, artifact)`` to bash-equivalent stdout (2-line)."""
+    contract = ac.load_contract(task_class, contracts_dir=str(contracts_dir))
+    payload = ac.validate_artifact(contract, artifact_path,
+                                    mini_ork_root=mini_ork_root)
+    return payload["verdict"] + "\n" + json.dumps(payload) + "\n"
+
+
+@pytest.fixture
+def home(tmp_path):
+    """Per-test MINI_ORK_HOME with empty config/artifact_contracts/."""
+    cfg = tmp_path / "config" / "artifact_contracts"
+    cfg.mkdir(parents=True)
+    return tmp_path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (1) load default contract (no file present)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_load_default_contract_parity(home):
+    """Default permissive contract (no file) — bash and Python both emit the
+    same JSON dict with the same key order and trailing newline."""
+    contracts_dir = home / "config" / "artifact_contracts"
+    bash_out = _bash_load("nonexistent-task-class", contracts_dir)
+    py_out = _python_load_stdout("nonexistent-task-class", contracts_dir)
+    assert bash_out == py_out
+    parsed = json.loads(bash_out)
+    assert parsed["_default"] is True
+    assert parsed["expected_artifact"] == "data"
+    assert parsed["failure_policy"] == "escalate"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (2) load YAML contract with patch + request_changes
+# ─────────────────────────────────────────────────────────────────────────────
+def test_load_yaml_contract_parity(home):
+    """YAML contract with expected_artifact=patch — bash parses via PyYAML,
+    Python port matches verbatim."""
+    contracts_dir = home / "config" / "artifact_contracts"
+    (contracts_dir / "test-patch.yaml").write_text(
+        "task_type: test-patch\n"
+        "expected_artifact: patch\n"
+        "failure_policy: request_changes\n"
+        "rollback_policy: auto\n"
+        "success_verifiers: []\n",
+        encoding="utf-8",
+    )
+    bash_out = _bash_load("test-patch", contracts_dir)
+    py_out = _python_load_stdout("test-patch", contracts_dir)
+    assert bash_out == py_out
+    parsed = json.loads(bash_out)
+    assert parsed["expected_artifact"] == "patch"
+    assert parsed["failure_policy"] == "request_changes"
+    assert parsed["rollback_policy"] == "auto"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (3) load JSON-with-.yaml-extension contract (JSON-fallback path on yaml-less envs)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_load_json_extension_yaml_parity(home):
+    """A .yaml file containing valid JSON. PyYAML (when installed) parses JSON
+    as a subset of YAML and produces the same dict; on yaml-less envs the JSON
+    fallback fires — both paths emit the same JSON to stdout."""
+    contracts_dir = home / "config" / "artifact_contracts"
+    (contracts_dir / "json-yaml.yaml").write_text(
+        '{"task_type": "json-yaml", "expected_artifact": "data", '
+        '"failure_policy": "rollback", "rollback_policy": "auto", '
+        '"success_verifiers": []}\n',
+        encoding="utf-8",
+    )
+    bash_out = _bash_load("json-yaml", contracts_dir)
+    py_out = _python_load_stdout("json-yaml", contracts_dir)
+    assert bash_out == py_out
+    parsed = json.loads(bash_out)
+    assert parsed["failure_policy"] == "rollback"
+    assert parsed["task_type"] == "json-yaml"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (4) validate correct-type .patch artifact → 'pass'
+# ─────────────────────────────────────────────────────────────────────────────
+def test_validate_pass_patch_artifact_parity(home):
+    """A valid .patch artifact against a patch-typed contract → 'pass' line
+    plus identical JSON dict on line 2."""
+    contracts_dir = home / "config" / "artifact_contracts"
+    (contracts_dir / "test-patch.yaml").write_text(
+        "task_type: test-patch\n"
+        "expected_artifact: patch\n"
+        "failure_policy: request_changes\n"
+        "rollback_policy: auto\n"
+        "success_verifiers: []\n",
+        encoding="utf-8",
+    )
+    artifact = home / "diff.patch"
+    artifact.write_text(
+        "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n",
+        encoding="utf-8",
+    )
+    bash_out = _bash_validate("test-patch", str(artifact), contracts_dir)
+    py_out = _python_validate_stdout("test-patch", str(artifact), contracts_dir)
+    assert bash_out == py_out
+    lines = bash_out.splitlines()
+    assert lines[0] == "pass"
+    payload = json.loads(lines[1])
+    assert payload["verdict"] == "pass"
+    assert payload["artifact_path"] == str(artifact)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (5) validate wrong-type .json artifact when patch expected → 'fail'
+# ─────────────────────────────────────────────────────────────────────────────
+def test_validate_fail_wrong_ext_parity(home):
+    """A .json artifact against a patch-typed contract → 'fail' line plus
+    identical reasons JSON."""
+    contracts_dir = home / "config" / "artifact_contracts"
+    (contracts_dir / "test-patch.yaml").write_text(
+        "task_type: test-patch\n"
+        "expected_artifact: patch\n"
+        "failure_policy: request_changes\n"
+        "rollback_policy: auto\n"
+        "success_verifiers: []\n",
+        encoding="utf-8",
+    )
+    artifact = home / "data.json"
+    artifact.write_text('{"k":"v"}', encoding="utf-8")
+    bash_out = _bash_validate("test-patch", str(artifact), contracts_dir)
+    py_out = _python_validate_stdout("test-patch", str(artifact), contracts_dir)
+    assert bash_out == py_out
+    lines = bash_out.splitlines()
+    assert lines[0] == "fail"
+    payload = json.loads(lines[1])
+    assert payload["verdict"] == "fail"
+    assert any("expected artifact type 'patch'" in r for r in payload["reasons"])
+    assert payload["failure_policy"] == "request_changes"
+    assert payload["rollback_policy"] == "auto"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (6) validate nonexistent artifact path → 'fail'
+# ─────────────────────────────────────────────────────────────────────────────
+def test_validate_fail_missing_artifact_parity(home):
+    """Artifact path that does not exist → 'fail' line with 'artifact not
+    found' reason, identical to bash output."""
+    contracts_dir = home / "config" / "artifact_contracts"
+    (contracts_dir / "test-patch.yaml").write_text(
+        "task_type: test-patch\n"
+        "expected_artifact: patch\n"
+        "failure_policy: request_changes\n"
+        "rollback_policy: auto\n"
+        "success_verifiers: []\n",
+        encoding="utf-8",
+    )
+    missing = str(home / "no-such-artifact.patch")
+    bash_out = _bash_validate("test-patch", missing, contracts_dir)
+    py_out = _python_validate_stdout("test-patch", missing, contracts_dir)
+    assert bash_out == py_out
+    lines = bash_out.splitlines()
+    assert lines[0] == "fail"
+    payload = json.loads(lines[1])
+    assert payload["verdict"] == "fail"
+    assert any("artifact not found" in r for r in payload["reasons"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (7) DB-coupled parity — sqlite3 verifier writes to a temp DB seeded by
+#     db/init.sh; both bash and Python must agree on 'pass' AND the row diff
+#     matches.
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def temp_db(tmp_path_factory):
+    """Spin up a real mini-ork SQLite DB via db/init.sh — kickoff requirement."""
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    r = subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"db/init.sh failed: rc={r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}")
+    return dbp, home
+
+
+def test_validate_db_coupled_verifier_parity(temp_db, monkeypatch):
+    """Contract with a sqlite3 verifier that writes a row to a temp DB; both
+    bash and Python must emit 'pass' AND the resulting row count diff must
+    match — proves verifier subprocess parity, not just JSON shape parity."""
+    dbp, home = temp_db
+    # Expose MINI_ORK_DB to the Python port's verifier subprocess (mirrors the
+    # bash subprocess env used above).
+    monkeypatch.setenv("MINI_ORK_DB", dbp)
+    contracts_dir = home / "config" / "artifact_contracts"
+    contracts_dir.mkdir(parents=True, exist_ok=True)
+
+    # Verifier creates the side table (idempotent) and INSERTs a marker row.
+    # `; true` swallows the trailing artifact_path arg the bash verifier harness
+    # always appends, so sqlite3 isn't called with extra positionals. (`:` would
+    # also work but YAML would mis-parse the trailing `:` as a key-value
+    # separator, turning the verifier into a dict and getting skipped by the
+    # bash's `isinstance(verifier, str)` guard.)
+    verifier_cmd = (
+        'sqlite3 "$MINI_ORK_DB" "CREATE TABLE IF NOT EXISTS _verifier_log '
+        "(artifact_path TEXT, marker TEXT); "
+        "INSERT INTO _verifier_log VALUES ('$1', 'parity-marker');\" "
+        ">/dev/null 2>&1; true"
+    )
+    contract_yaml = (
+        "task_type: db-coupled\n"
+        "expected_artifact: patch\n"
+        "failure_policy: escalate\n"
+        "rollback_policy: none\n"
+        "success_verifiers:\n"
+        f"  - {verifier_cmd}\n"
+    )
+    (contracts_dir / "db-coupled.yaml").write_text(contract_yaml, encoding="utf-8")
+
+    artifact = home / "diff.patch"
+    artifact.write_text(
+        "--- a/x\n+++ b/x\n@@ -1 +1 @@\n-a\n+b\n", encoding="utf-8"
+    )
+
+    # Sanity: side-table doesn't exist yet → row count = 0.
+    con = sqlite3.connect(dbp)
+    try:
+        con.execute(
+            "CREATE TABLE IF NOT EXISTS _verifier_log "
+            "(artifact_path TEXT, marker TEXT)"
+        )
+        con.commit()
+        before = con.execute(
+            "SELECT COUNT(*) FROM _verifier_log WHERE marker='parity-marker'"
+        ).fetchone()[0]
+        assert before == 0
+    finally:
+        con.close()
+
+    # Bash validate — must emit 'pass' AND write a row.
+    bash_out = _bash_validate(
+        "db-coupled", str(artifact), contracts_dir,
+        mini_ork_root=str(REPO),
+        extra_env={"MINI_ORK_DB": dbp},
+    )
+    assert bash_out.splitlines()[0] == "pass", f"bash stdout was: {bash_out!r}"
+
+    con = sqlite3.connect(dbp)
+    try:
+        after_bash = con.execute(
+            "SELECT COUNT(*) FROM _verifier_log WHERE marker='parity-marker'"
+        ).fetchone()[0]
+    finally:
+        con.close()
+    assert after_bash == 1, f"bash verifier wrote {after_bash} rows (expected 1)"
+
+    # Python validate — must emit identical stdout AND write a row.
+    py_out = _python_validate_stdout(
+        "db-coupled", str(artifact), contracts_dir, mini_ork_root=str(REPO),
+    )
+    assert py_out == bash_out, (
+        f"python stdout diverged from bash\n"
+        f"bash: {bash_out!r}\npython: {py_out!r}"
+    )
+
+    con = sqlite3.connect(dbp)
+    try:
+        after_py = con.execute(
+            "SELECT COUNT(*) FROM _verifier_log WHERE marker='parity-marker'"
+        ).fetchone()[0]
+    finally:
+        con.close()
+    assert after_py == 2, (
+        f"python verifier wrote {after_py - after_bash} new rows "
+        f"(expected 1, total = 2)"
+    )

--- a/tests/unit/test_gradient_extractor_py.py
+++ b/tests/unit/test_gradient_extractor_py.py
@@ -1,0 +1,271 @@
+"""Parity gate: mini_ork.ported.gradient_extractor vs lib/gradient_extractor.sh."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork import trace_store  # noqa: E402
+from mini_ork.ported import gradient_extractor as ge  # noqa: E402
+
+GE_SH = REPO / "lib" / "gradient_extractor.sh"
+TS_SH = REPO / "lib" / "trace_store.sh"
+
+
+@pytest.fixture
+def db(tmp_path):
+    home = tmp_path / "home"
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(REPO / "db" / "init.sh")],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return dbp
+
+
+def _bash(db: str, snippet: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    bash_env = {
+        **os.environ,
+        "MINI_ORK_ROOT": str(REPO),
+        "MINI_ORK_DB": db,
+        "MO_GRADIENT_DEDUP_SIM": "0",
+    }
+    if env:
+        bash_env.update(env)
+    return subprocess.run(
+        ["bash", "-c", f'. "{TS_SH}" && . "{GE_SH}" && {snippet}'],
+        env=bash_env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _py_store(payload: dict | str, db: str) -> tuple[int, str, str]:
+    out = io.StringIO()
+    err = io.StringIO()
+    old = os.environ.get("MO_GRADIENT_DEDUP_SIM")
+    os.environ["MO_GRADIENT_DEDUP_SIM"] = "0"
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            ge.store(payload, db=db)
+        rc = 0
+    except SystemExit as e:
+        rc = int(e.code or 0)
+    finally:
+        if old is None:
+            os.environ.pop("MO_GRADIENT_DEDUP_SIM", None)
+        else:
+            os.environ["MO_GRADIENT_DEDUP_SIM"] = old
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _py_extract(trace_id: str, db: str, override_fn=None, env: dict[str, str] | None = None) -> tuple[int, str, str]:
+    out = io.StringIO()
+    err = io.StringIO()
+    old = os.environ.get("MINI_ORK_GRADIENT_EXTRACTOR_FN")
+    try:
+        if env and "MINI_ORK_GRADIENT_EXTRACTOR_FN" in env:
+            os.environ["MINI_ORK_GRADIENT_EXTRACTOR_FN"] = env["MINI_ORK_GRADIENT_EXTRACTOR_FN"]
+        elif old is not None:
+            os.environ.pop("MINI_ORK_GRADIENT_EXTRACTOR_FN", None)
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            ge.extract(trace_id, db=db, override_fn=override_fn)
+        rc = 0
+    except SystemExit as e:
+        rc = int(e.code or 0)
+    finally:
+        if old is None:
+            os.environ.pop("MINI_ORK_GRADIENT_EXTRACTOR_FN", None)
+        else:
+            os.environ["MINI_ORK_GRADIENT_EXTRACTOR_FN"] = old
+    return rc, out.getvalue(), err.getvalue()
+
+
+def _row(db: str, gid: str) -> dict:
+    con = sqlite3.connect(db)
+    con.row_factory = sqlite3.Row
+    row = con.execute("SELECT * FROM gradient_records WHERE gradient_id=?", (gid,)).fetchone()
+    con.close()
+    assert row is not None
+    return dict(row)
+
+
+def _all_rows(db: str) -> list[dict]:
+    con = sqlite3.connect(db)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT gradient_id, target, signal, suggested_change, evidence, confidence, task_class "
+        "FROM gradient_records ORDER BY gradient_id"
+    ).fetchall()
+    con.close()
+    return [dict(r) for r in rows]
+
+
+def _assert_rows_match(left: list[dict], right: list[dict]) -> None:
+    assert len(left) == len(right)
+    for lrow, rrow in zip(left, right):
+        assert set(lrow) == set(rrow)
+        for key in lrow:
+            if key == "confidence":
+                assert abs(float(lrow[key]) - float(rrow[key])) <= 1e-6
+            else:
+                assert lrow[key] == rrow[key]
+
+
+def test_store_happy_path_round_trip(db):
+    payload = {
+        "gradient_id": "gr-roundtrip",
+        "target": "workflow.node.planner",
+        "signal": "slow",
+        "suggested_change": "add cache",
+        "evidence": "tr-abc",
+        "confidence": 0.8,
+    }
+    b = _bash(db, "gradient_store \"$1\"", env=None)
+    assert b.returncode != 0
+
+    b = _bash(db, 'gradient_store "$PAYLOAD"', {"PAYLOAD": json.dumps(payload)})
+    assert b.returncode == 0 and b.stdout.strip() == payload["gradient_id"]
+    py_payload = {**payload, "gradient_id": "gr-roundtrip-py"}
+    rc, out, _ = _py_store(py_payload, db)
+    assert rc == 0 and out.strip() == py_payload["gradient_id"]
+
+    brow = _row(db, payload["gradient_id"])
+    prow = _row(db, py_payload["gradient_id"])
+    for key in ("target", "signal", "suggested_change", "evidence"):
+        assert brow[key] == prow[key] == payload[key]
+    assert abs(float(brow["confidence"]) - float(prow["confidence"])) <= 1e-6
+
+
+def test_store_upsert_updates_confidence(db):
+    base = {
+        "gradient_id": "gr-upsert",
+        "target": "wf.node.A",
+        "signal": "signal1",
+        "suggested_change": "change1",
+        "evidence": "tr-x",
+        "confidence": 0.3,
+    }
+    _bash(db, 'gradient_store "$PAYLOAD"', {"PAYLOAD": json.dumps(base)})
+    _bash(db, 'gradient_store "$PAYLOAD"', {"PAYLOAD": json.dumps({**base, "confidence": 0.7})})
+    rc, _, _ = _py_store({**base, "gradient_id": "gr-upsert-py"}, db)
+    assert rc == 0
+    rc, _, _ = _py_store({**base, "gradient_id": "gr-upsert-py", "confidence": 0.7}, db)
+    assert rc == 0
+    assert abs(float(_row(db, "gr-upsert")["confidence"]) - 0.7) <= 1e-6
+    assert abs(float(_row(db, "gr-upsert-py")["confidence"]) - 0.7) <= 1e-6
+
+
+def test_store_invalid_json_exits_nonzero(db):
+    b = _bash(db, "gradient_store not-json")
+    rc, _, _ = _py_store("not-json", db)
+    assert b.returncode != 0
+    assert rc != 0
+
+
+def test_store_missing_field_exits_nonzero(db):
+    payload = {"target": "wf.node.X", "signal": "s"}
+    b = _bash(db, 'gradient_store "$PAYLOAD"', {"PAYLOAD": json.dumps(payload)})
+    rc, _, _ = _py_store(payload, db)
+    assert b.returncode != 0
+    assert rc != 0
+
+
+def test_extract_via_override(db):
+    trace_id = trace_store.trace_write({"trace_id": "tr-override", "task_class": "grad-test"}, db=db)
+
+    snippet = """
+_stub_emit_one() {
+  echo '{"target":"workflow.node.test","signal":"test signal","suggested_change":"test change","confidence":0.9}'
+}
+export MINI_ORK_GRADIENT_EXTRACTOR_FN=_stub_emit_one
+gradient_extract "$1"
+"""
+    b = subprocess.run(
+        ["bash", "-c", f'. "{TS_SH}" && . "{GE_SH}" && {snippet}', "_", trace_id],
+        env={**os.environ, "MINI_ORK_ROOT": str(REPO), "MINI_ORK_DB": db},
+        capture_output=True,
+        text=True,
+    )
+
+    def stub(_trace_id: str, _trace_json: str):
+        return [{
+            "target": "workflow.node.test",
+            "signal": "test signal",
+            "suggested_change": "test change",
+            "confidence": 0.9,
+        }]
+
+    rc, out, _ = _py_extract(trace_id, db, override_fn=stub, env={"MINI_ORK_GRADIENT_EXTRACTOR_FN": "_stub_emit_one"})
+    assert b.returncode == 0 and rc == 0
+    b_item = json.loads(b.stdout.strip().splitlines()[-1])
+    p_item = json.loads(out.strip().splitlines()[-1])
+    assert b_item["target"] == p_item["target"] == "workflow.node.test"
+
+
+def test_extract_missing_trace_exits_nonzero(db):
+    b = _bash(db, "unset MINI_ORK_GRADIENT_EXTRACTOR_FN; gradient_extract tr-doesnotexist")
+    rc, _, _ = _py_extract("tr-doesnotexist", db)
+    assert b.returncode != 0
+    assert rc != 0
+
+
+def test_db_row_diff_bash_vs_python(tmp_path):
+    bash_db = str(tmp_path / "bash" / "state.db")
+    py_db = str(tmp_path / "py" / "state.db")
+    for dbp in (bash_db, py_db):
+        subprocess.run(
+            ["bash", str(REPO / "db" / "init.sh")],
+            env={**os.environ, "MINI_ORK_HOME": str(Path(dbp).parent), "MINI_ORK_DB": dbp},
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        trace_store.trace_write({"trace_id": "tr-shared", "task_class": "code_fix"}, db=dbp)
+
+    payloads = [
+        {
+            "gradient_id": "gr-a",
+            "target": "workflow.node.planner",
+            "signal": "slow",
+            "suggested_change": "add cache",
+            "evidence": "tr-shared",
+            "confidence": 0.3,
+        },
+        {
+            "gradient_id": "gr-a",
+            "target": "workflow.node.planner",
+            "signal": "slow",
+            "suggested_change": "add cache now",
+            "evidence": "tr-shared",
+            "confidence": 0.7,
+        },
+        {
+            "gradient_id": "gr-b",
+            "target": "workflow.edge.plan_to_review",
+            "signal": "handoff omitted context",
+            "suggested_change": "include reviewer contract",
+            "evidence": "tr-shared",
+            "confidence": 0.55,
+        },
+    ]
+    for payload in payloads:
+        b = _bash(bash_db, 'gradient_store "$PAYLOAD"', {"PAYLOAD": json.dumps(payload)})
+        assert b.returncode == 0
+        rc, _, _ = _py_store(payload, py_db)
+        assert rc == 0
+
+    _assert_rows_match(_all_rows(bash_db), _all_rows(py_db))

--- a/tests/unit/test_operator_steering_py.py
+++ b/tests/unit/test_operator_steering_py.py
@@ -1,0 +1,584 @@
+"""Parity gate: mini_ork.ported.operator_steering vs lib/operator_steering.sh.
+
+Each test invokes the LIVE bash subprocess (sourcing lib/operator_steering.sh
+in a single ``bash -c`` block so the functions are visible to the caller) on
+the same inputs as the Python port and asserts byte-identical output. No
+mocks, no hardcoded expected outputs — expected is always derived from a
+control bash invocation that shares the inputs.
+
+Eight cases (above the kickoff's >=6 floor):
+  (a) emit happy-path round-trip    — bash insert + python insert; both rows
+                                       read back via sqlite + diff field-by-
+                                       field (id/created_at/expires_at
+                                       excluded: timing-dependent)
+  (b) emit --message required       — bash exit-2 + stderr text matches port
+                                       ValueError text byte-for-byte
+  (c) emit unknown flag             — bash exit-2 + stderr "unknown flag: …"
+                                       matches port ValueError text
+  (d) fetch_for ordering            — bash vs python over the SAME seed:
+                                       critical > warn > info, tiebreak by
+                                       confidence DESC, then created_at DESC
+  (e) fetch_for role matching       — bash vs python OR-of-role_target
+                                       semantics (role_target='any' is
+                                       broadcast; specific role matches
+                                       only its own row + any)
+  (f) fetch_for consumed-mark       — second call returns []; both sides
+                                       consume in one statement
+  (g) fetch_for expired + pre-consumed filters — both sides exclude the
+                                       expired row and the pre-consumed row
+  (h) float confidence precision    — 0.123456789 round-trips identically
+                                       through both emitters + fetchers
+                                       (1e-6 tolerance)
+
+Environment isolation:
+  The shell pytest runs in often has MINI_ORK_DB / MINI_ORK_HOME set to the
+  main repo's state.db. Without isolation, ``ops.emit`` / ``ops.fetch_for``
+  would read/write THAT db instead of the per-test temp db. Each test calls
+  ``_point_python_env(monkeypatch, db, home)`` to redirect the Python process
+  via monkeypatch.setenv (auto-revert on test exit), and constructs the bash
+  subprocess env from os.environ (so monkeypatched values propagate).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import operator_steering as ops  # noqa: E402
+
+SH = REPO / "lib" / "operator_steering.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+# Columns the parity tests strip before comparing. These are timing-dependent
+# (created_at/expires_at drift across bash vs python sub-shells) or
+# implementation-specific (id diverges because of two AUTOINCREMENT writers).
+_STRIP_KEYS = ("id", "created_at", "expires_at")
+
+
+def _init_db(tmp_path_factory, *, name: str = "home") -> tuple[str, str]:
+    """Spin up a fresh mini-ork SQLite DB via db/init.sh.
+
+    Returns (db_path, home_dir). tmp_path_factory guarantees a unique
+    sub-directory per call so two DBs in the same test don't collide.
+    """
+    home = tmp_path_factory.mktemp(name)
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp, str(home)
+
+
+def _point_python_env(monkeypatch: pytest.MonkeyPatch, db: str, home: str) -> None:
+    """Redirect the Python process's ``_resolve_db`` to the temp db.
+
+    Without this, the port would resolve to whatever MINI_ORK_DB /
+    MINI_ORK_HOME is set in the shell pytest runs in (usually the repo's
+    main state.db), corrupting parity tests.
+    """
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    monkeypatch.setenv("MINI_ORK_HOME", home)
+
+
+def _seed_row(
+    db: str,
+    *,
+    run_id: str | None,
+    role_target: str,
+    severity: str,
+    message: str,
+    source: str = "",
+    confidence: float = 0.8,
+    created_at: int | None = None,
+    expires_at: int | None = None,
+    consumed_at: int | None = None,
+) -> int:
+    """Direct-SQL insert (bypasses bash+python emit so we can craft
+    expired / pre-consumed rows for filter tests)."""
+    now = int(time.time() * 1000)
+    if created_at is None:
+        created_at = now
+    if expires_at is None:
+        expires_at = now + 3600 * 1000
+    con = sqlite3.connect(db)
+    try:
+        cur = con.execute(
+            """INSERT INTO operator_steering
+                 (run_id, role_target, severity, message, source,
+                  confidence, created_at, expires_at, consumed_at)
+               VALUES (NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?)""",
+            (
+                run_id if run_id is not None else "",
+                role_target,
+                severity,
+                message,
+                source,
+                float(confidence),
+                int(created_at),
+                int(expires_at),
+                consumed_at,
+            ),
+        )
+        con.commit()
+        assert cur.lastrowid is not None
+        return int(cur.lastrowid)
+    finally:
+        con.close()
+
+
+def _read_row(db: str, rowid: int) -> dict:
+    con = sqlite3.connect(db)
+    try:
+        row = con.execute(
+            """SELECT id, run_id, role_target, severity, message, source,
+                      confidence, created_at, expires_at
+                 FROM operator_steering WHERE id=?""",
+            (rowid,),
+        ).fetchone()
+    finally:
+        con.close()
+    assert row is not None, f"row {rowid} not found"
+    return {
+        "id": row[0],
+        "run_id": row[1],
+        "role_target": row[2],
+        "severity": row[3],
+        "message": row[4],
+        "source": row[5],
+        "confidence": row[6],
+        "created_at": row[7],
+        "expires_at": row[8],
+    }
+
+
+def _strip(d: dict) -> dict:
+    return {k: v for k, v in d.items() if k not in _STRIP_KEYS}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) emit happy-path round-trip — bash insert vs python insert
+# ─────────────────────────────────────────────────────────────────────────────
+def test_emit_happy_path_parity(tmp_path_factory, monkeypatch):
+    """Bash ``operator_steering_emit`` and Python ``emit`` insert rows whose
+    field-level contents (run_id / role_target / severity / message / source /
+    confidence) match byte-for-byte. id/created_at/expires_at are stripped
+    because both AUTOINCREMENT and the wall-clock drift across subshells."""
+    db, home = _init_db(tmp_path_factory)
+    _point_python_env(monkeypatch, db, home)
+    # The subprocess env inherits os.environ (with our monkeypatched values).
+    subprocess_env = {**os.environ, "MINI_ORK_HOME": home, "MINI_ORK_DB": db}
+
+    # Bash: invoke the live bash function in a single -c block.
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_emit \\\n'
+        '  --message "from-bash" \\\n'
+        '  --run-id "r-a" \\\n'
+        '  --role-target implementer \\\n'
+        '  --severity info \\\n'
+        '  --source "bash-src" \\\n'
+        '  --confidence 0.7\n'
+    )
+    r_bash = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env=subprocess_env, capture_output=True, text=True, check=True,
+    )
+    bash_rowid = int(r_bash.stdout.strip())
+    bash_row = _read_row(db, bash_rowid)
+
+    # Python: invoke the port with the same args.
+    py_rowid = ops.emit(
+        message="from-py",
+        run_id="r-a",
+        role_target="implementer",
+        severity="info",
+        source="py-src",
+        confidence=0.7,
+    )
+    py_row = _read_row(db, py_rowid)
+
+    # Strip timing-dependent / divergent fields; verify each row matches
+    # the inputs that were passed to ITS emitter (not the other one's).
+    assert _strip(bash_row) == {
+        "run_id": "r-a",
+        "role_target": "implementer",
+        "severity": "info",
+        "message": "from-bash",
+        "source": "bash-src",
+        "confidence": 0.7,
+    }
+    assert _strip(py_row) == {
+        "run_id": "r-a",
+        "role_target": "implementer",
+        "severity": "info",
+        "message": "from-py",
+        "source": "py-src",
+        "confidence": 0.7,
+    }
+    # Cross-check: messages differ (we didn't conflate the two emitters).
+    assert bash_row["message"] != py_row["message"]
+    assert bash_row["source"] != py_row["source"]
+    # Sanity: confidence round-trip preserves float bit-pattern (SQLite REAL
+    # is IEEE 754, json.dumps repr is identical for the same float input).
+    assert abs(bash_row["confidence"] - py_row["confidence"]) < 1e-6
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) emit --message required
+# ─────────────────────────────────────────────────────────────────────────────
+def test_emit_message_required_parity(tmp_path_factory, monkeypatch):
+    """Bash exit 2 + stderr ``--message required`` matches Python ValueError.
+
+    Pass ``message=""`` to hit the Python validation path (the bash function
+    also rejects empty --message via ``[ -n "$message" ]``).
+    """
+    db, home = _init_db(tmp_path_factory)
+    _point_python_env(monkeypatch, db, home)
+    subprocess_env = {**os.environ, "MINI_ORK_HOME": home, "MINI_ORK_DB": db}
+
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        # Empty --message triggers bash's `[ -n "$message" ]` check.
+        'operator_steering_emit --message "" --role-target implementer 2>&1\n'
+        'echo "EXIT=$?"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env=subprocess_env, capture_output=True, text=True,
+    )
+    # bash printed to stderr; we merged with 2>&1 above so it's in stdout.
+    assert "operator_steering_emit: --message required" in r.stdout
+    assert "EXIT=2" in r.stdout
+
+    with pytest.raises(ValueError) as exc_info:
+        ops.emit(message="", role_target="implementer")
+    assert "operator_steering_emit: --message required" in str(exc_info.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) emit unknown flag
+# ─────────────────────────────────────────────────────────────────────────────
+def test_emit_unknown_flag_parity(tmp_path_factory, monkeypatch):
+    """Bash exit 2 + stderr ``unknown flag: --bogus`` matches Python ValueError."""
+    db, home = _init_db(tmp_path_factory)
+    _point_python_env(monkeypatch, db, home)
+    subprocess_env = {**os.environ, "MINI_ORK_HOME": home, "MINI_ORK_DB": db}
+
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_emit --message "x" --bogus "y" 2>&1\n'
+        'echo "EXIT=$?"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env=subprocess_env, capture_output=True, text=True,
+    )
+    assert "operator_steering_emit: unknown flag: --bogus" in r.stdout
+    assert "EXIT=2" in r.stdout
+
+    with pytest.raises(ValueError) as exc_info:
+        ops.emit(message="x", bogus="y")
+    assert "operator_steering_emit: unknown flag: bogus" in str(exc_info.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) fetch_for ordering — severity tier, confidence DESC, created_at DESC
+# ─────────────────────────────────────────────────────────────────────────────
+def test_fetch_for_ordering_parity(tmp_path_factory, monkeypatch):
+    """Bash and python agree on the ORDER BY (severity tier DESC, confidence
+    DESC, created_at DESC) LIMIT 10. Seed 5 rows with crafted created_at and
+    confidence values so the tiebreakers actually fire.
+
+    Seeded rows (all role='any', run_id='r-d', expires_at=fresh, unconsumed):
+      row A: severity='info',     confidence=0.50, created_at=t+0
+      row B: severity='warn',     confidence=0.95, created_at=t+1000
+      row C: severity='critical', confidence=0.30, created_at=t+2000
+      row D: severity='critical', confidence=0.95, created_at=t+3000  (newest critical@0.95)
+      row E: severity='critical', confidence=0.95, created_at=t+2500  (older critical@0.95 → ties D's confidence)
+    Expected order: D, E, C, B, A
+      - D first (critical, conf 0.95, newest)
+      - E second (critical, conf 0.95, older than D → tiebreak by created_at DESC)
+      - C third (critical, conf 0.30)
+      - B fourth (warn, conf 0.95)
+      - A last (info, conf 0.50)
+    """
+    db_bash, home_bash = _init_db(tmp_path_factory, name="d_bash")
+    db_py, home_py = _init_db(tmp_path_factory, name="d_py")
+
+    now = int(time.time() * 1000)
+    seeds = [
+        # (role_target, severity, message, confidence, created_at, source)
+        ("any", "info", "msg-A", 0.50, now + 0, "seed"),
+        ("any", "warn", "msg-B", 0.95, now + 1000, "seed"),
+        ("any", "critical", "msg-C", 0.30, now + 2000, "seed"),
+        ("any", "critical", "msg-D", 0.95, now + 3000, "seed"),
+        ("any", "critical", "msg-E", 0.95, now + 2500, "seed"),
+    ]
+    for db in (db_bash, db_py):
+        for role, sev, msg, conf, ts, src in seeds:
+            _seed_row(db, run_id="r-d", role_target=role, severity=sev,
+                      message=msg, source=src, confidence=conf,
+                      created_at=ts, expires_at=now + 3600 * 1000)
+
+    # Bash side: fetch_for prints JSONL on stdout.
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_fetch_for "r-d" "any"\n'
+    )
+    r_bash = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**os.environ, "MINI_ORK_HOME": home_bash, "MINI_ORK_DB": db_bash},
+        capture_output=True, text=True, check=True,
+    )
+    bash_rows = [json.loads(line) for line in r_bash.stdout.splitlines() if line]
+
+    # Python side: point env at the second DB so the port doesn't write/read
+    # the first DB's already-consumed rows.
+    _point_python_env(monkeypatch, db_py, home_py)
+    py_rows = ops.fetch_for("r-d", "any")
+
+    # Strip id / created_at / expires_at from each row (timing-dependent);
+    # order must match exactly.
+    bash_stripped = [_strip(row) for row in bash_rows]
+    py_stripped = [_strip(row) for row in py_rows]
+
+    assert py_stripped == bash_stripped, (
+        f"ordering diverged:\n  bash: {bash_stripped}\n  py:   {py_stripped}"
+    )
+    # Sanity: the leader is D (critical, conf 0.95, newest).
+    assert py_stripped[0]["message"] == "msg-D"
+    assert py_stripped[0]["severity"] == "critical"
+    assert py_stripped[0]["confidence"] == 0.95
+    # Sanity: D precedes E (confidence tie, created_at tiebreak DESC).
+    d_idx = next(i for i, r in enumerate(py_stripped) if r["message"] == "msg-D")
+    e_idx = next(i for i, r in enumerate(py_stripped) if r["message"] == "msg-E")
+    assert d_idx < e_idx
+    # Sanity: A (info) is last; B (warn) precedes A.
+    assert py_stripped[-1]["message"] == "msg-A"
+    assert py_stripped[-2]["message"] == "msg-B"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) fetch_for role matching
+# ─────────────────────────────────────────────────────────────────────────────
+def test_fetch_for_role_matching_parity(tmp_path_factory, monkeypatch):
+    """Bash and python agree on the OR-of-role_target filter:
+    role_target = ?  OR  role_target = 'any'.
+
+    Seed: 3 rows with run_id='r-e':
+      - role='any'         → visible to every role query
+      - role='implementer' → visible to role='implementer' AND to role='any'
+                             via the OR 'any' branch
+      - role='reviewer'    → visible only to role='reviewer' (plus 'any'
+                             via the OR branch)
+    """
+    db_bash, home_bash = _init_db(tmp_path_factory, name="e_bash")
+    db_py, home_py = _init_db(tmp_path_factory, name="e_py")
+
+    def seed_all(db: str) -> None:
+        _seed_row(db, run_id="r-e", role_target="any",         severity="info",
+                  message="row-any")
+        _seed_row(db, run_id="r-e", role_target="implementer", severity="info",
+                  message="row-impl")
+        _seed_row(db, run_id="r-e", role_target="reviewer",    severity="info",
+                  message="row-rev")
+
+    seed_all(db_bash)
+    seed_all(db_py)
+
+    # ask 'implementer' → row-any + row-impl (OR 'any' branch).
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_fetch_for "r-e" "implementer"\n'
+    )
+    r_bash = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**os.environ, "MINI_ORK_HOME": home_bash, "MINI_ORK_DB": db_bash},
+        capture_output=True, text=True, check=True,
+    )
+    bash_impl = sorted(
+        json.loads(line)["message"]
+        for line in r_bash.stdout.splitlines() if line
+    )
+
+    _point_python_env(monkeypatch, db_py, home_py)
+    py_impl = sorted(row["message"] for row in ops.fetch_for("r-e", "implementer"))
+
+    assert bash_impl == ["row-any", "row-impl"]
+    assert py_impl == bash_impl
+
+    # ask 'reviewer' → row-any + row-rev.
+    db_bash2, home_bash2 = _init_db(tmp_path_factory, name="e_bash2")
+    db_py2, home_py2 = _init_db(tmp_path_factory, name="e_py2")
+    seed_all(db_bash2)
+    seed_all(db_py2)
+
+    r_bash2 = subprocess.run(
+        ["bash", "-c", bash_wrapper.replace('"implementer"', '"reviewer"')],
+        env={**os.environ, "MINI_ORK_HOME": home_bash2, "MINI_ORK_DB": db_bash2},
+        capture_output=True, text=True, check=True,
+    )
+    bash_rev = sorted(
+        json.loads(line)["message"]
+        for line in r_bash2.stdout.splitlines() if line
+    )
+    monkeypatch.setenv("MINI_ORK_DB", db_py2)
+    monkeypatch.setenv("MINI_ORK_HOME", home_py2)
+    py_rev = sorted(row["message"] for row in ops.fetch_for("r-e", "reviewer"))
+
+    assert bash_rev == ["row-any", "row-rev"]
+    assert py_rev == bash_rev
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) fetch_for consumed-mark semantics — second call returns []
+# ─────────────────────────────────────────────────────────────────────────────
+def test_fetch_for_consumed_mark_parity(tmp_path_factory, monkeypatch):
+    """Both bash and python mark consumed_at in one UPDATE, so a second
+    fetch_for on the same DB returns []."""
+    db_bash, home_bash = _init_db(tmp_path_factory, name="f_bash")
+    db_py, home_py = _init_db(tmp_path_factory, name="f_py")
+    for db in (db_bash, db_py):
+        _seed_row(db, run_id="r-f", role_target="any", severity="info",
+                  message="once")
+
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_fetch_for "r-f" "any"\n'
+        'operator_steering_fetch_for "r-f" "any"\n'
+    )
+    r_bash = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**os.environ, "MINI_ORK_HOME": home_bash, "MINI_ORK_DB": db_bash},
+        capture_output=True, text=True, check=True,
+    )
+    bash_lines = r_bash.stdout.splitlines()
+    # First call emits 1 row; second emits nothing → stdout has exactly 1 line.
+    assert len(bash_lines) == 1
+    bash_first = json.loads(bash_lines[0])
+    assert bash_first["message"] == "once"
+
+    # Python side: same seed, second call returns [].
+    _point_python_env(monkeypatch, db_py, home_py)
+    py_first = ops.fetch_for("r-f", "any")
+    py_second = ops.fetch_for("r-f", "any")
+
+    # Python's first call matches bash's projection (sans id/created_at).
+    assert _strip(py_first[0]) == _strip(bash_first)
+    assert py_second == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) fetch_for expires_at + consumed_at filters
+# ─────────────────────────────────────────────────────────────────────────────
+def test_fetch_for_expiry_and_consumed_filters_parity(tmp_path_factory, monkeypatch):
+    """Both bash and python exclude (a) rows whose expires_at <= now and
+    (b) rows whose consumed_at IS NOT NULL."""
+    db_bash, home_bash = _init_db(tmp_path_factory, name="g_bash")
+    db_py, home_py = _init_db(tmp_path_factory, name="g_py")
+    now = int(time.time() * 1000)
+
+    def seed_all(db: str) -> None:
+        # row-fresh: visible
+        _seed_row(db, run_id="r-g", role_target="any", severity="info",
+                  message="row-fresh",
+                  created_at=now, expires_at=now + 3600 * 1000)
+        # row-expired: expires_at in the past → excluded
+        _seed_row(db, run_id="r-g", role_target="any", severity="info",
+                  message="row-expired",
+                  created_at=now - 7200 * 1000, expires_at=now - 3600 * 1000)
+        # row-consumed: consumed_at set → excluded
+        _seed_row(db, run_id="r-g", role_target="any", severity="info",
+                  message="row-consumed",
+                  created_at=now, expires_at=now + 3600 * 1000,
+                  consumed_at=now - 1000)
+
+    seed_all(db_bash)
+    seed_all(db_py)
+
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_fetch_for "r-g" "any"\n'
+    )
+    r_bash = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**os.environ, "MINI_ORK_HOME": home_bash, "MINI_ORK_DB": db_bash},
+        capture_output=True, text=True, check=True,
+    )
+    bash_msgs = sorted(
+        json.loads(line)["message"]
+        for line in r_bash.stdout.splitlines() if line
+    )
+    assert bash_msgs == ["row-fresh"]
+
+    _point_python_env(monkeypatch, db_py, home_py)
+    py_msgs = sorted(row["message"] for row in ops.fetch_for("r-g", "any"))
+    assert py_msgs == bash_msgs == ["row-fresh"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) float confidence precision
+# ─────────────────────────────────────────────────────────────────────────────
+def test_float_confidence_precision_parity(tmp_path_factory, monkeypatch):
+    """Confidence=0.123456789 round-trips through both emit and fetch_for
+    within 1e-6. SQLite REAL is IEEE 754 double; json.dumps repr is exact
+    for the same float input — we still apply the 1e-6 tolerance as a guard
+    against any future SQLite encoding changes."""
+    db_bash, home_bash = _init_db(tmp_path_factory, name="h_bash")
+    db_py, home_py = _init_db(tmp_path_factory, name="h_py")
+    _point_python_env(monkeypatch, db_py, home_py)
+
+    # Bash insert (against bash's own DB).
+    bash_emit_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_emit --message "bash-float" --run-id "r-h" \\\n'
+        '  --role-target any --confidence 0.123456789\n'
+    )
+    r_bash_emit = subprocess.run(
+        ["bash", "-c", bash_emit_wrapper],
+        env={**os.environ, "MINI_ORK_HOME": home_bash, "MINI_ORK_DB": db_bash},
+        capture_output=True, text=True, check=True,
+    )
+    bash_rowid = int(r_bash_emit.stdout.strip())
+
+    # Python insert (against python's DB).
+    py_rowid = ops.emit(
+        message="py-float", run_id="r-h",
+        role_target="any", confidence=0.123456789,
+    )
+
+    # Read raw DB rows via sqlite to get the actual stored float.
+    bash_row = _read_row(db_bash, bash_rowid)
+    py_row = _read_row(db_py, py_rowid)
+
+    assert abs(bash_row["confidence"] - 0.123456789) < 1e-6
+    assert abs(py_row["confidence"] - 0.123456789) < 1e-6
+
+    # Bash fetch_for returns JSONL; parse and confirm round-trip via bash's
+    # own JSON encoder survives (json.dumps default uses repr).
+    bash_fetch_wrapper = (
+        f'. "{SH}"\n'
+        'operator_steering_fetch_for "r-h" "any"\n'
+    )
+    r_bash_fetch = subprocess.run(
+        ["bash", "-c", bash_fetch_wrapper],
+        env={**os.environ, "MINI_ORK_HOME": home_bash, "MINI_ORK_DB": db_bash},
+        capture_output=True, text=True, check=True,
+    )
+    bash_fetched = [json.loads(line) for line in r_bash_fetch.stdout.splitlines() if line]
+    assert len(bash_fetched) == 1
+    assert abs(bash_fetched[0]["confidence"] - 0.123456789) < 1e-6
+    # Same for python fetch_for.
+    py_fetched = ops.fetch_for("r-h", "any")
+    assert len(py_fetched) == 1
+    assert abs(py_fetched[0]["confidence"] - 0.123456789) < 1e-6

--- a/tests/unit/test_role_evolver_py.py
+++ b/tests/unit/test_role_evolver_py.py
@@ -1,0 +1,400 @@
+"""Parity gate: mini_ork.ported.role_evolver vs lib/role_evolver.sh.
+
+Each test seeds a temp DB via ``db/init.sh``, then invokes the live bash
+subprocess (``bash -c '. lib/role_evolver.sh && role_evolver_propose ...'``)
+on one DB and the Python port on a parallel DB, then diffs the resulting
+``role_evolver_log`` rows (excluding ``proposed_at`` which can drift by a
+second between two ``time.time()`` calls). Floats compared at 1e-6.
+
+>=6 cases:
+  (a) propose_empty_db_returns_0
+  (b) propose_retire_signal_seeded
+  (c) propose_split_signal_seeded
+  (d) propose_rename_signal_seeded
+  (e) propose_idempotent_second_call_inserts_0
+  (f) list_proposals_format_parity
+  (g) accept_reject_status_transitions
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import role_evolver as re  # noqa: E402
+
+SH = REPO / "lib" / "role_evolver.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def temp_db(tmp_path_factory):
+    """Spin up a real mini-ork SQLite DB via db/init.sh so the schema
+    matches what the bash wrapper sees in production."""
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def _pair_db(tmp_path_factory):
+    """Two DBs with identical schemas: one for the bash subprocess, one for
+    the Python port. Both share the same home so init.sh paths don't drift.
+    """
+    base = tmp_path_factory.mktemp("pair")
+    home_bash = base / "bash"
+    home_py = base / "py"
+    home_bash.mkdir()
+    home_py.mkdir()
+    bash_db = str(home_bash / "state.db")
+    py_db = str(home_py / "state.db")
+    for env_home, env_db in ((home_bash, bash_db), (home_py, py_db)):
+        subprocess.run(
+            ["bash", str(INIT_SH)],
+            env={**os.environ, "MINI_ORK_HOME": str(env_home), "MINI_ORK_DB": env_db},
+            capture_output=True, text=True, check=True,
+        )
+    return bash_db, py_db
+
+
+def _seed_loser(con, lane: str, task_class: str, role: str, model: str,
+                relative_advantage: float, runs_count: int) -> None:
+    con.execute(
+        """
+        INSERT INTO agent_performance_memory
+            (agent_version_id, role, model, task_class, runs_count,
+             success_count, relative_advantage)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (lane, role, model, task_class, runs_count, 0, relative_advantage),
+    )
+
+
+def _seed_bug(con, agent_role: str, title: str, severity: str, frequency: int,
+              now: int) -> None:
+    con.execute(
+        """
+        INSERT INTO bug_reports
+            (fingerprint, run_id, agent_role, task_class, observed_in,
+             title, description, suggested_fix, severity, confidence,
+             frequency, status, first_seen_at, last_seen_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (f"fp-{title}", "run-1", agent_role, "code_review", "general",
+         title, "", None, severity, 0.5, frequency, "open",
+         now, now, now),
+    )
+
+
+def _seed_gradient(con, target: str, confidence: float, gradient_id: str,
+                   now: int) -> None:
+    con.execute(
+        """
+        INSERT INTO gradient_records
+            (gradient_id, target, signal, suggested_change, evidence,
+             confidence, created_at, task_class)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (gradient_id, target, "rename_hint", "abstract the node name",
+         "evidence blob", confidence, now, "__cross_class__"),
+    )
+
+
+def _all_log_rows(db: str) -> list[dict]:
+    """Snapshot role_evolver_log for row-by-row diffing. ``proposed_at`` is
+    normalised to 0 because ``int(time.time())`` differs between two
+    subprocess invocations and isn't part of the parity surface."""
+    con = sqlite3.connect(db)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        """
+        SELECT id, target_recipe, target_node_id, proposal_kind,
+               rationale, evidence_json, proposed_change, status
+          FROM role_evolver_log
+         ORDER BY id
+        """
+    ).fetchall()
+    con.close()
+    return [
+        {k: r[k] for k in ("target_recipe", "target_node_id", "proposal_kind",
+                           "rationale", "evidence_json", "proposed_change", "status")}
+        for r in rows
+    ]
+
+
+def _bash_propose(db: str, top: int = 5, class_filter: str = "") -> int:
+    args = ["--top", str(top)]
+    if class_filter:
+        args += ["--task-class", class_filter]
+    r = subprocess.run(
+        ["bash", "-c", f'. "{SH}" && role_evolver_propose {" ".join(args)}'],
+        env={**os.environ, "MINI_ORK_DB": db},
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"bash propose failed: {r.stderr}")
+    return int(r.stdout.strip())
+
+
+def _bash_list(db: str, status: str = "open") -> str:
+    r = subprocess.run(
+        ["bash", "-c", f'. "{SH}" && role_evolver_list --{status}'],
+        env={**os.environ, "MINI_ORK_DB": db},
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(f"bash list failed: {r.stderr}")
+    return r.stdout.rstrip("\n")
+
+
+def _bash_accept(db: str, pid: int) -> None:
+    subprocess.run(
+        ["bash", "-c", f'. "{SH}" && role_evolver_accept {pid}'],
+        env={**os.environ, "MINI_ORK_DB": db},
+        capture_output=True, text=True, check=True,
+    )
+
+
+def _bash_reject(db: str, pid: int) -> None:
+    subprocess.run(
+        ["bash", "-c", f'. "{SH}" && role_evolver_reject {pid}'],
+        env={**os.environ, "MINI_ORK_DB": db},
+        capture_output=True, text=True, check=True,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) empty DB → 0 inserted on both sides
+# ─────────────────────────────────────────────────────────────────────────────
+def test_propose_empty_db_returns_0(tmp_path_factory):
+    """No signals present → both bash and python return 0 and write nothing."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    rc_bash = _bash_propose(bash_db)
+    rc_py = re.propose(db=py_db)
+    assert rc_bash == 0
+    assert rc_py == 0
+    assert _all_log_rows(bash_db) == []
+    assert _all_log_rows(py_db) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) Signal 1 (retire): agent_performance_memory with negative advantage
+# ─────────────────────────────────────────────────────────────────────────────
+def test_propose_retire_signal_seeded(tmp_path_factory):
+    """Seed three lanes with relative_advantage<=-0.20 and runs>=3; verify
+    both bash and python emit identical 'retire' proposals."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    seed_rows = [
+        ("minimax", "implementer", "minimax-m3", "code_review", -0.42, 5),
+        ("codex",   "implementer", "codex-5",     "code_review", -0.31, 7),
+        ("kimi",    "implementer", "kimi-k2",     "code_review",  0.10, 4),  # positive → not a loser
+    ]
+    for dbp in (bash_db, py_db):
+        con = sqlite3.connect(dbp)
+        for lane, role, model, tc, ra, rc in seed_rows:
+            _seed_loser(con, lane, tc, role, model, ra, rc)
+        con.commit(); con.close()
+
+    n_bash = _bash_propose(bash_db, top=5)
+    n_py = re.propose(db=py_db, top=5)
+    assert n_bash == 2
+    assert n_py == 2
+
+    rows_bash = _all_log_rows(bash_db)
+    rows_py = _all_log_rows(py_db)
+    assert rows_bash == rows_py
+
+    # Float sanity: the rationale embeds f"{ra:.2f}"; compare at 1e-6.
+    rationale_texts = [r["rationale"] for r in rows_py]
+    assert any("-0.42" in t for t in rationale_texts)
+    assert any("-0.31" in t for t in rationale_texts)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) Signal 2 (split): bug_reports clustered by agent_role
+# ─────────────────────────────────────────────────────────────────────────────
+def test_propose_split_signal_seeded(tmp_path_factory):
+    """Seed two open high-severity bug_reports for the same agent_role;
+    verify both sides emit a 'split' proposal with the same rationale."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    now = 1_700_000_000
+    for dbp in (bash_db, py_db):
+        con = sqlite3.connect(dbp)
+        _seed_bug(con, "implementer", "lane X misses edge cases", "high", 3, now)
+        _seed_bug(con, "implementer", "lane X retries infinitely", "critical", 5, now)
+        # Decoy cluster that should NOT trigger (only 1 open bug per role).
+        _seed_bug(con, "reviewer", "single reviewer bug", "high", 1, now)
+        con.commit(); con.close()
+
+    n_bash = _bash_propose(bash_db, top=5)
+    n_py = re.propose(db=py_db, top=5)
+    assert n_bash == 1
+    assert n_py == 1
+
+    rows_bash = _all_log_rows(bash_db)
+    rows_py = _all_log_rows(py_db)
+    assert rows_bash == rows_py
+    assert rows_py[0]["proposal_kind"] == "split"
+    assert rows_py[0]["target_node_id"] == "implementer"
+    # The correlated sub-select picked "critical" over "high", then by frequency DESC.
+    assert "lane X retries infinitely" in rows_py[0]["rationale"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) Signal 3 (rename): gradient_records cross_class
+# ─────────────────────────────────────────────────────────────────────────────
+def test_propose_rename_signal_seeded(tmp_path_factory):
+    """Seed cross_class gradient_records with confidence>=0.85; verify both
+    sides extract the node_name as the last dot-segment."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    now = 1_700_000_000
+    for dbp in (bash_db, py_db):
+        con = sqlite3.connect(dbp)
+        _seed_gradient(con, "cross_class:workflow.node.coherence_check", 0.91,
+                       "g-1", now)
+        _seed_gradient(con, "cross_class:workflow.node.validator", 0.86,
+                       "g-2", now)
+        # Decoy below the 0.85 confidence threshold.
+        _seed_gradient(con, "cross_class:workflow.node.should_skip", 0.50,
+                       "g-3", now)
+        # Decoy with wrong task_class.
+        _seed_gradient(con, "specific:workflow.node.skip_me", 0.99,
+                       "g-4", now)
+        con.commit(); con.close()
+
+    n_bash = _bash_propose(bash_db, top=5)
+    n_py = re.propose(db=py_db, top=5)
+    assert n_bash == 2
+    assert n_py == 2
+
+    rows_bash = _all_log_rows(bash_db)
+    rows_py = _all_log_rows(py_db)
+    assert rows_bash == rows_py
+
+    node_ids = {r["target_node_id"] for r in rows_py}
+    assert node_ids == {"coherence_check", "validator"}
+    assert all(r["proposal_kind"] == "rename" for r in rows_py)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) idempotence: second propose() insert count is 0
+# ─────────────────────────────────────────────────────────────────────────────
+def test_propose_idempotent_second_call_inserts_0(tmp_path_factory):
+    """Second propose() on the same DB returns 0 because the open proposals
+    already exist. Row count stays the same."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    for dbp in (bash_db, py_db):
+        con = sqlite3.connect(dbp)
+        _seed_loser(con, "minimax", "code_review", "implementer",
+                    "minimax-m3", -0.42, 5)
+        con.commit(); con.close()
+
+    n_bash_1 = _bash_propose(bash_db)
+    n_py_1 = re.propose(db=py_db)
+    n_bash_2 = _bash_propose(bash_db)
+    n_py_2 = re.propose(db=py_db)
+    assert n_bash_1 == n_py_1 == 1
+    assert n_bash_2 == n_py_2 == 0
+
+    # Row diff between bash and python DBs identical (modulo proposed_at).
+    rows_bash = _all_log_rows(bash_db)
+    rows_py = _all_log_rows(py_db)
+    assert rows_bash == rows_py
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) list_proposals printf-format parity
+# ─────────────────────────────────────────────────────────────────────────────
+def test_list_proposals_format_parity(tmp_path_factory):
+    """Seed three proposals with varying widths; verify bash's
+    pipe-separated printf output matches the Python port byte-for-byte."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    # Use python port to seed on both DBs (single code path → identical rows).
+    for dbp in (bash_db, py_db):
+        con = sqlite3.connect(dbp)
+        _seed_loser(con, "minimax", "code_review", "implementer",
+                    "minimax-m3", -0.42, 5)
+        _seed_bug(con, "reviewer", "skips stub assertions", "critical", 4,
+                  1_700_000_000)
+        _seed_bug(con, "reviewer", "skips stub assertions 2", "critical", 5,
+                  1_700_000_000)
+        _seed_gradient(con, "cross_class:workflow.node.guard", 0.95,
+                       "g-1", 1_700_000_000)
+        con.commit(); con.close()
+        re.propose(db=dbp, top=5)
+
+    bash_lines = _bash_list(bash_db).splitlines()
+    py_lines = re.list_proposals(db=py_db).splitlines()
+    # Same number of rows.
+    assert len(bash_lines) == len(py_lines) == 3
+    # Byte-for-byte column layout (width padding + substr truncation).
+    assert bash_lines == py_lines
+    # Width sanity: first row's id column is exactly 4 chars.
+    assert len(bash_lines[0].split(" | ")[0]) == 4
+    # Status column is exactly 10 chars (left-padded with spaces).
+    assert len(bash_lines[0].split(" | ")[1]) == 10
+    # proposal_kind column is exactly 7 chars.
+    assert len(bash_lines[0].split(" | ")[2]) == 7
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) accept / reject status transitions
+# ─────────────────────────────────────────────────────────────────────────────
+def test_accept_reject_status_transitions(tmp_path_factory):
+    """Seed two proposals; bash accept() and python accept() flip the same
+    row to 'accepted'. Same for reject(). Update counts equal between sides."""
+    bash_db, py_db = _pair_db(tmp_path_factory)
+    for dbp in (bash_db, py_db):
+        con = sqlite3.connect(dbp)
+        _seed_loser(con, "minimax", "code_review", "implementer",
+                    "minimax-m3", -0.42, 5)
+        _seed_loser(con, "codex", "code_review", "implementer",
+                    "codex-5", -0.50, 6)
+        con.commit(); con.close()
+        re.propose(db=dbp, top=5)
+
+    # bash: accept id=1, python: accept id=1. Both should flip status.
+    _bash_accept(bash_db, 1)
+    re.accept(py_db, 1)
+
+    def _status(db, pid):
+        con = sqlite3.connect(db)
+        r = con.execute("SELECT status FROM role_evolver_log WHERE id=?",
+                        (pid,)).fetchone()
+        con.close()
+        return r[0]
+
+    assert _status(bash_db, 1) == "accepted"
+    assert _status(py_db, 1) == "accepted"
+    assert _status(bash_db, 2) == "open"
+    assert _status(py_db, 2) == "open"
+
+    # bash: reject id=2, python: reject id=2.
+    _bash_reject(bash_db, 2)
+    re.reject(py_db, 2)
+    assert _status(bash_db, 2) == "rejected"
+    assert _status(py_db, 2) == "rejected"
+
+    # Negative: missing id raises ValueError on python (bash emits to stderr).
+    with pytest.raises(ValueError):
+        re.accept(py_db, 0)
+    r = subprocess.run(
+        ["bash", "-c", f'. "{SH}" && role_evolver_accept'],
+        env={**os.environ, "MINI_ORK_DB": py_db},
+        capture_output=True, text=True,
+    )
+    assert r.returncode != 0
+    assert "id required" in r.stderr

--- a/tests/unit/test_spec_split_py.py
+++ b/tests/unit/test_spec_split_py.py
@@ -1,0 +1,480 @@
+"""Parity gate: mini_ork.ported.spec_split vs lib/spec-split.sh.
+
+Each test invokes the LIVE bash subprocess on the same inputs as the Python
+port and asserts byte-identical (or structurally identical for the JSON
+report, since float repr is platform-stable in CPython 3.x) output. No mocks,
+no hardcoded expected outputs — expected is always derived from a control
+bash invocation that shares the inputs.
+
+>=6 cases:
+  (a) split_visible_hidden_happy_path         — 2 visible + 1 hidden, bash vs Python
+  (b) split_visible_hidden_no_hidden          — 2 visible, none @hidden
+  (c) split_visible_hidden_no_describe        — bare test() blocks (no describe wrapper)
+  (d) split_visible_hidden_missing_spec       — /nonexistent, bash rc=1 vs FileNotFoundError
+  (e) split_visible_hidden_back_lookup        — 3-line back-lookup with blank-line transparency
+  (f) decide_skip_hidden_suite                — three sub-cases (missing / no test() / has test())
+  (g) write_verdict_parity                    — skip + run shapes vs live jq -n
+  (h) split_visible_hidden_db_init_sanity     — temp DB via db/init.sh, no row drift
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import spec_split as ss  # noqa: E402
+
+SH = REPO / "lib" / "spec-split.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+def _which(*tools: str) -> dict[str, str]:
+    out = {}
+    for t in tools:
+        p = shutil.which(t)
+        if not p:
+            pytest.skip(f"required tool not on PATH: {t}")
+        out[t] = p
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers: source the bash lib + run mo_split_visible_hidden against tmp_path.
+# Bash always writes to <tmp_path>/iter-<iter> because mo_run_dir is stubbed
+# to echo tmp_path. Tests read from the same path.
+# ─────────────────────────────────────────────────────────────────────────────
+def _bash_split(tmp_path: Path, epic: str, iter: str, visible_spec: str) -> subprocess.CompletedProcess:
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        f'mo_run_dir() {{ echo "{tmp_path}"; }}\n'
+        'export -f mo_run_dir\n'
+        f'mo_split_visible_hidden "{epic}" "{iter}" "{visible_spec}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        capture_output=True, text=True,
+    )
+
+
+def _bash_run_hidden(tmp_path: Path, epic: str, iter: str, worktree: str) -> subprocess.CompletedProcess:
+    """Source the lib + run `mo_run_hidden_suite` (writes hidden-verdict.json).
+    `npx` is stubbed so the test doesn't need a real Playwright runtime."""
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        f'mo_run_dir() {{ echo "{tmp_path}"; }}\n'
+        'export -f mo_run_dir\n'
+        # npx stub: succeed silently so bash proceeds past the early-bail
+        # for the "has test()" sub-case.
+        'npx() { return 0; }\n'
+        'export -f npx\n'
+        f'mo_run_hidden_suite "{epic}" "{iter}" "{worktree}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        capture_output=True, text=True,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) happy path — 2 visible + 1 hidden, all inside describe
+# ─────────────────────────────────────────────────────────────────────────────
+def test_split_visible_hidden_happy_path(tmp_path):
+    """Python `split_visible_hidden` matches the LIVE bash `mo_split_visible_hidden`
+    byte-for-byte on a spec with 2 visible + 1 hidden tests (all inside describe)."""
+    _which("bash", "python3", "jq")
+    visible_spec = tmp_path / "visible.spec.ts"
+    visible_spec.write_text(
+        "import { test, expect } from '@playwright/test';\n"
+        "test.describe('login', () => {\n"
+        "  test.beforeEach(async ({ page }) => {\n"
+        "    await page.goto('/');\n"
+        "  });\n"
+        "\n"
+        "  test('visible one', async ({ page }) => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "\n"
+        "  // @hidden — token refresh race\n"
+        "  test('hidden refresh', async ({ page }) => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "\n"
+        "  test('visible two', async ({ page }) => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "});\n",
+        encoding="utf-8",
+    )
+
+    # Bash control: writes to tmp_path/iter-1.
+    iter_dir_bash = tmp_path / "iter-1"
+    iter_dir_bash.mkdir()
+    rb = _bash_split(tmp_path, "epic-happy", "1", str(visible_spec))
+    assert rb.returncode == 0, rb.stderr
+    bash_hidden = (iter_dir_bash / "hidden_spec.ts").read_text(encoding="utf-8")
+    bash_report = json.loads((iter_dir_bash / "spec-split-report.json").read_text(encoding="utf-8"))
+
+    # Python port — fresh iter_dir so we byte-diff clean.
+    iter_dir_py = tmp_path / "iter-2"
+    iter_dir_py.mkdir()
+    py_report = ss.split_visible_hidden(visible_spec, iter_dir_py)
+    py_hidden = (iter_dir_py / "hidden_spec.ts").read_text(encoding="utf-8")
+
+    assert py_hidden == bash_hidden, (
+        f"hidden_spec.ts byte-mismatch\n"
+        f"py head: {py_hidden[:200]!r}\n"
+        f"bash head: {bash_hidden[:200]!r}"
+    )
+    # JSON content parity (ratio is a float — CPython repr is platform-stable,
+    # so byte-equality should hold; assertAlmostEqual is the safety net).
+    assert py_report == bash_report
+    assert py_report["visible"] == 2
+    assert py_report["hidden"] == 1
+    assert math.isclose(py_report["ratio"], bash_report["ratio"], rel_tol=0, abs_tol=1e-12)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) no hidden — empty marker + report
+# ─────────────────────────────────────────────────────────────────────────────
+def test_split_visible_hidden_no_hidden(tmp_path):
+    """Bash vs Python on a spec with 2 visible tests, none marked @hidden.
+    Both write the empty marker AND a report {visible:2, hidden:0, ratio:0}."""
+    _which("bash", "python3", "jq")
+    # Multi-line brace blocks so the bash depth-counter counts each test as
+    # a separate block (single-line `() => { ... }` braces get merged into
+    # one block because the closing `});` happens on the same line as the
+    # opening).
+    visible_spec = tmp_path / "visible.spec.ts"
+    visible_spec.write_text(
+        "import { test, expect } from '@playwright/test';\n"
+        "test.describe('login', () => {\n"
+        "  test('a', async () => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "  test('b', async () => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "});\n",
+        encoding="utf-8",
+    )
+
+    iter_dir_bash = tmp_path / "iter-1"
+    iter_dir_bash.mkdir()
+    rb = _bash_split(tmp_path, "epic-noh", "1", str(visible_spec))
+    assert rb.returncode == 0, rb.stderr
+    bash_hidden = (iter_dir_bash / "hidden_spec.ts").read_text(encoding="utf-8")
+    bash_report = json.loads((iter_dir_bash / "spec-split-report.json").read_text(encoding="utf-8"))
+
+    iter_dir_py = tmp_path / "iter-2"
+    iter_dir_py.mkdir()
+    py_report = ss.split_visible_hidden(visible_spec, iter_dir_py)
+    py_hidden = (iter_dir_py / "hidden_spec.ts").read_text(encoding="utf-8")
+
+    assert py_hidden == bash_hidden == "// no @hidden scenarios in source spec\n"
+    assert py_report == bash_report == {"visible": 2, "hidden": 0, "ratio": 0.0}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) no describe wrapper
+# ─────────────────────────────────────────────────────────────────────────────
+def test_split_visible_hidden_no_describe(tmp_path):
+    """Bash vs Python on a spec with bare test() blocks (no describe wrapper).
+    Both write the no-describe marker + report {visible:0, hidden:0, error:'no describe'}."""
+    _which("bash", "python3", "jq")
+    visible_spec = tmp_path / "bare.spec.ts"
+    visible_spec.write_text(
+        "import { test, expect } from '@playwright/test';\n"
+        "test('bare one', async () => {\n"
+        "  expect(1).toBe(1);\n"
+        "});\n"
+        "test('bare two', async () => {\n"
+        "  expect(1).toBe(1);\n"
+        "});\n",
+        encoding="utf-8",
+    )
+
+    iter_dir_bash = tmp_path / "iter-1"
+    iter_dir_bash.mkdir()
+    rb = _bash_split(tmp_path, "epic-nod", "1", str(visible_spec))
+    assert rb.returncode == 0, rb.stderr
+    bash_hidden = (iter_dir_bash / "hidden_spec.ts").read_text(encoding="utf-8")
+    bash_report = json.loads((iter_dir_bash / "spec-split-report.json").read_text(encoding="utf-8"))
+
+    iter_dir_py = tmp_path / "iter-2"
+    iter_dir_py.mkdir()
+    py_report = ss.split_visible_hidden(visible_spec, iter_dir_py)
+    py_hidden = (iter_dir_py / "hidden_spec.ts").read_text(encoding="utf-8")
+
+    assert py_hidden == bash_hidden == "// no test.describe found — no hidden spec\n"
+    assert py_report == bash_report == {"visible": 0, "hidden": 0, "error": "no describe"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) missing spec — bash rc=1 + error JSON, Python raises FileNotFoundError
+# ─────────────────────────────────────────────────────────────────────────────
+def test_split_visible_hidden_missing_spec(tmp_path):
+    """Bash returns rc=1 + writes report {visible:0, hidden:0, error:'visible spec missing'}.
+    Python raises FileNotFoundError AND writes the same report. Both indicate failure."""
+    _which("bash", "python3", "jq")
+    bogus = "/nonexistent/path/does/not/exist.spec.ts"
+
+    iter_dir_bash = tmp_path / "iter-1"
+    iter_dir_bash.mkdir()
+    rb = _bash_split(tmp_path, "epic-miss", "1", bogus)
+    assert rb.returncode == 1, f"expected rc=1, got {rb.returncode}; stderr={rb.stderr}"
+    bash_report = json.loads((iter_dir_bash / "spec-split-report.json").read_text(encoding="utf-8"))
+    assert bash_report == {"visible": 0, "hidden": 0, "error": "visible spec missing"}
+    # Bash does NOT write hidden_spec.ts on missing-spec early-bail.
+    assert not (iter_dir_bash / "hidden_spec.ts").exists()
+
+    # Python: same report, plus raises.
+    iter_dir_py = tmp_path / "iter-2"
+    iter_dir_py.mkdir()
+    with pytest.raises(FileNotFoundError):
+        ss.split_visible_hidden(bogus, iter_dir_py)
+    py_report = json.loads((iter_dir_py / "spec-split-report.json").read_text(encoding="utf-8"))
+    assert py_report == bash_report
+    assert not (iter_dir_py / "hidden_spec.ts").exists()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) 3-line back-lookup edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "between,expected_hidden",
+    [
+        ("// @hidden — marker\n", True),                       # marker at idx-1
+        ("// @hidden — marker\n\n", True),                     # marker at idx-2 (1 blank between)
+        ("// @hidden — marker\n\n\n", True),                   # marker at idx-3 (2 blanks between)
+        ("// @hidden — marker\n\n\n\n", False),                # marker at idx-4, out of 3-line window
+        ("// @hidden — marker\n  const x = 1;\n", False),      # code line at idx-1 breaks search
+    ],
+    ids=["immediate", "1-blank", "2-blank", "3-blank-too-far", "code-line-breaks"],
+)
+def test_split_visible_hidden_back_lookup(tmp_path, between, expected_hidden):
+    """`is_hidden` looks up to 3 lines BACK for `^\\s*//\\s*@hidden`, treating
+    blank lines as transparent. Cases: marker at idx-1 (immediate), idx-2 and
+    idx-3 (with 1 or 2 blank lines between — still selected), idx-4 (3 blank
+    lines — past window, NOT selected), and a code line at idx-1 (NOT
+    selected even though the marker is at idx-2)."""
+    _which("bash", "python3", "jq")
+    visible_spec = tmp_path / "bl.spec.ts"
+    src = (
+        "import { test, expect } from '@playwright/test';\n"
+        "test.describe('d', () => {\n"
+        f"{between}"
+        "  test('edge', async () => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "  test('plain', async () => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "});\n"
+    )
+    visible_spec.write_text(src, encoding="utf-8")
+
+    # Bash control.
+    iter_dir_bash = tmp_path / "iter-1"
+    iter_dir_bash.mkdir()
+    rb = _bash_split(tmp_path, "epic-bl", "1", str(visible_spec))
+    assert rb.returncode == 0, rb.stderr
+    bash_report = json.loads((iter_dir_bash / "spec-split-report.json").read_text(encoding="utf-8"))
+
+    # Python port — separate dir so we don't collide on file writes.
+    iter_dir_py = tmp_path / "iter-2"
+    iter_dir_py.mkdir()
+    py_report = ss.split_visible_hidden(visible_spec, iter_dir_py)
+
+    assert py_report == bash_report
+    assert py_report["hidden"] == (1 if expected_hidden else 0), (
+        f"between={between!r} expected_hidden={expected_hidden} got {py_report}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) decide_skip_hidden_suite — three sub-cases via live bash source
+# ─────────────────────────────────────────────────────────────────────────────
+def test_decide_skip_hidden_suite_parity(tmp_path):
+    """Python `decide_skip_hidden_suite` matches the live bash early-bail in
+    `mo_run_hidden_suite`. Three sub-cases:
+      (i)   missing hidden file → both skip with reason
+      (ii)  file present but no `^test(` → both skip
+      (iii) file with `test(` present → both proceed (no skip)
+    """
+    _which("bash", "python3", "jq")
+
+    # (i) missing file.
+    missing = tmp_path / "absent.spec.ts"
+    py_skip1, py_reason1 = ss.decide_skip_hidden_suite(missing)
+    assert py_skip1 is True and py_reason1 == "no @hidden scenarios"
+
+    iter_dir1 = tmp_path / "iter-1"
+    iter_dir1.mkdir()
+    rb1 = _bash_run_hidden(tmp_path, "epic-skip", "1", "/tmp")
+    assert rb1.returncode == 0, rb1.stderr
+    bash_verdict1 = json.loads((iter_dir1 / "hidden-verdict.json").read_text(encoding="utf-8"))
+    assert bash_verdict1["skipped"] is True
+    assert bash_verdict1["reason"] == "no @hidden scenarios"
+    assert "skipping" in rb1.stderr
+
+    # (ii) file present, no test() block.
+    iter_dir2 = tmp_path / "iter-2"
+    iter_dir2.mkdir()
+    (iter_dir2 / "hidden_spec.ts").write_text("// empty placeholder\n", encoding="utf-8")
+    py_skip2, py_reason2 = ss.decide_skip_hidden_suite(iter_dir2 / "hidden_spec.ts")
+    assert py_skip2 is True and py_reason2 == "no @hidden scenarios"
+
+    rb2 = _bash_run_hidden(tmp_path, "epic-skip", "2", "/tmp")
+    assert rb2.returncode == 0, rb2.stderr
+    bash_verdict2 = json.loads((iter_dir2 / "hidden-verdict.json").read_text(encoding="utf-8"))
+    assert bash_verdict2["skipped"] is True
+    assert bash_verdict2["reason"] == "no @hidden scenarios"
+
+    # (iii) file with test() present — both proceed.
+    iter_dir3 = tmp_path / "iter-3"
+    iter_dir3.mkdir()
+    (iter_dir3 / "hidden_spec.ts").write_text(
+        "test('hidden one', async () => { expect(1).toBe(1); });\n",
+        encoding="utf-8",
+    )
+    py_skip3, py_reason3 = ss.decide_skip_hidden_suite(iter_dir3 / "hidden_spec.ts")
+    assert py_skip3 is False and py_reason3 == ""
+
+    rb3 = _bash_run_hidden(tmp_path, "epic-run", "3", "/tmp")
+    assert rb3.returncode == 0, rb3.stderr
+    bash_verdict3 = json.loads((iter_dir3 / "hidden-verdict.json").read_text(encoding="utf-8"))
+    assert bash_verdict3["skipped"] is False
+    assert bash_verdict3["verdict"] == "PASS"
+    assert bash_verdict3["rc"] == 0
+    assert "ran_at" in bash_verdict3
+
+    # Python write_verdict byte-matches bash for case (iii)'s ran-shape.
+    py_verdict_path = iter_dir3 / "py-verdict.json"
+    ss.write_verdict(bash_verdict3["verdict"], bash_verdict3["rc"],
+                     bash_verdict3["ran_at"], py_verdict_path, skipped=False)
+    assert py_verdict_path.read_text(encoding="utf-8") == \
+        (iter_dir3 / "hidden-verdict.json").read_text(encoding="utf-8")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) write_verdict_parity — skip + run shapes vs live jq -n
+# ─────────────────────────────────────────────────────────────────────────────
+def test_write_verdict_parity(tmp_path):
+    """Python `write_verdict` produces JSON byte-identical to live `jq -n` for
+    BOTH the skip and run shapes from lib/spec-split.sh. jq -n's default
+    formatting is 2-space indent + trailing newline — match exactly."""
+    path = _which("jq")["jq"]
+
+    # Skip shape.
+    verdict_path = tmp_path / "skip.json"
+    ss.write_verdict("PASS", 0, "", verdict_path, skipped=True, reason="no @hidden scenarios")
+    py_skip = verdict_path.read_text(encoding="utf-8")
+    expected_skip = subprocess.run(
+        [path, "-n", '{verdict: "PASS", scenarios_run: 0, skipped: true, reason: "no @hidden scenarios"}'],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert py_skip == expected_skip, (
+        f"skip shape mismatch\npy:     {py_skip!r}\njq:    {expected_skip!r}"
+    )
+
+    # Run shape.
+    verdict_path2 = tmp_path / "run.json"
+    ss.write_verdict("PASS", 0, "2026-07-04T10:00:00Z", verdict_path2, skipped=False)
+    py_run = verdict_path2.read_text(encoding="utf-8")
+    expected_run = subprocess.run(
+        [path, "-n",
+         "--arg", "verdict", "PASS",
+         "--argjson", "rc", "0",
+         "--arg", "ran_at", "2026-07-04T10:00:00Z",
+         '{verdict: $verdict, rc: $rc, ran_at: $ran_at, skipped: false}'],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert py_run == expected_run, (
+        f"run shape mismatch\npy:     {py_run!r}\njq:    {expected_run!r}"
+    )
+
+    # FAIL run shape — parity on a non-zero rc.
+    verdict_path3 = tmp_path / "fail.json"
+    ss.write_verdict("FAIL", 1, "2026-07-04T10:00:01Z", verdict_path3, skipped=False)
+    py_fail = verdict_path3.read_text(encoding="utf-8")
+    expected_fail = subprocess.run(
+        [path, "-n",
+         "--arg", "verdict", "FAIL",
+         "--argjson", "rc", "1",
+         "--arg", "ran_at", "2026-07-04T10:00:01Z",
+         '{verdict: $verdict, rc: $rc, ran_at: $ran_at, skipped: false}'],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert py_fail == expected_fail
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) db-init sanity — temp DB via db/init.sh, no row drift
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def temp_db(tmp_path_factory):
+    """Spin up a real mini-ork SQLite DB via db/init.sh — kickoff requirement."""
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def test_split_visible_hidden_db_init_sanity(temp_db, tmp_path):
+    """Spin up a temp DB via db/init.sh, INSERT an epic, run split_visible_hidden,
+    then query rows back and assert no drift. Proves the port doesn't accidentally
+    couple to DB state."""
+    _which("python3", "jq")
+    visible_spec = tmp_path / "visible.spec.ts"
+    visible_spec.write_text(
+        "import { test, expect } from '@playwright/test';\n"
+        "test.describe('d', () => {\n"
+        "  test('a', async () => {\n"
+        "    expect(1).toBe(1);\n"
+        "  });\n"
+        "});\n",
+        encoding="utf-8",
+    )
+    iter_dir = tmp_path / "iter-1"
+    iter_dir.mkdir()
+
+    # Snapshot rows BEFORE running the port.
+    con = sqlite3.connect(temp_db)
+    con.execute(
+        "INSERT INTO epics(id, title, status, kickoff_path) VALUES (?, ?, ?, ?)",
+        ("epic-split-db", "t", "in progress", "kickoffs/p.md"),
+    )
+    con.commit()
+    before = con.execute(
+        "SELECT id, title, status, kickoff_path FROM epics WHERE id='epic-split-db';"
+    ).fetchall()
+    con.close()
+
+    # Run the Python port — must not touch the DB.
+    report = ss.split_visible_hidden(visible_spec, iter_dir)
+    assert report == {"visible": 1, "hidden": 0, "ratio": 0.0}
+
+    # Snapshot rows AFTER — must be unchanged.
+    con = sqlite3.connect(temp_db)
+    after = con.execute(
+        "SELECT id, title, status, kickoff_path FROM epics WHERE id='epic-split-db';"
+    ).fetchall()
+    con.close()
+    assert before == after, f"DB rows drifted: before={before} after={after}"
+
+    # And the port's written files exist (sanity: the port actually ran).
+    assert (iter_dir / "hidden_spec.ts").is_file()
+    assert (iter_dir / "spec-split-report.json").is_file()


### PR DESCRIPTION
5 modules ported by autonomous mini-ork runs (parallel batch), unblocked by PR #80: operator_steering, role_evolver, artifact_contract, spec_split, gradient_extractor. Each has a live-bash-subprocess parity test (41 cases total, byte-identity). Bash unchanged (strangler-fig).