### PR TITLE
feat(python-migration): autonomous port of final 4 leaf modules

### DIFF
--- a/mini_ork/ported/cross_epic_gradient.py
+++ b/mini_ork/ported/cross_epic_gradient.py
@@ -1,0 +1,207 @@
+"""cross_epic_gradient — Python port of lib/cross_epic_gradient.sh.
+
+Fan-out gradient transfer across task_classes: when the SAME target recurs
+across >=`min_classes` distinct task_classes with confidence >= `min_confidence`
+inside a sliding window, promote it to a pseudo task_class `__cross_class__`
+so `context_assembler` injects the lesson into every task's failure_modes pane.
+
+Co-existence model (strangler-fig): bash `lib/cross_epic_gradient.sh` is the
+authoritative source. This module mirrors its inline-Python heredoc byte-for-byte
+(per `lib/cross_epic_gradient.sh` lines 35-120). Parity is enforced by
+`tests/unit/test_cross_epic_gradient_py.py` (>=6 cases; the gating case is an
+end-to-end LIVE-bash subprocess against a temp DB seeded identically to the
+Python side, asserting byte-equal gradient_records rows + identical stdout int).
+
+Idempotence: gradient_id = 'gr-cx-' + sha256(target.encode('utf-8')).hexdigest()[:12].
+Mixed bash+python re-runs converge via UPSERT (deterministic id ⇒ same row ⇒
+UPDATE, not duplicate INSERT).
+
+Public API:
+  promote(min_classes=2, min_confidence=0.7, window='14d', db=None) -> int
+
+`db` resolution: explicit kwarg > $MINI_ORK_DB env > $MINI_ORK_HOME/state.db —
+mirrors the bash `STATE_DB` precedence.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+__all__ = ["promote", "_parse_window"]
+
+_WINDOW_RE = re.compile(r"^(\d+)([dh])$")
+_DEFAULT_WINDOW_SECS = 14 * 86400
+
+
+def _parse_window(window: str) -> int:
+    """Parse `Nd` (days) or `Nh` (hours) → seconds. Fallback 14d on bad input.
+
+    Mirrors lib/cross_epic_gradient.sh:
+        m = re.match(r"^(\\d+)([dh])$", window.strip())
+        secs = (int(m.group(1)) * (86400 if m.group(2) == 'd' else 3600)) if m else 14 * 86400
+    """
+    m = _WINDOW_RE.match(window.strip())
+    if not m:
+        return _DEFAULT_WINDOW_SECS
+    n, unit = int(m.group(1)), m.group(2)
+    return n * (86400 if unit == "d" else 3600)
+
+
+def _find_recurring_targets(
+    con: sqlite3.Connection, since: int, min_conf: float, min_classes: int
+) -> list[tuple[str, str, int]]:
+    """First pass: find targets recurring across >=min_classes distinct classes
+    with confidence >=min_conf inside the [since, now] window.
+
+    Mirrors the SQL in lib/cross_epic_gradient.sh (interpolation of `since` is
+    unchanged so the parity test surfaces any integer-format drift; `min_conf`
+    and `min_classes` use parameter binding to match bash).
+    """
+    rows = con.execute(
+        f"""
+        SELECT target,
+               GROUP_CONCAT(DISTINCT task_class) AS classes,
+               COUNT(DISTINCT task_class)        AS n_classes
+          FROM gradient_records
+         WHERE created_at >= {since}
+           AND task_class NOT IN ('', '__cross_class__')
+           AND task_class IS NOT NULL
+           AND confidence >= ?
+           AND target IS NOT NULL AND target != ''
+         GROUP BY target
+        HAVING n_classes >= ?
+        """,
+        (min_conf, min_classes),
+    ).fetchall()
+    return [(t, c, n) for t, c, n in rows]
+
+
+def _pick_exemplar(
+    con: sqlite3.Connection, target: str
+) -> Optional[tuple[float, str, str, str]]:
+    """Pick the highest-confidence matching row for `target` (deterministic tie-break
+    by sqlite3's natural row order). Mirrors the bash inner query.
+    """
+    row = con.execute(
+        """
+        SELECT confidence, signal, suggested_change, evidence
+          FROM gradient_records
+         WHERE target = ?
+           AND task_class NOT IN ('', '__cross_class__')
+           AND task_class IS NOT NULL
+         ORDER BY confidence DESC
+         LIMIT 1
+        """,
+        (target,),
+    ).fetchone()
+    return row  # (conf, signal, suggested_change, evidence) | None
+
+
+def _upsert_cross_class(
+    con: sqlite3.Connection, target: str, exemplar: tuple
+) -> bool:
+    """Insert-or-update the `__cross_class__` row for `target`.
+
+    Returns True iff NEW row (counts toward `promoted`), False iff UPDATE in place.
+    Mirrors the bash branch + truncation invariants:
+      sig, suggested, evidence are [:500]/[:500]/[:1000]-truncated respectively,
+      AND inserted in (gid, cx_target, sig[:500], suggested[:1000], evidence[:1000], ...)
+      NOT (sig, suggested, evidence) — that ordering is load-bearing for the
+      parity test.
+    """
+    top_conf, top_signal, top_change, top_evidence = exemplar
+    gid = "gr-cx-" + hashlib.sha256(target.encode("utf-8")).hexdigest()[:12]
+    cx_target = f"cross_class:{target}"
+    sig = top_signal or f"Target {target} flagged across task_classes"
+    suggested = top_change or f"Lesson fanned out across task_classes"
+    evidence = top_evidence or ""
+
+    exists = con.execute(
+        "SELECT 1 FROM gradient_records WHERE gradient_id=? LIMIT 1", (gid,)
+    ).fetchone()
+    if exists:
+        con.execute(
+            """
+            UPDATE gradient_records
+               SET confidence=?, suggested_change=?, signal=?,
+                   evidence=?, target=?, task_class='__cross_class__'
+             WHERE gradient_id=?
+            """,
+            (top_conf, suggested[:1000], sig[:500], evidence[:1000], cx_target, gid),
+        )
+        return False
+    con.execute(
+        """
+        INSERT INTO gradient_records
+            (gradient_id, target, signal, suggested_change,
+             evidence, confidence, task_class, created_at)
+        VALUES (?,?,?,?,?,?, '__cross_class__', ?)
+        """,
+        (
+            gid,
+            cx_target,
+            sig[:500],
+            suggested[:1000],
+            evidence[:1000],
+            top_conf,
+            int(time.time()),
+        ),
+    )
+    return True
+
+
+def _resolve_db(db: Optional[str]) -> str:
+    """Mirror bash `STATE_DB="${MINI_ORK_DB:-${MINI_ORK_HOME:-.mini-ork}/state.db}"`."""
+    if db is not None:
+        return db
+    env_db = os.environ.get("MINI_ORK_DB")
+    if env_db:
+        return env_db
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return str(Path(home) / "state.db")
+
+
+def promote(
+    min_classes: int = 2,
+    min_confidence: float = 0.7,
+    window: str = "14d",
+    db: Optional[str] = None,
+) -> int:
+    """Promote cross-class gradients. Returns count of NEW __cross_class__ rows.
+
+    Mirrors lib/cross_epic_gradient.sh::cross_epic_gradient_promote byte-for-byte.
+    `sqlite3.Error` propagates (no silent-0 fallback — bash's heredoc also raises
+    via uncaught Python, so the parity holds).
+    """
+    db_path = _resolve_db(db)
+    secs = _parse_window(window)
+    since = int(time.time()) - secs
+
+    con = sqlite3.connect(db_path)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        recurring = _find_recurring_targets(con, since, min_confidence, min_classes)
+        rows = []
+        for target, classes, n_classes in recurring:
+            exemplar = _pick_exemplar(con, target)
+            if exemplar:
+                # (target, classes, n_classes, conf, signal, suggested, evidence)
+                rows.append((target, classes, n_classes) + exemplar)
+        promoted = 0
+        for row in rows:
+            target = row[0]
+            exemplar = row[3:]
+            if not target:
+                continue
+            if _upsert_cross_class(con, target, exemplar):
+                promoted += 1
+        con.commit()
+    finally:
+        con.close()
+    print(promoted)
+    return promoted

--- a/mini_ork/ported/mid_node_injector.py
+++ b/mini_ork/ported/mid_node_injector.py
@@ -1,0 +1,301 @@
+"""Mid-node operator-steering injector — Python port of lib/mid_node_injector.sh.
+
+Faithful port of the deterministic sidecar surfaces of
+``lib/mid_node_injector.sh``: the two pure formatters and the per-tick
+DB→fifo/prompt pipeline that an in-process caller would invoke. The bash
+script stays in place (strangler-fig co-existence) so the production
+sidecar keeps working; this module gives Python callers an in-process
+target and gives ``tests/unit/test_mid_node_injector_py.py`` a stable
+surface to byte-diff against the live bash subprocess.
+
+Co-existence model (strangler-fig): bash ``lib/mid_node_injector.sh`` is
+the authoritative source. Parity is enforced by the live-subprocess
+harness in ``tests/unit/test_mid_node_injector_py.py`` (>=6 cases; floats
+1e-6; DB row-by-row diff via sqlite3 SELECT on operator_steering).
+
+JSON encoding choice (note for reviewers): bash uses ``jq -nc --arg t
+"$body" '{...}'`` which produces compact (no-whitespace) ASCII-compatible
+JSON with jq's native string escaping (Unicode surrogate pairs preserved).
+Python mirrors this with ``json.dumps(..., separators=(',', ':'),
+ensure_ascii=False)`` — the closest semantic match. Edge-case parity
+test (case 3) exercises Unicode + quotes + newlines so any future drift
+between jq and json.dumps surfaces immediately.
+
+Scope (parity surface, NOT full bash):
+  - The two pure formatters (``_mid_injector_format_claude_user_msg`` /
+    ``_mid_injector_format_codex_prompt``) — full parity required.
+  - The DB→fifo and DB→codex-fork.out per-tick pipeline (one iteration
+    of ``_mid_injector_claude_loop`` / ``_mid_injector_codex_loop``) —
+    full parity required; consumers of these functions must have a
+    reader pre-attached to the fifo to avoid EPIPE (mirrors bash's
+    ``2>/dev/null || true`` on ``printf '%s\\n' "$line" >"$fifo_in"``).
+  - The in-process start_claude/stop loop wrapper — Python uses a
+    daemon thread + ``threading.Event`` to mirror bash's sidecar
+    subprocess; this is a strangler-fig divergence and is NOT covered
+    by parity tests (loop wrapper parity is intentionally out of scope,
+    matching how operator_steering.py isolates the deterministic SQL
+    surface).
+
+Out of scope (intentionally NOT ported — bash keeps owning these):
+  - ``kill -0 / kill -TERM`` parent-process signalling — Python loop
+    wrapper checks ``os.kill(parent_pid, 0)`` for parity with the
+    shell-side ``kill -0`` semantics, but does not actually SIGTERM
+    any process.
+  - ``codex fork <session_id> "..." --output-format text`` subprocess
+    exec — codex_tick appends the formatted prompts to
+    ``{fork_out_dir}/codex-fork.out`` as placeholders (no real exec).
+
+Pipeline map (bash function → Python):
+  _mid_injector_pid_file               → _resolve_pid_path
+  _mid_injector_format_claude_user_msg → format_claude_user_msg
+  _mid_injector_format_codex_prompt    → format_codex_prompt
+  _mid_injector_claude_loop (one tick) → claude_tick
+  _mid_injector_codex_loop  (one tick) → codex_tick
+  mid_node_injector_start (claude)     → start_claude
+  mid_node_injector_stop               → stop
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+
+from mini_ork.ported.operator_steering import fetch_for as _steer_fetch
+
+__all__ = [
+    "format_claude_user_msg",
+    "format_codex_prompt",
+    "claude_tick",
+    "codex_tick",
+    "start_claude",
+    "stop",
+]
+
+
+def _resolve_pid_path() -> str:
+    """Mirror ``_mid_injector_pid_file`` in lib/mid_node_injector.sh.
+
+    Bash: ``echo "${MINI_ORK_RUN_DIR:-/tmp}/.mid-node-injector.pid"``.
+    The /tmp fallback rarely fires in production but is preserved for
+    parity so tests that omit MINI_ORK_RUN_DIR exercise the same path.
+    """
+    base = os.environ.get("MINI_ORK_RUN_DIR") or "/tmp"
+    return os.path.join(base, ".mid-node-injector.pid")
+
+
+def format_claude_user_msg(message: str, severity: str = "info",
+                           source: str = "operator") -> str:
+    """Mirror ``_mid_injector_format_claude_user_msg`` in lib/mid_node_injector.sh.
+
+    Build a claude-shaped stream-json user message from a steering row.
+    Returns one JSON line ready to push into a stream-json fifo.
+
+    Encoding parity: bash uses ``jq -nc --arg t "$body" '{...}'`` —
+    compact JSON, no whitespace, jq-native string escaping. Python
+    mirrors with ``json.dumps(..., separators=(',', ':'),
+    ensure_ascii=False)``. Tested byte-for-byte against the live bash
+    subprocess in tests/unit/test_mid_node_injector_py.py.
+    """
+    body = f"OPERATOR STEERING [{severity}] (from {source}): {message}"
+    return json.dumps(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": body}],
+            },
+        },
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def format_codex_prompt(message: str, severity: str = "info",
+                        source: str = "operator") -> str:
+    """Mirror ``_mid_injector_format_codex_prompt`` in lib/mid_node_injector.sh.
+
+    Build the codex-shaped continuation prompt from a steering row.
+    Returns a plain text string to pass as ``codex fork <id> "..."``.
+    Bash uses ``printf '\\n'`` so the newline separator is a literal
+    ``\\n`` byte — Python mirrors exactly.
+    """
+    return (
+        f"OPERATOR STEERING [{severity}] (from {source}): {message}\n"
+        f"Continue your task with this guidance."
+    )
+
+
+def claude_tick(fifo_in: str, run_id: str, role: str = "any") -> int:
+    """Mirror one iteration of ``_mid_injector_claude_loop``.
+
+    Fetch all unconsumed steering rows for (run_id, role) via
+    ``operator_steering.fetch_for`` (the single SQL source of truth,
+    shared with operator_steering.py) and push each as a formatted
+    stream-json user message into ``fifo_in`` followed by ``\\n``.
+
+    Returns the count of rows successfully written. Best-effort: a
+    BrokenPipeError or OSError on the write is silently swallowed to
+    mirror the bash ``2>/dev/null || true`` after ``printf '%s\\n'
+    "$line" >"$fifo_in"`` — when the reader (claude) has closed the
+    fifo, the bash printf silently drops the message, and so does this
+    function.
+
+    The fetch_for call is one statement that both reads and marks
+    consumed, so a second call with the same args on the same DB
+    returns 0 (mirrors bash's one-shot fetch + UPDATE).
+    """
+    rows = _steer_fetch(run_id, role)
+    written = 0
+    for row in rows:
+        line = format_claude_user_msg(
+            row["message"],
+            row.get("severity") or "info",
+            row.get("source") or "operator",
+        )
+        try:
+            with open(fifo_in, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+            written += 1
+        except (BrokenPipeError, OSError):
+            # Mirror bash `2>/dev/null || true` on the printf — best-effort.
+            continue
+    return written
+
+
+def codex_tick(session_id_file: str, run_id: str, role: str,
+               fork_out_dir: str) -> dict:
+    """Mirror one iteration of ``_mid_injector_codex_loop``.
+
+    Fetch unconsumed steering rows for (run_id, role), format each as
+    a codex continuation prompt, and append the prompts to
+    ``{fork_out_dir}/codex-fork.out`` (placeholder text — bash invokes
+    ``codex fork`` for real; Python only writes the prompt text, no
+    exec).
+
+    Returns ``{'written': n, 'session_id': sid, 'prompts': [...]}`` or
+    ``{'written': 0, 'reason': 'no_session_id'}`` when the session_id
+    file is empty (mirrors bash's "dropped steering — session_id not
+    yet captured" stderr + continue, which is the permanent-loss
+    warning at lib/mid_node_injector.sh:131).
+    """
+    sid = ""
+    if os.path.isfile(session_id_file):
+        try:
+            with open(session_id_file, encoding="utf-8") as f:
+                sid = f.read().strip()
+        except OSError:
+            sid = ""
+    if not sid:
+        return {"written": 0, "reason": "no_session_id"}
+
+    rows = _steer_fetch(run_id, role)
+    if not rows:
+        return {"written": 0, "session_id": sid, "prompts": []}
+
+    os.makedirs(fork_out_dir, exist_ok=True)
+    out_path = os.path.join(fork_out_dir, "codex-fork.out")
+    prompts: list[str] = []
+    for row in rows:
+        prompt = format_codex_prompt(
+            row["message"],
+            row.get("severity") or "info",
+            row.get("source") or "operator",
+        )
+        prompts.append(prompt)
+        with open(out_path, "a", encoding="utf-8") as f:
+            f.write(prompt + "\n")
+    return {"written": len(prompts), "session_id": sid, "prompts": prompts}
+
+
+def start_claude(fifo_in: str, run_id: str, role: str,
+                 poll_secs: float = 5.0,
+                 parent_pid: int | None = None) -> int:
+    """Mirror ``mid_node_injector_start claude …`` in lib/mid_node_injector.sh.
+
+    Spawn a daemon thread that runs ``claude_tick`` in a loop until the
+    parent process exits (detected via ``os.kill(parent_pid, 0)``) or
+    ``stop()`` flips the threading.Event.
+
+    Returns the thread id (used as the pseudo-PID by stop()). Writes
+    the id to the pid file at ``_resolve_pid_path()`` so stop() can
+    find it. Defaults ``parent_pid`` to ``os.getpid()`` so a Python
+    process can spin up its own sidecar without explicitly passing its
+    own PID (mirrors bash's ``$$`` self-reference at
+    lib/mid_node_injector.sh:168).
+
+    Strangler-fig divergence: bash uses an out-of-process subprocess
+    that other tooling can ``kill -TERM``; Python uses an in-process
+    daemon thread plus a threading.Event. Loop wrapper parity is
+    intentionally out of scope per the kickoff — parity tests cover
+    the deterministic ``claude_tick`` body, not the loop wrapper.
+    """
+    pid_path = _resolve_pid_path()
+    stop_event = threading.Event()
+    ppid = parent_pid if parent_pid is not None else os.getpid()
+
+    def _loop() -> None:
+        while not stop_event.is_set():
+            try:
+                os.kill(ppid, 0)
+            except ProcessLookupError:
+                break
+            except PermissionError:
+                # Process exists but we lack perms — treat as still alive.
+                pass
+            try:
+                claude_tick(fifo_in, run_id, role)
+            except sqlite3.Error:
+                # Let DB errors propagate to the test harness; production
+                # callers can wrap. Mirrors bash's `2>/dev/null || continue`
+                # for the fetch — but a sqlite error mid-tick is loud.
+                raise
+            if stop_event.wait(poll_secs):
+                break
+
+    t = threading.Thread(target=_loop, name="mid-injector-claude", daemon=True)
+    t.start()
+
+    # Persist the pseudo-PID so stop() can find the thread + flag it.
+    os.makedirs(os.path.dirname(pid_path) or ".", exist_ok=True)
+    with open(pid_path, "w", encoding="utf-8") as f:
+        # We can't write the thread id (not an int PID); write a sentinel
+        # that stop() recognises, paired with the in-process Event.
+        f.write(f"thread:{t.ident}\n")
+        f.write(f"started:{int(time.time())}\n")
+    # Stash the event on a module-level singleton so stop() can reach it
+    # without re-reading the file. Module-level state is intentional and
+    # limited to this single Event — matches bash's pid-file-as-state.
+    global _stop_event
+    _stop_event = stop_event
+    return int(t.ident or 0)
+
+
+# Module-level threading.Event used by stop() to signal start_claude's loop.
+_stop_event: threading.Event | None = None
+
+
+def stop(pid_path: str | None = None) -> bool:
+    """Mirror ``mid_node_injector_stop`` in lib/mid_node_injector.sh.
+
+    Signal the loop wrapper started by ``start_claude`` to exit, then
+    remove the pid file. Returns True if a loop was signalled, False
+    otherwise.
+
+    Strangler-fig divergence: bash sends ``kill -TERM`` to a real
+    subprocess; Python flips the module-level threading.Event set by
+    start_claude. No real signal is sent.
+    """
+    path = pid_path or _resolve_pid_path()
+    if os.path.isfile(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+    global _stop_event
+    if _stop_event is not None:
+        _stop_event.set()
+        _stop_event = None
+        return True
+    return False

--- a/mini_ork/ported/runs_tracker.py
+++ b/mini_ork/ported/runs_tracker.py
@@ -1,0 +1,382 @@
+"""mini-ork dispatch tracker — Python port of lib/runs-tracker.sh.
+
+Faithful in-process port of all six functions from `lib/runs-tracker.sh`:
+
+  mo_runs_ensure_schema            → ensure_schema
+  mo_runs_resolve_claude_session_id → resolve_claude_session_id
+  mo_runs_sql_escape                → sql_escape
+  mo_runs_open                      → open
+  mo_runs_update_progress           → update_progress
+  mo_runs_close                     → close
+
+The bash library is the authoritative source. This module mirrors its
+SQL byte-for-byte (including the COALESCE+rationale append and the single-
+connection `last_insert_rowid()` extraction) so callers have an in-process
+alternative entry point and parity tests have a stable target.
+
+Co-existence model (strangler-fig):
+  bash `lib/runs-tracker.sh` stays untouched (this port never replaces it
+  in the call path). Parity is enforced by `tests/unit/test_runs_tracker_py.py`
+  which invokes the live bash library via subprocess and SELECT-diffs the
+  resulting rows against the Python port.
+
+Rationale-column append semantics (mirrors bash exactly):
+  Bash:  rationale = COALESCE(rationale, '') ||
+                    CASE WHEN rationale IS NULL OR rationale = '' THEN '' ELSE ' | ' END ||
+                    'iter:' || '<escaped verdict>'
+  Same SQL template is reproduced here; on the first append (rationale NULL
+  or empty) no ' | ' separator is emitted, so the column starts with
+  'iter:FAIL' / 'final:APPROVE'. On subsequent appends the ' | ' separator
+  joins them ('iter:FAIL | iter:WARN'). Verified against the live bash row
+  diff in tests/unit/test_runs_tracker_py.py::test_update_progress_parity.
+
+Module-level _SCHEMA_INIT_DB is a per-DB-path set (mirrors bash's session-
+wide _MO_RUNS_SCHEMA_INIT=1 guard but keyed on the actual DB file so tests
+with fresh per-case temp DBs still exercise the CREATE statements). The
+guard prevents repeated DDLS on hot paths (audit F-01: ~300K wasted
+sqlite3 forks/day at 100K dispatch volume).
+
+Forbidden-fallbacks compliance:
+  Bash silently swallows sqlite3 errors via 2>/dev/null. The Python port
+  surfaces them via `warnings.warn(...)` (matching the row-diff contract —
+  best-effort audit trail — while honoring no-silent-recovery). The warn
+  fires AFTER the SQL is emitted; row content is unchanged either way
+  unless the connection itself failed.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import sqlite3
+import subprocess
+import warnings
+from datetime import datetime, timezone
+
+
+__all__ = [
+    "ensure_schema",
+    "resolve_claude_session_id",
+    "sql_escape",
+    "open",
+    "update_progress",
+    "close",
+]
+
+
+_SCHEMA_INIT_DB: set[str] = set()
+
+
+def _db_path_or_default(db: str | os.PathLike | None) -> str:
+    """Mirror bash `_MO_DB` resolution order:
+
+        MINI_ORK_DB (explicit)  or  ${MINI_ORK_HOME:-.mini-ork}/state.db
+    """
+    if db is not None:
+        return os.fspath(db)
+    env_db = os.environ.get("MINI_ORK_DB")
+    if env_db:
+        return env_db
+    home = os.environ.get("MINI_ORK_HOME", ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+def _normalize_db_key(db_path: str) -> str:
+    """Absolute path is the dict key for _SCHEMA_INIT_DB."""
+    return os.path.abspath(db_path)
+
+
+def ensure_schema(db: str | os.PathLike | None = None) -> None:
+    """Mirror lib/runs-tracker.sh::mo_runs_ensure_schema.
+
+    Idempotent. Defensive ADD COLUMN for `runs.claude_session_id` /
+    `runs.zellij_session_name` (gated on pragma_table_info, so re-runs don't
+    fail with "duplicate column" on DBs that already have those columns from
+    migration 0001_core.sql). CREATE TABLE IF NOT EXISTS for orch_dispatches
+    + the three primary indexes.
+
+    Module-level per-DB guard short-circuits repeat calls in the same
+    process — mirrors bash's `_MO_RUNS_SCHEMA_INIT=1` export.
+    """
+    db_path = _db_path_or_default(db)
+    key = _normalize_db_key(db_path)
+    if key in _SCHEMA_INIT_DB:
+        return
+    try:
+        con = sqlite3.connect(db_path)
+        try:
+            for col in ("claude_session_id", "zellij_session_name"):
+                present = con.execute(
+                    "SELECT COUNT(*) FROM pragma_table_info('runs') WHERE name=?;",
+                    (col,),
+                ).fetchone()[0]
+                if not present:
+                    con.execute(f"ALTER TABLE runs ADD COLUMN {col} TEXT;")
+            con.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS orch_dispatches (
+                  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                  parent_dispatch_id  INTEGER REFERENCES orch_dispatches(id),
+                  epic_id             TEXT NOT NULL,
+                  group_id            TEXT,
+                  dispatched_by       TEXT NOT NULL CHECK (dispatched_by IN
+                    ('claude-session','orchestrator','human-cli','scaffold')),
+                  claude_session_id   TEXT,
+                  zellij_session_name TEXT,
+                  kickoff_path        TEXT,
+                  run_dir             TEXT,
+                  status              TEXT NOT NULL CHECK (status IN
+                    ('pending','in_progress','fanned_out','completed','cancelled')),
+                  rationale           TEXT,
+                  created_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                  updated_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                  closed_at           TEXT
+                );
+                CREATE INDEX IF NOT EXISTS idx_orch_dispatches_epic    ON orch_dispatches(epic_id);
+                CREATE INDEX IF NOT EXISTS idx_orch_dispatches_status  ON orch_dispatches(status);
+                CREATE INDEX IF NOT EXISTS idx_orch_dispatches_session ON orch_dispatches(claude_session_id);
+                """
+            )
+            con.commit()
+        finally:
+            con.close()
+    except sqlite3.Error as exc:
+        warnings.warn(f"[mini-ork] runs_tracker.ensure_schema: {exc}", stacklevel=2)
+    _SCHEMA_INIT_DB.add(key)
+
+
+def resolve_claude_session_id(
+    zellij: str | None = None,
+    home_dir: str | os.PathLike | None = None,
+) -> str:
+    """Mirror lib/runs-tracker.sh::mo_runs_resolve_claude_session_id.
+
+    Reads `$HOME/.claude/status/<zellij>.json` and extracts `.session_id`.
+    Returns '' when (a) zellij is empty, (b) the file is absent, or (c) the
+    file is missing the session_id key / unparseable. Order matches bash:
+    ZELLIJ_SESSION_NAME || ZELLIJ, then bail on empty / missing file.
+
+    `home_dir` defaults to `$HOME` (mirrors bash `~`), but tests can override
+    to point at a fixture root.
+    """
+    if not zellij:
+        zellij = (
+            os.environ.get("ZELLIJ_SESSION_NAME")
+            or os.environ.get("ZELLIJ")
+            or ""
+        )
+    if not zellij:
+        return ""
+    base = os.path.expanduser(
+        os.fspath(home_dir) if home_dir else "~"
+    )
+    status_file = os.path.join(base, ".claude", "status", f"{zellij}.json")
+    if not os.path.isfile(status_file):
+        return ""
+    try:
+        with io.open(status_file, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return ""
+    return data.get("session_id") or ""
+
+
+def sql_escape(value: str | None) -> str:
+    """Mirror lib/runs-tracker.sh::mo_runs_sql_escape (sed s/'/''/g).
+
+    SQLite single-quote escape: a single `'` becomes two (`''`). None and
+    empty pass through as empty (mirrors `${1:-}` defaulting).
+    """
+    s = "" if value is None else str(value)
+    return s.replace("'", "''")
+
+
+def _git_branch(worktree: str) -> str:
+    """Mirror `git -C "$worktree" symbolic-ref --short HEAD 2>/dev/null || echo unknown`."""
+    try:
+        r = subprocess.run(
+            ["git", "-C", worktree, "symbolic-ref", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        branch = (r.stdout or "").strip()
+        if branch:
+            return branch
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return "unknown"
+
+
+def _utc_run_stamp() -> str:
+    """Mirror bash `date -u +%Y%m%dT%H%M%S` — UTC seconds-precision stamp."""
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+
+
+def open(
+    db: str | os.PathLike | None,
+    epic: str,
+    worktree: str,
+) -> int:
+    """Mirror lib/runs-tracker.sh::mo_runs_open.
+
+    Inserts one orch_dispatches row with status='in_progress'. Returns the
+    dispatch id (cursor.lastrowid on the SAME connection that executed the
+    INSERT — bash does this with `INSERT ... ; SELECT last_insert_rowid();`
+    in one sqlite3 invocation, capturing the same connection's rowid).
+
+    Args:
+        db: SQLite path (explicit). Falls back to $MINI_ORK_DB or
+            $MINI_ORK_HOME/state.db if None.
+        epic: The epic id this dispatch belongs to.
+        worktree: A git worktree path; the current branch becomes `branch`.
+            `run_dir` is derived as `mini-ork/{JOB_ID or 'unknown'}/{epic}/{utc stamp}`.
+
+    Returns dispatch id on success, -1 on sqlite3 error (with stderr warn).
+    """
+    db_path = _db_path_or_default(db)
+    ensure_schema(db_path)
+    branch = _git_branch(worktree)  # retained for parity w/ bash (unused in INSERT)
+    _ = branch  # explicit no-op; bash copies branch to a local var too
+    job_id = os.environ.get("JOB_ID") or ""
+    zellij = (
+        os.environ.get("ZELLIJ_SESSION_NAME")
+        or os.environ.get("ZELLIJ")
+        or ""
+    )
+    claude_sid = resolve_claude_session_id()
+    run_dir = f"mini-ork/{job_id or 'unknown'}/{epic}/{_utc_run_stamp()}"
+
+    epic_sql = "'" + sql_escape(epic) + "'"
+    group_sql = "'" + sql_escape(job_id) + "'" if job_id else "NULL"
+    claude_sid_sql = "'" + sql_escape(claude_sid) + "'" if claude_sid else "NULL"
+    zellij_sql = "'" + sql_escape(zellij) + "'" if zellij else "NULL"
+    run_dir_sql = "'" + sql_escape(run_dir) + "'"
+
+    sql = (
+        "INSERT INTO orch_dispatches "
+        "(epic_id, group_id, dispatched_by, claude_session_id, "
+        "zellij_session_name, run_dir, status) VALUES "
+        f"({epic_sql}, {group_sql}, 'claude-session', "
+        f"{claude_sid_sql}, {zellij_sql}, {run_dir_sql}, 'in_progress');"
+    )
+    try:
+        con = sqlite3.connect(db_path)
+        try:
+            cur = con.execute(sql)
+            con.commit()
+            return int(cur.lastrowid or 0)
+        finally:
+            con.close()
+    except sqlite3.Error as exc:
+        warnings.warn(f"[mini-ork] runs_tracker.open: {exc}", stacklevel=2)
+        return -1
+
+
+def _append_rationale_segment(
+    db_path: str,
+    dispatch_id: int,
+    label: str,
+    escaped_value: str,
+    *,
+    set_status: str | None = None,
+    set_closed_at: bool = False,
+) -> None:
+    """Internal helper — shared SQL template for update_progress and close.
+
+    Mirrors the bash UPDATE pattern:
+
+        rationale = COALESCE(rationale, '') ||
+                    CASE WHEN rationale IS NULL OR rationale = '' THEN '' ELSE ' | ' END ||
+                    '<label>:' || '<escaped_value>'
+
+    `set_status` updates the status column (used by close).
+    `set_closed_at` sets closed_at to NOW() (used by close).
+    """
+    extra_sets: list[str] = []
+    params: list[object] = []
+    if set_status is not None:
+        extra_sets.append("status     = ?")
+        params.append(set_status)
+    if set_closed_at:
+        extra_sets.append("closed_at  = strftime('%Y-%m-%dT%H:%M:%fZ','now')")
+    extra_sets.append("updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')")
+    rationale_sql = (
+        f"rationale  = COALESCE(rationale, '') || "
+        f"CASE WHEN rationale IS NULL OR rationale = '' THEN '' ELSE ' | ' END || "
+        f"'{label}:' || ?"
+    )
+    params.append(escaped_value)
+    params.append(dispatch_id)
+    sql = (
+        "UPDATE orch_dispatches SET "
+        + ", ".join(extra_sets)
+        + f", {rationale_sql} "
+        + "WHERE id = ?;"
+    )
+    try:
+        con = sqlite3.connect(db_path)
+        try:
+            con.execute(sql, params)
+            con.commit()
+        finally:
+            con.close()
+    except sqlite3.Error as exc:
+        warnings.warn(
+            f"[mini-ork] runs_tracker.{label}_append: {exc}", stacklevel=2
+        )
+
+
+def update_progress(
+    db: str | os.PathLike | None,
+    dispatch_id: int,
+    verdict: str,
+) -> None:
+    """Mirror lib/runs-tracker.sh::mo_runs_update_progress.
+
+    Bumps `updated_at` and appends `iter:<verdict>` (or ` | iter:<verdict>`
+    if rationale already populated) to the `rationale` column.
+    """
+    if not dispatch_id:
+        return
+    db_path = _db_path_or_default(db)
+    _append_rationale_segment(
+        db_path,
+        dispatch_id,
+        "iter",
+        sql_escape(verdict),
+        set_status=None,
+        set_closed_at=False,
+    )
+
+
+def close(
+    db: str | os.PathLike | None,
+    dispatch_id: int,
+    epic: str,
+    final_verdict: str,
+) -> None:
+    """Mirror lib/runs-tracker.sh::mo_runs_close.
+
+    Maps `final_verdict` to status (`APPROVE|MERGED|SALVAGED` → completed;
+    anything else → cancelled), stamps `closed_at` to NOW, appends
+    `final:<verdict>` to `rationale`. `epic` is retained to match the bash
+    signature (unused — bash doesn't reference it either).
+    """
+    if not dispatch_id:
+        return
+    _ = epic  # noqa: F841 — mirror bash signature; unused
+    db_path = _db_path_or_default(db)
+    new_status = (
+        "completed"
+        if final_verdict in ("APPROVE", "MERGED", "SALVAGED")
+        else "cancelled"
+    )
+    _append_rationale_segment(
+        db_path,
+        dispatch_id,
+        "final",
+        sql_escape(final_verdict),
+        set_status=new_status,
+        set_closed_at=True,
+    )

--- a/mini_ork/ported/steering_checkpoint.py
+++ b/mini_ork/ported/steering_checkpoint.py
@@ -1,0 +1,228 @@
+"""HITL steering checkpoints — Python port of lib/steering_checkpoint.sh.
+
+A checkpoint lets a recipe pause an in-flight run for human steering, then
+resume once steering arrives. It composes two primitives that already exist:
+``operator_steering`` (the steering message carrier) and the dispatcher's
+plan-status gate (the pause/resume), exactly like ``plan_status=needs_answers``.
+
+Co-existence model (strangler-fig): bash ``lib/steering_checkpoint.sh`` is the
+authoritative source and stays untouched. This module mirrors its public API
+1:1 so Python callers get an in-process surface and
+``tests/unit/test_steering_checkpoint_py.py`` gets a stable target to byte-diff
+against the live bash subprocess.
+
+Shared-DB invariant: the bash library ``source``s ``operator_steering.sh`` to
+inherit ``_operator_steering_db`` / ``_operator_steering_now_ms``. The port
+reuses ``mini_ork.ported.operator_steering._resolve_db`` / ``._now_ms`` for the
+same reason — ``has_unconsumed`` must read the exact ``state.db`` that
+``operator_steering.emit`` / ``.fetch_for`` write to, or it reads an empty DB.
+If ``operator_steering`` is unavailable at import time, we fall through to the
+same env-only path bash uses when the ``declare -F`` probe misses.
+
+Public API (bash function → Python):
+  mo_steering_has_unconsumed   → has_unconsumed(run_id, role='any') -> int
+  mo_steering_checkpoint_mark  → mark(run_id, node_id, reason=None) -> None
+  mo_steering_checkpoint_clear → clear(run_id) -> None
+  mo_steering_checkpoint_status→ status(run_id) -> dict
+  mo_steering_checkpoint_gate  → gate(run_id, node_id='checkpoint', role='any') -> int
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sqlite3
+import sys
+import time
+
+__all__ = [
+    "has_unconsumed",
+    "mark",
+    "clear",
+    "status",
+    "gate",
+]
+
+
+# Reuse the db-path + now-ms helpers from the operator_steering port, mirroring
+# bash's `. operator_steering.sh` + `declare -F _operator_steering_db` inheritance.
+# If the port is unavailable at import time, fall through to the same env-only
+# path bash uses when the declare probe misses.
+try:
+    from mini_ork.ported.operator_steering import _resolve_db as _op_resolve_db
+    from mini_ork.ported.operator_steering import _now_ms as _op_now_ms
+except ImportError:  # pragma: no cover - env-only fallback
+    _op_resolve_db = None
+    _op_now_ms = None
+
+
+def _db() -> str:
+    """Mirror ``_mo_steering_db``: reuse ``_operator_steering_db`` when present,
+    else the env fallback ``${MINI_ORK_DB:-${MINI_ORK_HOME:-$(pwd)/.mini-ork}/state.db}``."""
+    if _op_resolve_db is not None:
+        return _op_resolve_db()
+    if os.environ.get("MINI_ORK_DB"):
+        return os.environ["MINI_ORK_DB"]
+    if os.environ.get("MINI_ORK_HOME"):
+        return os.path.join(os.environ["MINI_ORK_HOME"], "state.db")
+    return os.path.join(os.getcwd(), ".mini-ork", "state.db")
+
+
+def _now_ms() -> int:
+    """Mirror ``_mo_steering_now_ms``: reuse ``_operator_steering_now_ms`` when
+    present, else ``int(time.time() * 1000)``."""
+    if _op_now_ms is not None:
+        return _op_now_ms()
+    return int(time.time() * 1000)
+
+
+def _log(level: str, msg: str) -> None:
+    """Mirror ``_mo_steering_log``: one-line JSON to stderr."""
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sys.stderr.write(
+        '{"level":"%s","subsystem":"steering_checkpoint","ts":"%s","msg":"%s"}\n'
+        % (level, ts, msg)
+    )
+
+
+def _run_dir(run_id: str) -> str:
+    """Mirror ``_mo_steering_run_dir``: MINI_ORK_RUN_DIR when set+isdir, else
+    ``${MINI_ORK_HOME:-.mini-ork}/runs/<run_id>``."""
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    if run_dir and os.path.isdir(run_dir):
+        return run_dir
+    home = os.environ.get("MINI_ORK_HOME") or ".mini-ork"
+    return os.path.join(home, "runs", run_id)
+
+
+def _sentinel_path(run_id: str) -> str:
+    return os.path.join(_run_dir(run_id), ".steering-checkpoint")
+
+
+def _marker_path(run_id: str) -> str:
+    return os.path.join(_run_dir(run_id), ".steering-checkpoint.json")
+
+
+def has_unconsumed(run_id: str, role: str = "any") -> int:
+    """Mirror ``mo_steering_has_unconsumed``.
+
+    rc=0 when an unconsumed, unexpired steering row exists for this run (or the
+    global NULL-run queue) addressed to ``role`` (or ``"any"`` on either side);
+    rc=1 otherwise. rc=2 when ``run_id`` is empty (bash: "run_id required").
+    rc=1 when the DB file is absent (bash: ``[ -f "$_db" ] || return 1``).
+    """
+    if not run_id:
+        _log("error", "mo_steering_has_unconsumed: run_id required")
+        return 2
+
+    db = _db()
+    if not os.path.isfile(db):
+        return 1  # no db → nothing to consume
+
+    now = _now_ms()
+    con = sqlite3.connect(db, timeout=5.0)
+    try:
+        con.execute("PRAGMA busy_timeout = 5000")
+        row = con.execute(
+            """SELECT 1 FROM operator_steering
+                WHERE consumed_at IS NULL
+                  AND expires_at > ?
+                  AND (run_id = ? OR run_id IS NULL)
+                  AND (role_target = ? OR role_target = 'any' OR ? = 'any')
+                LIMIT 1""",
+            (now, run_id, role, role),
+        ).fetchone()
+    finally:
+        con.close()
+    return 0 if row else 1
+
+
+def mark(run_id: str, node_id: str, reason: str | None = None) -> None:
+    """Mirror ``mo_steering_checkpoint_mark``: truncate the sentinel and write
+    the ``.steering-checkpoint.json`` marker.
+
+    Empty ``run_id`` is a no-op (bash returns rc=2 without writing). The bash
+    ``mark`` swallows mkdir/write failures (``2>/dev/null || true`` on both the
+    ``mkdir -p`` and the python heredoc), so the port mirrors that narrowly with
+    an OSError guard — this is faithful bash behavior, not a recovery fallback.
+    """
+    if not run_id:
+        return
+    run_dir = _run_dir(run_id)
+    try:
+        os.makedirs(run_dir, exist_ok=True)
+    except OSError:
+        pass
+    sentinel = _sentinel_path(run_id)
+    marker = _marker_path(run_id)
+    now = _now_ms()
+    try:
+        with open(sentinel, "w"):
+            pass  # `: > "$sentinel"` — truncate/create, empty content
+        with open(marker, "w") as fh:
+            json.dump({
+                "awaiting_steering": True,
+                "run_id": run_id,
+                "node_id": node_id,
+                "reason": reason or None,
+                "requested_at_ms": int(now),
+            }, fh)
+    except OSError:
+        pass
+    _log("info", f"checkpoint awaiting steering: run={run_id} node={node_id}")
+
+
+def clear(run_id: str) -> None:
+    """Mirror ``mo_steering_checkpoint_clear``: remove the sentinel + marker.
+
+    Empty ``run_id`` is a no-op (bash returns rc=2 without removing). Missing
+    files are ignored (bash: ``rm -f … 2>/dev/null || true``).
+    """
+    if not run_id:
+        return
+    for path in (_sentinel_path(run_id), _marker_path(run_id)):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def status(run_id: str) -> dict:
+    """Mirror ``mo_steering_checkpoint_status``: emit the awaiting-state JSON.
+
+    - empty ``run_id`` → ``{"awaiting": False}``
+    - sentinel + marker present → marker dict + ``awaiting=True`` + ``sentinel_path``
+    - sentinel present, marker absent → ``{"awaiting": True, "sentinel_path": …}``
+    - no sentinel → ``{"awaiting": False}``
+    """
+    if not run_id:
+        return {"awaiting": False}
+    sentinel = _sentinel_path(run_id)
+    marker = _marker_path(run_id)
+    if os.path.isfile(sentinel):
+        if os.path.isfile(marker):
+            with open(marker) as fh:
+                m = json.load(fh)
+            m["awaiting"] = True
+            m["sentinel_path"] = sentinel
+            return m
+        return {"awaiting": True, "sentinel_path": sentinel}
+    return {"awaiting": False}
+
+
+def gate(run_id: str, node_id: str = "checkpoint", role: str = "any") -> int:
+    """Mirror ``mo_steering_checkpoint_gate``: the composite the dispatcher calls.
+
+    rc=0 → steering present (marker cleared), proceed.
+    rc=2 → no steering yet (marker written), pause the run.
+    rc=2 also when ``run_id`` is empty (bash: "run_id required").
+    """
+    if not run_id:
+        _log("error", "gate: run_id required")
+        return 2
+    if has_unconsumed(run_id, role) == 0:
+        clear(run_id)
+        _log("info", f"checkpoint satisfied: run={run_id} node={node_id}")
+        return 0
+    mark(run_id, node_id, "awaiting human steering")
+    return 2

--- a/tests/unit/test_cross_epic_gradient_py.py
+++ b/tests/unit/test_cross_epic_gradient_py.py
@@ -1,0 +1,564 @@
+"""Parity gate: mini_ork.ported.cross_epic_gradient vs lib/cross_epic_gradient.sh.
+
+Each test seeds a temp DB (created via db/init.sh — kickoff requirement) and
+invokes the LIVE bash subprocess on a sibling DB; the Python port is called on
+a parallel DB copy. Row content (`SELECT * FROM gradient_records ORDER BY
+gradient_id`) must match byte-for-byte (confidence at 1e-6 tolerance). No mocks,
+no hardcoded expected outputs — expected is always derived from a control bash
+invocation that shares the inputs and the seed.
+
+Run pattern: bash-side and python-side each get a private DB seeded
+identically BEFORE either side runs. This prevents the first runner's INSERT
+from corrupting the second runner's expected INSERT branch (deterministic gid
+turns the second call into an UPDATE).
+
+>=6 cases:
+  (1) empty DB                                          — promotes==0
+  (2) sub-threshold distinct classes                    — promotes==0
+  (3) sub-threshold confidence                          — promotes==0
+  (4) single recurring target + deterministic gid       — promotes==1, row
+                                                          inserted with
+                                                          gid=='gr-cx-'+sha256[:12],
+                                                          task_class='__cross_class__',
+                                                          target='cross_class:<t>'
+  (5) re-promote idempotency                            — 2nd call returns 0;
+                                                          row updated in place,
+                                                          not duplicated
+  (6) multiple distinct recurring targets in one call   — promotes==N, all rows
+                                                          coexist with stable gids
+  (7) exemplar selection: MAX(confidence) per target    — picked row mirrors
+                                                          max-confidence seed
+  (8) excluded-classes: task_class='' or '__cross_class__'
+                                                          must NOT seed clustering
+  (9) end-to-end LIVE-bash-vs-python parity             — same seed into two DB
+                                                          copies, run each side,
+                                                          SELECT * ordered by gid,
+                                                          assert byte-equal
+                                                          row tuples (confidence
+                                                          1e-6).
+"""
+from __future__ import annotations
+
+import hashlib
+import math
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from io import StringIO
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import cross_epic_gradient as cx  # noqa: E402
+
+SH = REPO / "lib" / "cross_epic_gradient.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+_GRADIENT_COLUMNS = (
+    "gradient_id", "target", "signal", "suggested_change",
+    "evidence", "confidence", "task_class", "created_at",
+)
+
+
+def _which(*tools: str) -> dict[str, str]:
+    out = {}
+    for t in tools:
+        p = shutil.which(t)
+        if not p:
+            pytest.skip(f"required tool not on PATH: {t}")
+        out[t] = p
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DB fixtures + seed helpers
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def temp_db(tmp_path_factory):
+    """A real mini-ork SQLite DB initialised by db/init.sh — kickoff explicitly
+    requires 'temp DB created by db/init.sh'."""
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def _seed(dbp: str, rows: list[dict], fixed_ts: int | None = None) -> None:
+    """Insert seed rows into `gradient_records`. `created_at` defaults to a
+    fixed 60s-in-the-past value — comfortably inside any default window
+    (`since = now - 14d`), and stable across bash-side and python-side
+    invocations that may run seconds apart.
+
+    Pass an explicit `fixed_ts` to guarantee byte-identical `created_at`
+    across multiple `_seed` calls in the same test (otherwise the two
+    sequential seed calls can drift by a few seconds, breaking tests that
+    do strict tuple equality on seeded rows).
+    """
+    ts = int(time.time()) - 60 if fixed_ts is None else fixed_ts
+    con = sqlite3.connect(dbp)
+    try:
+        for r in rows:
+            con.execute(
+                """
+                INSERT INTO gradient_records
+                    (gradient_id, target, signal, suggested_change,
+                     evidence, confidence, task_class, created_at)
+                VALUES (?,?,?,?,?,?,?,?)
+                """,
+                (
+                    r["gradient_id"],
+                    r["target"],
+                    r.get("signal", "sig"),
+                    r.get("suggested_change", "fix"),
+                    r.get("evidence", "ev"),
+                    r["confidence"],
+                    r.get("task_class", "tcA"),
+                    ts,
+                ),
+            )
+        con.commit()
+    finally:
+        con.close()
+
+
+def _seed_db_with_copy(
+    tmp_path_factory, seed_rows: list[dict]
+) -> tuple[str, str]:
+    """Initialise two identical DBs (bash-side + python-side) and seed them
+    with the same rows. Returns (bash_db, py_db). Each side gets a private
+    DB BEFORE either runs, so the first runner's INSERT does not corrupt
+    the second runner's expected INSERT branch.
+
+    Both DBs are seeded with the SAME `created_at` so seeded rows match
+    byte-for-byte across the two DBs (any drift between two `int(time.time())`
+    reads would break strict tuple equality).
+    """
+    shared_ts = int(time.time()) - 60
+    home = tmp_path_factory.mktemp("home")
+    bash_db = str(home / "bash.db")
+    py_db = str(home / "py.db")
+    for dbp in (bash_db, py_db):
+        subprocess.run(
+            ["bash", str(INIT_SH)],
+            env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+            capture_output=True, text=True, check=True,
+        )
+        _seed(dbp, seed_rows, fixed_ts=shared_ts)
+    return bash_db, py_db
+
+
+def _all_rows(dbp: str) -> list[tuple]:
+    """SELECT all gradient_records ordered by gradient_id (stable diff order)."""
+    con = sqlite3.connect(dbp)
+    try:
+        col_sql = ", ".join(_GRADIENT_COLUMNS)
+        return con.execute(
+            f"SELECT {col_sql} FROM gradient_records ORDER BY gradient_id"
+        ).fetchall()
+    finally:
+        con.close()
+
+
+def _bash(db: str, snippet: str) -> subprocess.CompletedProcess:
+    """Source lib/cross_epic_gradient.sh and run `snippet` (a single shell
+    statement that calls cross_epic_gradient_promote). The bash function prints
+    promoted-count on stdout — we do NOT strip trailing newlines, so the
+    parity check on `promoted` matches byte-for-byte."""
+    bash_wrapper = f'. "{SH}"\n{snippet}\n'
+    return subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={
+            **os.environ,
+            "MINI_ORK_DB": db,
+            "MINI_ORK_ROOT": str(REPO),
+            "MINI_ORK_HOME": str(REPO),
+        },
+        capture_output=True, text=True,
+    )
+
+
+def _promote_capture(db: str):
+    """Run cx.promote(db=...) with stdout captured. Returns (returned_int, stdout_str)."""
+    buf = StringIO()
+    with mock.patch("sys.stdout", buf):
+        returned = cx.promote(db=db)
+    return returned, buf.getvalue()
+
+
+def _gradient_id(target: str) -> str:
+    return "gr-cx-" + hashlib.sha256(target.encode("utf-8")).hexdigest()[:12]
+
+
+def _row_parity(bash_row: tuple, py_row: tuple) -> None:
+    """Compare two rows field-by-field. Confidence at 1e-6, created_at ignored
+    (both sides use int(time.time()) at INSERT time but the calls may run
+    seconds apart)."""
+    assert len(bash_row) == len(py_row) == 8
+    fields = ("gradient_id", "target", "signal", "suggested_change",
+              "evidence", "confidence", "task_class", "created_at")
+    for i, f in enumerate(fields):
+        if f == "confidence":
+            assert math.isclose(bash_row[i], py_row[i], abs_tol=1e-6), (
+                f"confidence drift: bash={bash_row[i]} py={py_row[i]}"
+            )
+        elif f == "created_at":
+            continue  # live-clock; both sides use time.time() but may drift
+        else:
+            assert bash_row[i] == py_row[i], (
+                f"{f}: bash={bash_row[i]!r} py={py_row[i]!r}"
+            )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (1) empty DB — bash and python both print 0, no rows inserted.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_empty_db(tmp_path_factory):
+    """Empty DB → bash prints 0, python prints 0, gradient_records is empty on
+    both sides (no rows inserted)."""
+    _which("bash", "python3")
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, [])
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0, rb.stderr
+
+    py_returned, py_stdout = _promote_capture(py_db)
+
+    assert py_returned == 0
+    assert rb.stdout == py_stdout == "0\n"
+    assert _all_rows(bash_db) == _all_rows(py_db) == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (2) sub-threshold distinct classes (1 class only) — no promotion.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_subthreshold_classes(tmp_path_factory):
+    """1 distinct task_class for the same target (min_classes=2) → no rows."""
+    _which("bash", "python3")
+    target = "agent.reviewer.prompt"
+    seed_rows = [
+        {"gradient_id": "g1", "target": target, "task_class": "tcA", "confidence": 0.9},
+        {"gradient_id": "g2", "target": target, "task_class": "tcA", "confidence": 0.85},
+    ]
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0
+    py_returned, _ = _promote_capture(py_db)
+
+    assert rb.stdout == "0\n"
+    assert py_returned == 0
+    # Only the 2 seeded rows on each side; no __cross_class__ row inserted.
+    bash_rows = _all_rows(bash_db)
+    py_rows = _all_rows(py_db)
+    assert len(bash_rows) == 2 == len(py_rows)
+    assert bash_rows == py_rows  # seed identical, no INSERTs
+    assert all(r[6] != "__cross_class__" for r in bash_rows)
+    assert all(r[6] != "__cross_class__" for r in py_rows)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (3) sub-threshold confidence — no promotion.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_subthreshold_confidence(tmp_path_factory):
+    """3 distinct classes BUT confidence=0.5 (min_confidence=0.7) → no rows."""
+    _which("bash", "python3")
+    target = "verifier.lens-exists"
+    seed_rows = [
+        {"gradient_id": "g1", "target": target, "task_class": "tcA", "confidence": 0.5},
+        {"gradient_id": "g2", "target": target, "task_class": "tcB", "confidence": 0.6},
+        {"gradient_id": "g3", "target": target, "task_class": "tcC", "confidence": 0.5},
+    ]
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0
+    py_returned, _ = _promote_capture(py_db)
+
+    assert rb.stdout == "0\n"
+    assert py_returned == 0
+    assert _all_rows(bash_db) == _all_rows(py_db)
+    assert len(_all_rows(bash_db)) == 3
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (4) single recurring target — promoted=1, row inserted with deterministic gid.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_single_recurring_target(tmp_path_factory):
+    """3 distinct classes, all confidence>=0.7 → promotes=1, new row has
+    gid='gr-cx-'+sha256(target)[:12], task_class='__cross_class__',
+    target='cross_class:<target>', confidence=MAX seed."""
+    _which("bash", "python3")
+    target = "workflow.recipe.framework_edit"
+    expected_gid = _gradient_id(target)
+    seed_rows = [
+        {"gradient_id": "g1", "target": target, "task_class": "tcA", "confidence": 0.7,
+         "suggested_change": "low-conf fix"},
+        {"gradient_id": "g2", "target": target, "task_class": "tcB", "confidence": 0.95,
+         "suggested_change": "BEST fix"},
+        {"gradient_id": "g3", "target": target, "task_class": "tcC", "confidence": 0.8,
+         "suggested_change": "mid fix"},
+    ]
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0, rb.stderr
+
+    py_returned, py_stdout = _promote_capture(py_db)
+
+    assert rb.stdout == py_stdout == "1\n"
+    assert py_returned == 1
+
+    bash_rows = _all_rows(bash_db)
+    py_rows = _all_rows(py_db)
+    # 3 seeded + 1 promoted = 4 rows on each side.
+    assert len(bash_rows) == 4 == len(py_rows)
+
+    bash_promoted = [r for r in bash_rows if r[0] == expected_gid]
+    py_promoted = [r for r in py_rows if r[0] == expected_gid]
+    assert len(bash_promoted) == 1 == len(py_promoted)
+
+    # Content sanity on the bash-side promoted row (python mirror is asserted below).
+    assert bash_promoted[0][0] == expected_gid
+    assert bash_promoted[0][1] == f"cross_class:{target}"
+    assert bash_promoted[0][6] == "__cross_class__"
+    assert math.isclose(bash_promoted[0][5], 0.95, abs_tol=1e-6)
+    assert bash_promoted[0][3] == "BEST fix"
+
+    # Pairwise parity between bash row and python row.
+    _row_parity(bash_promoted[0], py_promoted[0])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (5) re-promote idempotency — 2nd call returns 0, row updated in place.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_idempotent(tmp_path_factory):
+    """Run promote() twice on the SAME DB. First call inserts (promotes=1),
+    second call updates in place (promotes=0); total row count remains 4
+    (3 seeded + 1 promoted). Tested independently for bash and for python."""
+    _which("bash", "python3")
+    target = "agent.reviewer.prompt"
+    seed_rows = [
+        {"gradient_id": "g1", "target": target, "task_class": "tcA", "confidence": 0.8},
+        {"gradient_id": "g2", "target": target, "task_class": "tcB", "confidence": 0.85},
+        {"gradient_id": "g3", "target": target, "task_class": "tcC", "confidence": 0.9},
+    ]
+
+    # ── Bash side ──
+    bash_db, _ = _seed_db_with_copy(tmp_path_factory, seed_rows)
+    rb1 = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb1.returncode == 0
+    assert rb1.stdout == "1\n"
+    rb2 = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb2.returncode == 0
+    assert rb2.stdout == "0\n"
+
+    # ── Python side (parallel fresh DB seeded identically) ──
+    _, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+    py_returned1, py_stdout1 = _promote_capture(py_db)
+    py_returned2, py_stdout2 = _promote_capture(py_db)
+    assert py_stdout1 == "1\n" and py_returned1 == 1
+    assert py_stdout2 == "0\n" and py_returned2 == 0
+
+    # Row count unchanged (no duplicate INSERTs) on python side.
+    py_rows_after = _all_rows(py_db)
+    assert len(py_rows_after) == 4
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (6) multiple distinct recurring targets promoted together.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_multiple_targets(tmp_path_factory):
+    """2 distinct targets, each recurring across 3 classes → 2 promoted rows in
+    one call. Both must coexist with stable deterministic gids."""
+    _which("bash", "python3")
+    seed_rows = [
+        # Target 1 across tcA/tcB/tcC.
+        {"gradient_id": "gA1", "target": "agent.reviewer", "task_class": "tcA", "confidence": 0.8},
+        {"gradient_id": "gA2", "target": "agent.reviewer", "task_class": "tcB", "confidence": 0.85},
+        {"gradient_id": "gA3", "target": "agent.reviewer", "task_class": "tcC", "confidence": 0.9},
+        # Target 2 across tcD/tcE/tcF.
+        {"gradient_id": "gB1", "target": "verifier.lens", "task_class": "tcD", "confidence": 0.75},
+        {"gradient_id": "gB2", "target": "verifier.lens", "task_class": "tcE", "confidence": 0.82},
+        {"gradient_id": "gB3", "target": "verifier.lens", "task_class": "tcF", "confidence": 0.88},
+    ]
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0
+    py_returned, py_stdout = _promote_capture(py_db)
+
+    assert rb.stdout == py_stdout == "2\n"
+    assert py_returned == 2
+
+    bash_rows = _all_rows(bash_db)
+    py_rows = _all_rows(py_db)
+    # 6 seed + 2 promoted = 8 rows on each side.
+    assert len(bash_rows) == 8 == len(py_rows)
+
+    expected_gids = {_gradient_id("agent.reviewer"), _gradient_id("verifier.lens")}
+    bash_gids = {r[0] for r in bash_rows}
+    py_gids = {r[0] for r in py_rows}
+    assert expected_gids.issubset(bash_gids)
+    assert expected_gids.issubset(py_gids)
+
+    # Cross-class rows must have task_class='__cross_class__' on both sides.
+    for r in bash_rows:
+        if r[0] in expected_gids:
+            assert r[6] == "__cross_class__"
+    for r in py_rows:
+        if r[0] in expected_gids:
+            assert r[6] == "__cross_class__"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (7) exemplar selection — picks MAX(confidence) for each target.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_exemplar_max_confidence(tmp_path_factory):
+    """For each target, the promoted row's confidence and suggested_change must
+    come from the seeded row with the highest confidence."""
+    _which("bash", "python3")
+    target = "agent.refiner.prompt"
+    expected_gid = _gradient_id(target)
+    seed_rows = [
+        {"gradient_id": "g1", "target": target, "task_class": "tcA", "confidence": 0.71,
+         "suggested_change": "lo conf fix", "signal": "lo sig"},
+        {"gradient_id": "g2", "target": target, "task_class": "tcB", "confidence": 0.99,
+         "suggested_change": "BEST fix", "signal": "BEST sig"},
+        {"gradient_id": "g3", "target": target, "task_class": "tcC", "confidence": 0.85,
+         "suggested_change": "mid fix", "signal": "mid sig"},
+    ]
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0
+    _promote_capture(py_db)
+
+    bash_promoted = [r for r in _all_rows(bash_db) if r[0] == expected_gid]
+    py_promoted = [r for r in _all_rows(py_db) if r[0] == expected_gid]
+    assert len(bash_promoted) == 1 == len(py_promoted)
+
+    _row_parity(bash_promoted[0], py_promoted[0])
+    assert math.isclose(bash_promoted[0][5], 0.99, abs_tol=1e-6)
+    assert bash_promoted[0][3] == "BEST fix"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (8) excluded classes — task_class='' and '__cross_class__' must NOT seed clusters.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_excludes_blank_and_cross_class(tmp_path_factory):
+    """Seeded rows with task_class IN ('', '__cross_class__') are excluded from
+    clustering. Verify both the gate (excluded rows DON'T trigger promotion on
+    their own) AND the safety (a target with mixed valid+excluded classes still
+    promotes iff the valid count crosses min_classes)."""
+    _which("bash", "python3")
+    # target A: 3 valid classes (tcA/tcB/tcC) → SHOULD promote.
+    # target B: 2 valid + 2 excluded → SHOULD promote (excluded don't poison).
+    # target C: 1 valid + 2 excluded → should NOT promote (only 1 valid class).
+    seed_rows = [
+        {"gradient_id": "gA1", "target": "good.A", "task_class": "tcA", "confidence": 0.9},
+        {"gradient_id": "gA2", "target": "good.A", "task_class": "tcB", "confidence": 0.85},
+        {"gradient_id": "gA3", "target": "good.A", "task_class": "tcC", "confidence": 0.8},
+        {"gradient_id": "gB1", "target": "good.B", "task_class": "tcD", "confidence": 0.9},
+        {"gradient_id": "gB2", "target": "good.B", "task_class": "tcE", "confidence": 0.85},
+        {"gradient_id": "gB3", "target": "good.B", "task_class": "", "confidence": 0.99},
+        {"gradient_id": "gB4", "target": "good.B", "task_class": "__cross_class__", "confidence": 0.99},
+        {"gradient_id": "gC1", "target": "good.C", "task_class": "tcF", "confidence": 0.9},
+        {"gradient_id": "gC2", "target": "good.C", "task_class": "", "confidence": 0.99},
+        {"gradient_id": "gC3", "target": "good.C", "task_class": "__cross_class__", "confidence": 0.99},
+    ]
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0
+    py_returned, py_stdout = _promote_capture(py_db)
+
+    # good.A and good.B promote; good.C does NOT.
+    assert rb.stdout == py_stdout == "2\n"
+    assert py_returned == 2
+
+    bash_rows = _all_rows(bash_db)
+    py_rows = _all_rows(py_db)
+    # 10 seed + 2 promoted = 12 rows on each side.
+    assert len(bash_rows) == 12 == len(py_rows)
+
+    expected_gids = {_gradient_id("good.A"), _gradient_id("good.B")}
+    bash_gids = {r[0] for r in bash_rows}
+    py_gids = {r[0] for r in py_rows}
+    assert expected_gids.issubset(bash_gids)
+    assert expected_gids.issubset(py_gids)
+    # good.C must NOT have a promoted row.
+    assert _gradient_id("good.C") not in bash_gids
+    assert _gradient_id("good.C") not in py_gids
+
+    # Pairwise parity on the 2 promoted rows.
+    for gid in expected_gids:
+        b_row = next(r for r in bash_rows if r[0] == gid)
+        p_row = next(r for r in py_rows if r[0] == gid)
+        _row_parity(b_row, p_row)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (9) end-to-end LIVE-bash-vs-python row parity — gating acceptance test.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_promote_end_to_end_live_bash_parity(tmp_path_factory):
+    """Gating case. Seed the same rows into two DBs. Run bash on one, run
+    python on the other. SELECT * ordered by gradient_id on each side and
+    assert the row tuples are byte-equal (confidence at 1e-6 tolerance)."""
+    _which("bash", "python3")
+
+    seed_rows = [
+        {"gradient_id": "seed-1", "target": "agent.reviewer.prompt",
+         "task_class": "tcA", "confidence": 0.75,
+         "suggested_change": "fix-A", "signal": "sig-A", "evidence": "ev-A"},
+        {"gradient_id": "seed-2", "target": "agent.reviewer.prompt",
+         "task_class": "tcB", "confidence": 0.92,
+         "suggested_change": "fix-B", "signal": "sig-B", "evidence": "ev-B"},
+        {"gradient_id": "seed-3", "target": "agent.reviewer.prompt",
+         "task_class": "tcC", "confidence": 0.81,
+         "suggested_change": "fix-C", "signal": "sig-C", "evidence": "ev-C"},
+        {"gradient_id": "seed-4", "target": "verifier.lens-exists",
+         "task_class": "tcD", "confidence": 0.88,
+         "suggested_change": "fix-D", "signal": "sig-D", "evidence": "ev-D"},
+        {"gradient_id": "seed-5", "target": "verifier.lens-exists",
+         "task_class": "tcE", "confidence": 0.70,
+         "suggested_change": "fix-E", "signal": "sig-E", "evidence": "ev-E"},
+        {"gradient_id": "seed-6", "target": "verifier.lens-exists",
+         "task_class": "tcF", "confidence": 0.83,
+         "suggested_change": "fix-F", "signal": "sig-F", "evidence": "ev-F"},
+        # Excluded-class sentinel — must NOT seed a cluster on its own.
+        {"gradient_id": "seed-excl", "target": "agent.reviewer.prompt",
+         "task_class": "__cross_class__", "confidence": 0.99,
+         "suggested_change": "X", "signal": "X", "evidence": "X"},
+    ]
+
+    bash_db, py_db = _seed_db_with_copy(tmp_path_factory, seed_rows)
+
+    rb = _bash(bash_db, "cross_epic_gradient_promote")
+    assert rb.returncode == 0, rb.stderr
+
+    py_returned, py_stdout = _promote_capture(py_db)
+
+    # Stdout (integer count): 2 promotions (agent.reviewer.prompt + verifier.lens-exists).
+    assert rb.stdout == py_stdout == "2\n"
+    assert py_returned == 2
+
+    # Row lists: same length (7 seeded + 2 promoted = 9 on each side).
+    bash_rows = _all_rows(bash_db)
+    py_rows = _all_rows(py_db)
+    assert len(bash_rows) == len(py_rows) == 9, (
+        f"row count drift: bash={len(bash_rows)} py={len(py_rows)}"
+    )
+
+    # Byte-equality on each paired row. Compare by gradient_id order.
+    for b_row, p_row in zip(bash_rows, py_rows):
+        _row_parity(b_row, p_row)

--- a/tests/unit/test_mid_node_injector_py.py
+++ b/tests/unit/test_mid_node_injector_py.py
@@ -1,0 +1,440 @@
+"""Parity gate: mini_ork.ported.mid_node_injector vs lib/mid_node_injector.sh.
+
+Each test invokes the LIVE bash subprocess (sourcing lib/mid_node_injector.sh
+in a single ``bash -c`` block so the functions are visible to the caller)
+on the same inputs as the Python port and asserts byte-identical output.
+No mocks, no hardcoded expected outputs — expected is always derived from
+a control bash invocation that shares the inputs.
+
+Seven cases (above the kickoff's >=6 floor):
+  (1) format_claude_user_msg defaults       — bash vs py, sev='info', src='operator'
+  (2) format_claude_user_msg custom         — bash vs py, sev='warn', src='dashboard:abc'
+  (3) format_claude_user_msg special chars  — msg with quotes / newlines / Unicode
+                                                (she said "hi"\nمرحبا) — exercises
+                                                jq --arg vs json.dumps escaping
+  (4) format_codex_prompt defaults          — bash vs py, sev='info', src='operator'
+  (5) format_codex_prompt custom            — bash vs py, sev='critical', src='operator-cli'
+  (6) claude_tick db row diff               — seed 3 rows (one matched, one wrong
+                                                role, one expired), call claude_tick,
+                                                assert (a) fifo contents == bash-format
+                                                helper output for matched row, (b)
+                                                operator_steering rows where
+                                                consumed_at IS NOT NULL match the
+                                                matched set, (c) zero diff on full
+                                                SELECT projection
+  (7) codex_tick db row diff                — seed 2 rows, write session_id file,
+                                                call codex_tick, assert prompts list
+                                                == bash-format helper output, assert
+                                                consumed_at DB state matches
+
+Environment isolation: same pattern as test_operator_steering_py.py —
+each test sets MINI_ORK_DB / MINI_ORK_HOME to a temp DB initialised by
+db/init.sh via ``_point_python_env(monkeypatch, db, home)`` so the
+Python port doesn't read the shell pytest's main repo state.db.
+
+Fifo reader: bash ``printf >fifo_in`` will block forever if no reader
+is attached; ``open('a').write()`` would do the same. To avoid hangs,
+the claude_tick test launches a background ``cat fifo > out &`` reader
+before the tick so writes don't block.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mid_node_injector as mni  # noqa: E402
+
+SH = REPO / "lib" / "mid_node_injector.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures + helpers
+# ─────────────────────────────────────────────────────────────────────────────
+def _init_db(tmp_path_factory, *, name: str = "home") -> tuple[str, str]:
+    """Spin up a fresh mini-ork SQLite DB via db/init.sh.
+
+    Returns (db_path, home_dir). tmp_path_factory guarantees a unique
+    sub-directory per call so two DBs in the same test don't collide.
+    """
+    home = tmp_path_factory.mktemp(name)
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp, str(home)
+
+
+def _point_python_env(monkeypatch: pytest.MonkeyPatch, db: str, home: str) -> None:
+    """Redirect the Python process's ``_resolve_db`` to the temp db."""
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    monkeypatch.setenv("MINI_ORK_HOME", home)
+
+
+def _bash_format_claude(message: str, severity: str, source: str) -> str:
+    """Invoke live bash ``_mid_injector_format_claude_user_msg`` and return its stdout.
+
+    The bash function is defined inside lib/mid_node_injector.sh as a
+    private (underscore-prefixed) helper; sourcing the lib exposes it.
+    """
+    # Escape single quotes for the bash -c wrapper. Pass the three
+    # args via positional $1/$2/$3 (set via shell assignments) to
+    # avoid quoting headaches with multi-line strings.
+    wrapper = (
+        f'. "{SH}"\n'
+        f'_mid_injector_format_claude_user_msg "$1" "$2" "$3"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", wrapper, "_", message, severity, source],
+        capture_output=True, text=True, check=True,
+    )
+    return r.stdout.rstrip("\n")
+
+
+def _bash_format_codex(message: str, severity: str, source: str) -> str:
+    """Invoke live bash ``_mid_injector_format_codex_prompt`` and return its stdout."""
+    wrapper = (
+        f'. "{SH}"\n'
+        f'_mid_injector_format_codex_prompt "$1" "$2" "$3"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", wrapper, "_", message, severity, source],
+        capture_output=True, text=True, check=True,
+    )
+    # bash printf ends with a literal \n (the trailing "guidance." has no
+    # newline); strip exactly one trailing newline if present so the
+    # comparison with Python's f-string (which has no \n) is clean.
+    return r.stdout.rstrip("\n")
+
+
+def _seed_row(
+    db: str,
+    *,
+    run_id: str | None,
+    role_target: str,
+    severity: str,
+    message: str,
+    source: str = "",
+    confidence: float = 0.8,
+    created_at: int | None = None,
+    expires_at: int | None = None,
+    consumed_at: int | None = None,
+) -> int:
+    """Direct-SQL insert (bypasses emit so we can craft expired rows)."""
+    now = int(time.time() * 1000)
+    if created_at is None:
+        created_at = now
+    if expires_at is None:
+        expires_at = now + 3600 * 1000
+    con = sqlite3.connect(db)
+    try:
+        cur = con.execute(
+            """INSERT INTO operator_steering
+                 (run_id, role_target, severity, message, source,
+                  confidence, created_at, expires_at, consumed_at)
+               VALUES (NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?)""",
+            (
+                run_id if run_id is not None else "",
+                role_target,
+                severity,
+                message,
+                source,
+                float(confidence),
+                int(created_at),
+                int(expires_at),
+                consumed_at,
+            ),
+        )
+        con.commit()
+        assert cur.lastrowid is not None
+        return int(cur.lastrowid)
+    finally:
+        con.close()
+
+
+def _read_all_rows(db: str) -> list[dict]:
+    con = sqlite3.connect(db)
+    try:
+        rows = con.execute(
+            """SELECT id, run_id, role_target, severity, message, source,
+                      confidence, created_at, expires_at, consumed_at
+                 FROM operator_steering
+                ORDER BY id"""
+        ).fetchall()
+    finally:
+        con.close()
+    return [
+        {
+            "id": r[0], "run_id": r[1], "role_target": r[2], "severity": r[3],
+            "message": r[4], "source": r[5], "confidence": r[6],
+            "created_at": r[7], "expires_at": r[8], "consumed_at": r[9],
+        }
+        for r in rows
+    ]
+
+
+def _consumed_ids(db: str) -> set[int]:
+    con = sqlite3.connect(db)
+    try:
+        rows = con.execute(
+            "SELECT id FROM operator_steering WHERE consumed_at IS NOT NULL"
+        ).fetchall()
+    finally:
+        con.close()
+    return {int(r[0]) for r in rows}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (1) format_claude_user_msg defaults — bash vs python
+# ─────────────────────────────────────────────────────────────────────────────
+def test_format_claude_default_parity():
+    """Bash ``_mid_injector_format_claude_user_msg`` defaults (sev='info',
+    src='operator') matches Python ``format_claude_user_msg`` byte-for-byte."""
+    msg = "hello from operator"
+    bash_out = _bash_format_claude(msg, "info", "operator")
+    py_out = mni.format_claude_user_msg(msg, "info", "operator")
+    assert py_out == bash_out, f"format_claude_user_msg divergence:\n  bash: {bash_out!r}\n  py:   {py_out!r}"
+    # Sanity: the output is valid JSON with the expected shape.
+    parsed = json.loads(py_out)
+    assert parsed["type"] == "user"
+    assert parsed["message"]["role"] == "user"
+    assert parsed["message"]["content"][0]["type"] == "text"
+    assert parsed["message"]["content"][0]["text"] == "OPERATOR STEERING [info] (from operator): hello from operator"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (2) format_claude_user_msg custom severity/source
+# ─────────────────────────────────────────────────────────────────────────────
+def test_format_claude_custom_parity():
+    """Custom severity='warn' and source='dashboard:abc' exercise the
+    format-string interpolation path (both sides build the same body
+    then JSON-encode)."""
+    msg = "please review PR #42"
+    bash_out = _bash_format_claude(msg, "warn", "dashboard:abc")
+    py_out = mni.format_claude_user_msg(msg, "warn", "dashboard:abc")
+    assert py_out == bash_out
+    parsed = json.loads(py_out)
+    assert parsed["message"]["content"][0]["text"] == "OPERATOR STEERING [warn] (from dashboard:abc): please review PR #42"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (3) format_claude_user_msg special chars — quotes, newlines, Unicode
+# ─────────────────────────────────────────────────────────────────────────────
+def test_format_claude_special_chars_parity():
+    """jq ``--arg`` and ``json.dumps`` differ slightly in how they handle
+    control characters and Unicode. This case exercises the hardest
+    overlap: a message with embedded double-quotes, an escaped newline,
+    and a non-ASCII run. If parity breaks here, document the chosen
+    mode in the module docstring (per the risk note in the plan)."""
+    msg = 'she said "hi"\nمرحبا'
+    bash_out = _bash_format_claude(msg, "info", "operator")
+    py_out = mni.format_claude_user_msg(msg, "info", "operator")
+    assert py_out == bash_out, (
+        f"special-chars divergence:\n  bash: {bash_out!r}\n  py:   {py_out!r}"
+    )
+    # Both sides should parse as valid JSON.
+    py_parsed = json.loads(py_out)
+    bash_parsed = json.loads(bash_out)
+    assert py_parsed == bash_parsed
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (4) format_codex_prompt defaults
+# ─────────────────────────────────────────────────────────────────────────────
+def test_format_codex_default_parity():
+    """Bash ``_mid_injector_format_codex_prompt`` matches Python
+    ``format_codex_prompt`` byte-for-byte. Bash printf includes a
+    literal ``\\n`` between body and 'Continue...' suffix; Python
+    mirrors via the f-string \\n separator."""
+    msg = "continue with the rewrite"
+    bash_out = _bash_format_codex(msg, "info", "operator")
+    py_out = mni.format_codex_prompt(msg, "info", "operator")
+    assert py_out == bash_out, f"format_codex_prompt divergence:\n  bash: {bash_out!r}\n  py:   {py_out!r}"
+    assert py_out.endswith("Continue your task with this guidance.")
+    assert "\n" in py_out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (5) format_codex_prompt custom severity/source
+# ─────────────────────────────────────────────────────────────────────────────
+def test_format_codex_custom_parity():
+    """Custom severity='critical' and source='operator-cli' exercise the
+    printf interpolation path on both sides."""
+    msg = "abort the dispatch cycle"
+    bash_out = _bash_format_codex(msg, "critical", "operator-cli")
+    py_out = mni.format_codex_prompt(msg, "critical", "operator-cli")
+    assert py_out == bash_out
+    assert py_out.startswith("OPERATOR STEERING [critical] (from operator-cli): abort the dispatch cycle")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (6) claude_tick — DB row diff against live bash harness equivalent
+# ─────────────────────────────────────────────────────────────────────────────
+def test_claude_tick_db_diff(tmp_path_factory, monkeypatch):
+    """Seed 3 rows for run_id='r-cl' role='implementer':
+      row A (matched, role=implementer, unexpired)         → consumed
+      row B (wrong role, role=reviewer)                    → not consumed
+      row C (expired)                                     → not consumed
+
+    claude_tick must:
+      (a) write exactly A's formatted line to the fifo (B/C filtered out)
+      (b) mark A's consumed_at; B/C's consumed_at stay NULL
+      (c) project operator_steering to a deterministic row set and
+          confirm A is consumed, B/C are not.
+
+    No bash subprocess for the loop body itself — bash ``_mid_injector_claude_loop``
+    is a daemon that calls ``operator_steering_fetch_for`` (which is
+    parity-tested in test_operator_steering_py.py) then writes to the
+    fifo. We assert against the deterministic sidecar surface
+    (fifo + DB projection) which is the parity surface the kickoff
+    requires.
+    """
+    db, home = _init_db(tmp_path_factory, name="claude_tick")
+    _point_python_env(monkeypatch, db, home)
+
+    now = int(time.time() * 1000)
+    matched_id = _seed_row(
+        db, run_id="r-cl", role_target="implementer", severity="info",
+        message="please add the input guard", source="dashboard",
+    )
+    wrong_role_id = _seed_row(
+        db, run_id="r-cl", role_target="reviewer", severity="info",
+        message="reviewer-only steering",
+    )
+    expired_id = _seed_row(
+        db, run_id="r-cl", role_target="implementer", severity="info",
+        message="expired steering",
+        created_at=now - 7200 * 1000, expires_at=now - 3600 * 1000,
+    )
+
+    # Set up a fifo + a background reader so the open('a').write() doesn't
+    # block on EPIPE/EPERM. We use cat in the background; it's portable
+    # across the bash test harness host (verified by test_operator_steering_py.py).
+    fifo = str(Path(home) / "fifo_in")
+    out = str(Path(home) / "fifo_out")
+    os.mkfifo(fifo)
+    reader = subprocess.Popen(
+        ["bash", "-c", f"cat {fifo} > {out}"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    # Give the reader a moment to open the write end of the fifo.
+    time.sleep(0.05)
+
+    try:
+        written = mni.claude_tick(fifo, "r-cl", "implementer")
+        # Wait briefly for the reader to drain the fifo.
+        time.sleep(0.05)
+    finally:
+        reader.terminate()
+        try:
+            reader.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            reader.kill()
+
+    assert written == 1, f"claude_tick wrote {written} rows, expected 1 (only row A matches)"
+
+    # (a) fifo contents == bash-format helper output for the matched row.
+    fifo_contents = Path(out).read_text(encoding="utf-8")
+    expected_line = _bash_format_claude(
+        "please add the input guard", "info", "dashboard"
+    )
+    expected_written = expected_line + "\n"
+    assert fifo_contents == expected_written, (
+        f"fifo contents divergence:\n  got:  {fifo_contents!r}\n  want: {expected_written!r}"
+    )
+
+    # (b) consumed_at set only for A.
+    consumed = _consumed_ids(db)
+    assert matched_id in consumed
+    assert wrong_role_id not in consumed
+    assert expired_id not in consumed
+
+    # (c) Full SELECT projection — diff the relevant fields row-by-row.
+    all_rows = _read_all_rows(db)
+    by_id = {r["id"]: r for r in all_rows}
+    assert by_id[matched_id]["consumed_at"] is not None
+    assert by_id[wrong_role_id]["consumed_at"] is None
+    assert by_id[expired_id]["consumed_at"] is None
+    # Message + role + run_id preserved through consume (mark-only update).
+    assert by_id[matched_id]["message"] == "please add the input guard"
+    assert by_id[matched_id]["role_target"] == "implementer"
+    assert by_id[matched_id]["run_id"] == "r-cl"
+    # Float confidence round-tripped; bash + python write the same float.
+    assert abs(by_id[matched_id]["confidence"] - 0.8) < 1e-6
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (7) codex_tick — DB row diff with session_id present
+# ─────────────────────────────────────────────────────────────────────────────
+def test_codex_tick_db_diff(tmp_path_factory, monkeypatch):
+    """Seed 2 rows for run_id='r-cx' role='implementer'. Write a
+    session_id file. codex_tick must:
+      (a) return written=2 with prompts[0] == bash format helper output
+      (b) write the two prompts (plus trailing newline each) to
+          {fork_out_dir}/codex-fork.out
+      (c) mark both rows consumed (consumed_at IS NOT NULL)
+    """
+    db, home = _init_db(tmp_path_factory, name="codex_tick")
+    _point_python_env(monkeypatch, db, home)
+
+    id_1 = _seed_row(
+        db, run_id="r-cx", role_target="implementer", severity="info",
+        message="first steering", source="operator",
+    )
+    id_2 = _seed_row(
+        db, run_id="r-cx", role_target="implementer", severity="warn",
+        message="second steering", source="dashboard",
+    )
+
+    session_id_file = str(Path(home) / "session_id")
+    Path(session_id_file).write_text("abc123def\n", encoding="utf-8")
+    fork_out_dir = str(Path(home) / "fork_out")
+
+    result = mni.codex_tick(session_id_file, "r-cx", "implementer", fork_out_dir)
+
+    assert result["written"] == 2
+    assert result["session_id"] == "abc123def"
+    assert len(result["prompts"]) == 2
+
+    # (a) prompts == bash format helper output for the matched rows,
+    # in the order fetch_for returns them (severity DESC then confidence
+    # DESC then created_at DESC; both rows here have distinct severities
+    # so 'warn' comes before 'info').
+    expected_prompt_warn = _bash_format_codex("second steering", "warn", "dashboard")
+    expected_prompt_info = _bash_format_codex("first steering", "info", "operator")
+    assert result["prompts"][0] == expected_prompt_warn, (
+        f"prompts[0] divergence:\n  got:  {result['prompts'][0]!r}\n  want: {expected_prompt_warn!r}"
+    )
+    assert result["prompts"][1] == expected_prompt_info, (
+        f"prompts[1] divergence:\n  got:  {result['prompts'][1]!r}\n  want: {expected_prompt_info!r}"
+    )
+
+    # (b) codex-fork.out has both prompts + trailing newlines.
+    fork_out_path = Path(fork_out_dir) / "codex-fork.out"
+    expected_out = expected_prompt_warn + "\n" + expected_prompt_info + "\n"
+    assert fork_out_path.read_text(encoding="utf-8") == expected_out
+
+    # (c) Both rows marked consumed.
+    consumed = _consumed_ids(db)
+    assert id_1 in consumed
+    assert id_2 in consumed
+    # Sanity: full row projection preserved.
+    rows = _read_all_rows(db)
+    by_id = {r["id"]: r for r in rows}
+    assert by_id[id_1]["message"] == "first steering"
+    assert by_id[id_2]["message"] == "second steering"
+    assert by_id[id_1]["role_target"] == "implementer"
+    assert by_id[id_2]["role_target"] == "implementer"
+    assert abs(by_id[id_1]["confidence"] - 0.8) < 1e-6
+    assert abs(by_id[id_2]["confidence"] - 0.8) < 1e-6

--- a/tests/unit/test_runs_tracker_py.py
+++ b/tests/unit/test_runs_tracker_py.py
@@ -1,0 +1,521 @@
+"""Parity gate: mini_ork.ported.runs_tracker vs lib/runs-tracker.sh.
+
+Each test invokes the LIVE bash subprocess (sqlite3 / git / jq from PATH,
+or a sub-bash that sources `lib/runs-tracker.sh`) against a temp DB
+initialized by `db/init.sh` and asserts byte-identical / column-identical
+output. No mocks, no hardcoded expected outputs — expected is always
+derived from a control bash invocation that shares the inputs.
+
+Test surface (>= 6 cases, kickoff requires at least this many):
+
+  (a) ensure_schema              — bash + Python idempotent CREATE / ADD
+                                    COLUMN, no errors, schema unchanged
+  (b) sql_escape                 — single-quote escape (bash `sed s/'/''/g`)
+  (c) resolve_claude_session_id  — absent file → '', present file → session_id
+  (d) open                       — row diff: bash vs Python across all
+                                    orch_dispatches columns (timestamps
+                                    matched by regex, not by equality)
+  (e) update_progress            — rationale column byte-equality after two
+                                    update_progress calls ('iter:FAIL | iter:WARN')
+  (f) close                      — APPROVE → completed, FAIL → cancelled,
+                                    rationale ends in 'final:<verdict>'
+
+Each test that needs sqlite3 / git / jq / bash skips (not fails) when the
+tool is missing, matching the reflection_refiner parity test pattern.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import runs_tracker as rt  # noqa: E402
+
+SH = REPO / "lib" / "runs-tracker.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$")
+
+
+def _which(*tools: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for t in tools:
+        p = shutil.which(t)
+        if not p:
+            pytest.skip(f"required tool not on PATH: {t}")
+        out[t] = p
+    return out
+
+
+def _init_db(tmp_path: Path) -> str:
+    """Run db/init.sh against a fresh temp DB and return its path."""
+    home = tmp_path / ".mini-ork-home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp,
+             "HOME": str(tmp_path)},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def _git_worktree(tmp_path: Path) -> str:
+    """Create a real git worktree (one commit, on a branch) for `git symbolic-ref`."""
+    repo = tmp_path / "wt"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "f").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "f"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "-b", "feat-x"], check=True)
+    return str(repo)
+
+
+def _row_dict(db_path: str, row_id: int) -> dict:
+    """SELECT * from orch_dispatches WHERE id=? and return as dict (None → '')."""
+    con = sqlite3.connect(db_path)
+    try:
+        cols = [r[1] for r in con.execute("PRAGMA table_info(orch_dispatches);").fetchall()]
+        row = con.execute(
+            f"SELECT * FROM orch_dispatches WHERE id=?;", (row_id,)
+        ).fetchone()
+    finally:
+        con.close()
+    if row is None:
+        return {}
+    out: dict = {}
+    for col, val in zip(cols, row):
+        out[col] = "" if val is None else val
+    return out
+
+
+def _diff_row_columns(
+    bash_row: dict, py_row: dict, *, exclude: tuple[str, ...] = ("id",)
+) -> list[str]:
+    """Return column-level diff messages. Excludes `id` (rows may differ) and
+    any caller-listed excludes. Timestamps are checked by regex match against
+    the millisecond-precision Z-format. When both ports record NULL for a
+    timestamp column, the value is the empty string in both dicts and the
+    check passes (no spurious diff)."""
+    issues: list[str] = []
+    for col in (set(bash_row) | set(py_row)) - set(exclude):
+        if col not in bash_row or col not in py_row:
+            issues.append(f"missing col {col!r}")
+            continue
+        b, p = bash_row[col], py_row[col]
+        if col in ("created_at", "updated_at", "closed_at"):
+            # Both empty → both NULL → match.
+            if not b and not p:
+                continue
+            if not (TS_RE.match(b or "") and TS_RE.match(p or "")):
+                issues.append(f"{col}: bash={b!r} py={p!r}")
+            continue
+        if b != p:
+            issues.append(f"{col}: bash={b!r} != py={p!r}")
+    return issues
+
+
+def _shell_env(db_path: str, tmp_path: Path, **extra) -> dict:
+    return {
+        **os.environ,
+        "MINI_ORK_DB": db_path,
+        "MINI_ORK_HOME": str(tmp_path),
+        "HOME": str(tmp_path),
+        "REPO": str(REPO),
+        **extra,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) ensure_schema — idempotency
+# ─────────────────────────────────────────────────────────────────────────────
+def test_ensure_schema_idempotent(tmp_path):
+    """Live bash `mo_runs_ensure_schema` + Python `ensure_schema` both run
+    idempotently against a fresh db/init.sh-populated DB; columns and table
+    end up identical; second call is a no-op in both ports."""
+    _which("bash", "sqlite3")
+    db_path = _init_db(tmp_path)
+
+    # Baseline schema introspection.
+    def schema_signature(p: str) -> dict[str, tuple]:
+        con = sqlite3.connect(p)
+        try:
+            cols = tuple(
+                (r[1], r[2])  # (name, type)
+                for r in con.execute("PRAGMA table_info(orch_dispatches);").fetchall()
+            )
+            runs_cols = tuple(
+                (r[1], r[2])
+                for r in con.execute("PRAGMA table_info(runs);").fetchall()
+            )
+            return {
+                "orch_dispatches": cols,
+                "runs": runs_cols,
+            }
+        finally:
+            con.close()
+
+    base = schema_signature(db_path)
+
+    # 1st call: bash.
+    bash_call = (
+        f'. "{SH}"\n'
+        f'mo_runs_ensure_schema\n'
+    )
+    r1 = subprocess.run(
+        ["bash", "-c", bash_call],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    )
+    assert r1.returncode == 0
+
+    # 2nd call: bash.
+    r2 = subprocess.run(
+        ["bash", "-c", bash_call],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    )
+    assert r2.returncode == 0
+
+    after_bash = schema_signature(db_path)
+    assert after_bash == base, f"bash mutated schema: {after_bash} != {base}"
+
+    # 1st call: python.
+    rt.ensure_schema(db_path)
+    after_py1 = schema_signature(db_path)
+    assert after_py1 == base, f"py mutated schema: {after_py1} != {base}"
+
+    # 2nd call: python (no-op due to per-DB guard).
+    rt.ensure_schema(db_path)
+    after_py2 = schema_signature(db_path)
+    assert after_py2 == base
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) sql_escape — bash sed s/'/''/g vs Python str.replace
+# ─────────────────────────────────────────────────────────────────────────────
+def test_sql_escape_parity():
+    """Python `sql_escape` matches the live bash `mo_runs_sql_escape` byte-for-byte
+    across empty / plain / single-quote / backslash inputs.
+
+    A literal NUL byte is intentionally omitted — bash's `printf '%s'` truncates
+    at NUL (C-string semantics), so the live bash function drops NULs in
+    practice; the Python port retains them on purpose for direct string→SQL
+    callers. The parity contract covers printable ASCII identifiers (verdicts,
+    run_dir, run-stamps) which is the realistic surface."""
+    _which("bash", "sed")
+
+    inputs = [
+        "",
+        "no-quotes",
+        "it's",
+        "two'quotes''in'one",
+        "back\\slash",
+        "tail-quote'",
+        "'leading-quote",
+        "mixed 'quote' and back\\slash",
+    ]
+
+    # Drive the bash function with a single sed that mirrors mo_runs_sql_escape:
+    #   printf '%s' "$1" | sed "s/'/''/g"
+    bash_script = (
+        "shopt -s nocasematch 2>/dev/null; "
+        "printf '%s' \"$1\" | sed \"s/'/''/g\"\n"
+    )
+    for val in inputs:
+        r = subprocess.run(
+            ["bash", "-c", bash_script, "_", val],
+            capture_output=True, text=True, check=True,
+        )
+        bash_out = r.stdout  # bash omits trailing newline
+        py_out = rt.sql_escape(val)
+        assert py_out == bash_out, (
+            f"sql_escape mismatch for {val!r}: py={py_out!r} bash={bash_out!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) resolve_claude_session_id — absent file → '', present file → session_id
+# ─────────────────────────────────────────────────────────────────────────────
+def test_resolve_claude_session_id_parity(tmp_path):
+    """Live bash `mo_runs_resolve_claude_session_id` vs Python.
+
+    Two sub-cases: (i) status file absent → both return ''; (ii) status
+    file present with `session_id` → both return the session_id value.
+    """
+    _which("bash")
+
+    # (i) absent status file
+    bash_wrapper = (
+        f'. "{SH}"\n'
+        # HOME is set to tmp_path by env; .claude/status/ doesn't exist.
+        'mo_runs_resolve_claude_session_id\n'
+    )
+    r_abs = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**_shell_env("unused", tmp_path), "ZELLIJ_SESSION_NAME": "zellij-x"},
+        capture_output=True, text=True, check=True,
+    )
+    bash_abs = r_abs.stdout.rstrip("\n")
+    py_abs = rt.resolve_claude_session_id("zellij-x")
+    assert bash_abs == "" == py_abs, (
+        f"absent-file: bash={bash_abs!r} py={py_abs!r}"
+    )
+
+    # (ii) present status file with session_id
+    status_dir = tmp_path / ".claude" / "status"
+    status_dir.mkdir(parents=True)
+    sentinel = "sess-uuid-12345-deadbeef"
+    (status_dir / "zellij-y.json").write_text(
+        f'{{"session_id": "{sentinel}"}}\n', encoding="utf-8"
+    )
+    r_present = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**_shell_env("unused", tmp_path), "ZELLIJ_SESSION_NAME": "zellij-y"},
+        capture_output=True, text=True, check=True,
+    )
+    bash_present = r_present.stdout.rstrip("\n")
+    # Pass home_dir=tmp_path so the port's path-resolution matches the
+    # bash subprocess's HOME-driven ~ expansion.
+    py_present = rt.resolve_claude_session_id("zellij-y", home_dir=tmp_path)
+    assert bash_present == sentinel == py_present, (
+        f"present-file: bash={bash_present!r} py={py_present!r}"
+    )
+
+    # (iii) env-var fallback: ZELLIJ (without the SESSION_NAME suffix) is honored
+    # when ZELLIJ_SESSION_NAME is unset. bash: local zellij="${ZELLIJ_SESSION_NAME:-${ZELLIJ:-}}"
+    r_env_fallback = subprocess.run(
+        ["bash", "-c", bash_wrapper],
+        env={**_shell_env("unused", tmp_path), "ZELLIJ": "zellij-env-only"},
+        capture_output=True, text=True, check=True,
+    )
+    bash_env_only = r_env_fallback.stdout.rstrip("\n")
+    py_env_only = rt.resolve_claude_session_id()  # no zellij arg → reads env
+    assert bash_env_only == "" == py_env_only, (
+        f"env-fallback (no file for zellij-env-only): "
+        f"bash={bash_env_only!r} py={py_env_only!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) open — full row diff after live bash + Python insert
+# ─────────────────────────────────────────────────────────────────────────────
+def test_open_row_diff_parity(tmp_path):
+    """Live bash `mo_runs_open epic wt` vs Python `open(db, epic, wt)`.
+
+    Both ports insert into the SAME temp DB. bash returns lastrowid via
+    the bash `tail -1` trick; Python returns cursor.lastrowid via the same
+    connection. We SELECT * both rows and compare column-by-column. The
+    `id` column differs across rows by construction (sequential inserts);
+    other columns must match byte-for-byte (timestamps verified by regex
+    since they are millisecond-precision NOW())."""
+    _which("bash", "sqlite3", "git")
+    db_path = _init_db(tmp_path)
+    wt = _git_worktree(tmp_path)
+
+    bash_call = (
+        f'. "{SH}"\n'
+        # JOB_ID unset so group_id branch resolves to NULL
+        # ZELLIJ_SESSION_NAME unset so zellij_session_name resolves to NULL
+        # HOME → tmp_path (.claude/status missing) so claude_session_id NULL
+        f'mo_runs_open "epic-runs-d" "{wt}"\n'
+    )
+    r_bash = subprocess.run(
+        ["bash", "-c", bash_call],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    )
+    bash_id = int(r_bash.stdout.strip().splitlines()[-1])
+
+    py_id = rt.open(db_path, "epic-runs-d", wt)
+
+    assert bash_id > 0 and py_id > 0 and bash_id != py_id
+
+    bash_row = _row_dict(db_path, bash_id)
+    py_row = _row_dict(db_path, py_id)
+
+    issues = _diff_row_columns(bash_row, py_row)
+    assert not issues, "\n".join(issues)
+
+    # Sanity: column-level expectations (per plan: NULL branches for
+    # group_id / claude_session_id / zellij_session_name when JOB_ID and
+    # ZELLIJ unset; status='in_progress'; rationale NULL).
+    for key, want in [
+        ("parent_dispatch_id", ""),
+        ("epic_id", "epic-runs-d"),
+        ("group_id", ""),
+        ("dispatched_by", "claude-session"),
+        ("claude_session_id", ""),
+        ("zellij_session_name", ""),
+        ("status", "in_progress"),
+        ("rationale", ""),
+        ("closed_at", ""),
+    ]:
+        assert py_row.get(key) == want, f"py {key}: got {py_row.get(key)!r} want {want!r}"
+    assert py_row.get("branch", "") == ""  # not stored
+    assert py_row["run_dir"].startswith("mini-ork/unknown/epic-runs-d/")
+    assert TS_RE.match(py_row["created_at"]), py_row["created_at"]
+    assert TS_RE.match(py_row["updated_at"]), py_row["updated_at"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) update_progress — rationale column byte-equality after 2 calls
+# ─────────────────────────────────────────────────────────────────────────────
+def test_update_progress_rationale_diff(tmp_path):
+    """Live bash `mo_runs_update_progress` vs Python `update_progress`:
+    open one row, call twice with verdicts ('FAIL', 'WARN'), assert the
+    `rationale` column is `iter:FAIL | iter:WARN` exactly across ports."""
+    _which("bash", "sqlite3", "git")
+    db_path = _init_db(tmp_path)
+    wt = _git_worktree(tmp_path)
+
+    # bash open.
+    bash_call = (
+        f'. "{SH}"\n'
+        f'mo_runs_open "epic-runs-e" "{wt}"\n'
+    )
+    r_bash_open = subprocess.run(
+        ["bash", "-c", bash_call],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    )
+    bash_id = int(r_bash_open.stdout.strip().splitlines()[-1])
+    bash_update = (
+        f'. "{SH}"\n'
+        f'mo_runs_update_progress "{bash_id}" "FAIL"\n'
+        f'mo_runs_update_progress "{bash_id}" "WARN"\n'
+    )
+    subprocess.run(
+        ["bash", "-c", bash_update],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    )
+
+    # python open + update.
+    py_id = rt.open(db_path, "epic-runs-e", wt)
+    rt.update_progress(db_path, py_id, "FAIL")
+    rt.update_progress(db_path, py_id, "WARN")
+
+    bash_row = _row_dict(db_path, bash_id)
+    py_row = _row_dict(db_path, py_id)
+
+    assert bash_row["rationale"] == py_row["rationale"] == "iter:FAIL | iter:WARN"
+    # updated_at must match the Z-format (parity verified via regex, not equality)
+    assert TS_RE.match(bash_row["updated_at"])
+    assert TS_RE.match(py_row["updated_at"])
+    # The bash and python rows were updated at different times (sequential
+    # calls), so updated_at values are not expected to be byte-equal.
+    assert bash_row["updated_at"] != py_row["updated_at"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) close — APPROVE → completed, FAIL → cancelled, rationale ends in 'final:'
+# ─────────────────────────────────────────────────────────────────────────────
+def test_close_status_and_rationale_diff(tmp_path):
+    """Live bash `mo_runs_close` vs Python `close`: APPROVE → completed,
+    FAIL → cancelled, rationale ends in `final:<verdict>` byte-for-byte
+    across ports."""
+    _which("bash", "sqlite3", "git")
+    db_path = _init_db(tmp_path)
+    wt = _git_worktree(tmp_path)
+
+    # ---- APPROVE → completed
+    bash_id_approve = int(subprocess.run(
+        ["bash", "-c", f'. "{SH}"\nmo_runs_open "epic-approve" "{wt}"\n'],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    ).stdout.strip().splitlines()[-1])
+    subprocess.run(
+        ["bash", "-c", (
+            f'. "{SH}"\n'
+            f'mo_runs_close "{bash_id_approve}" "epic-approve" "APPROVE"\n'
+        )],
+        env=_shell_env(db_path, tmp_path), capture_output=True, text=True, check=True,
+    )
+
+    py_id_approve = rt.open(db_path, "epic-approve", wt)
+    rt.close(db_path, py_id_approve, "epic-approve", "APPROVE")
+
+    bash_approve_row = _row_dict(db_path, bash_id_approve)
+    py_approve_row = _row_dict(db_path, py_id_approve)
+
+    assert bash_approve_row["status"] == "completed" == py_approve_row["status"]
+    assert bash_approve_row["rationale"] == "final:APPROVE" == py_approve_row["rationale"]
+    assert TS_RE.match(bash_approve_row["closed_at"])
+    assert TS_RE.match(py_approve_row["closed_at"])
+
+    # ---- FAIL → cancelled
+    bash_id_fail = int(subprocess.run(
+        ["bash", "-c", f'. "{SH}"\nmo_runs_open "epic-fail" "{wt}"\n'],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    ).stdout.strip().splitlines()[-1])
+    subprocess.run(
+        ["bash", "-c", (
+            f'. "{SH}"\n'
+            f'mo_runs_close "{bash_id_fail}" "epic-fail" "FAIL"\n'
+        )],
+        env=_shell_env(db_path, tmp_path), capture_output=True, text=True, check=True,
+    )
+
+    py_id_fail = rt.open(db_path, "epic-fail", wt)
+    rt.close(db_path, py_id_fail, "epic-fail", "FAIL")
+
+    bash_fail_row = _row_dict(db_path, bash_id_fail)
+    py_fail_row = _row_dict(db_path, py_id_fail)
+
+    assert bash_fail_row["status"] == "cancelled" == py_fail_row["status"]
+    assert bash_fail_row["rationale"] == "final:FAIL" == py_fail_row["rationale"]
+    assert TS_RE.match(bash_fail_row["closed_at"])
+    assert TS_RE.match(py_fail_row["closed_at"])
+
+    # ---- MERGED + SALVAGED also map to completed
+    bash_id_merged = int(subprocess.run(
+        ["bash", "-c", f'. "{SH}"\nmo_runs_open "epic-m" "{wt}"\n'],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    ).stdout.strip().splitlines()[-1])
+    subprocess.run(
+        ["bash", "-c", (
+            f'. "{SH}"\n'
+            f'mo_runs_close "{bash_id_merged}" "epic-m" "MERGED"\n'
+        )],
+        env=_shell_env(db_path, tmp_path), capture_output=True, text=True, check=True,
+    )
+    py_id_merged = rt.open(db_path, "epic-m", wt)
+    rt.close(db_path, py_id_merged, "epic-m", "MERGED")
+    bash_m = _row_dict(db_path, bash_id_merged)
+    py_m = _row_dict(db_path, py_id_merged)
+    assert bash_m["status"] == "completed" == py_m["status"]
+    assert bash_m["rationale"] == "final:MERGED" == py_m["rationale"]
+
+    bash_id_salvaged = int(subprocess.run(
+        ["bash", "-c", f'. "{SH}"\nmo_runs_open "epic-s" "{wt}"\n'],
+        env=_shell_env(db_path, tmp_path),
+        capture_output=True, text=True, check=True,
+    ).stdout.strip().splitlines()[-1])
+    subprocess.run(
+        ["bash", "-c", (
+            f'. "{SH}"\n'
+            f'mo_runs_close "{bash_id_salvaged}" "epic-s" "SALVAGED"\n'
+        )],
+        env=_shell_env(db_path, tmp_path), capture_output=True, text=True, check=True,
+    )
+    py_id_salvaged = rt.open(db_path, "epic-s", wt)
+    rt.close(db_path, py_id_salvaged, "epic-s", "SALVAGED")
+    bash_s = _row_dict(db_path, bash_id_salvaged)
+    py_s = _row_dict(db_path, py_id_salvaged)
+    assert bash_s["status"] == "completed" == py_s["status"]
+    assert bash_s["rationale"] == "final:SALVAGED" == py_s["rationale"]

--- a/tests/unit/test_steering_checkpoint_py.py
+++ b/tests/unit/test_steering_checkpoint_py.py
@@ -1,0 +1,390 @@
+"""Parity gate: mini_ork.ported.steering_checkpoint vs lib/steering_checkpoint.sh.
+
+Each test invokes the LIVE bash subprocess (sourcing lib/steering_checkpoint.sh,
+which itself sources lib/operator_steering.sh, in a single ``bash -c`` block so
+the functions are visible to the caller) on the same inputs as the Python port
+and asserts identical output — return code, sentinel/marker file presence, and
+marker/status JSON fields. No mocks, no hardcoded expected outputs: expected is
+always derived from a control bash invocation sharing the inputs.
+
+Eight cases (above the kickoff's >=6 floor):
+  (a) has_unconsumed empty run_id      → both rc=2 + stderr "run_id required"
+  (b) has_unconsumed missing db        → both rc=1
+  (c) has_unconsumed no-rows / seeded  → both rc=1 then rc=0, incl. global
+                                          NULL-run queue matching
+  (d) mark + status + clear round-trip → sentinel created then removed; marker
+                                          JSON byte-equivalent (bash vs python);
+                                          status JSON fields match
+  (e) gate with steering present       → both rc=0 + marker cleared
+  (f) gate with no steering            → both rc=2 + marker JSON keys match
+  (g) role-matching parity             → bash rc == py rc for role in
+                                          {any, planner, reviewer} incl. the
+                                          '? = any' broadcast branch (both dirs)
+  (h) DB-diff parity                   → 3 mixed run/role rows; bash and python
+                                          see the SAME subset for every probe
+
+Environment isolation (mirrors tests/unit/test_operator_steering_py.py):
+  The shell pytest runs in often has MINI_ORK_DB / MINI_ORK_HOME / MINI_ORK_RUN_DIR
+  pointed at the real repo. Each test redirects the Python process via
+  monkeypatch.setenv (auto-revert) AND builds the bash subprocess env from
+  os.environ so the monkeypatched values propagate to both sides identically.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import steering_checkpoint as sc  # noqa: E402
+
+SC_SH = REPO / "lib" / "steering_checkpoint.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+def _init_db(tmp_path_factory, *, name: str = "home") -> tuple[str, str]:
+    """Spin up a fresh mini-ork SQLite DB via db/init.sh; returns (db, home)."""
+    home = tmp_path_factory.mktemp(name)
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp, str(home)
+
+
+def _point_env(monkeypatch: pytest.MonkeyPatch, *, db: str, home: str,
+               run_dir: str | None = None) -> dict:
+    """Redirect the Python process env AND return the matching subprocess env.
+
+    Without this the port would resolve to whatever the shell pytest inherited
+    (usually the repo's real state.db / run dir), corrupting parity.
+    """
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    monkeypatch.setenv("MINI_ORK_HOME", home)
+    if run_dir is not None:
+        monkeypatch.setenv("MINI_ORK_RUN_DIR", run_dir)
+    else:
+        monkeypatch.delenv("MINI_ORK_RUN_DIR", raising=False)
+    return dict(os.environ)
+
+
+def _seed_row(
+    db: str,
+    *,
+    run_id: str | None,
+    role_target: str = "any",
+    severity: str = "info",
+    message: str = "steer",
+    source: str = "",
+    confidence: float = 0.8,
+    created_at: int | None = None,
+    expires_at: int | None = None,
+    consumed_at: int | None = None,
+) -> int:
+    """Direct-SQL insert so we can craft expired / pre-consumed / global-NULL
+    rows for the filter tests (bypasses the emit path, which lives behind a
+    separate port)."""
+    now = int(time.time() * 1000)
+    if created_at is None:
+        created_at = now
+    if expires_at is None:
+        expires_at = now + 3600 * 1000
+    con = sqlite3.connect(db)
+    try:
+        cur = con.execute(
+            """INSERT INTO operator_steering
+                 (run_id, role_target, severity, message, source,
+                  confidence, created_at, expires_at, consumed_at)
+               VALUES (NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?)""",
+            (
+                run_id if run_id is not None else "",
+                role_target, severity, message, source,
+                float(confidence), int(created_at), int(expires_at), consumed_at,
+            ),
+        )
+        con.commit()
+        assert cur.lastrowid is not None
+        return int(cur.lastrowid)
+    finally:
+        con.close()
+
+
+def _bash_has_unconsumed(env: dict, run_id: str, role: str = "any"):
+    """Run the live bash has_unconsumed; return (rc, stderr)."""
+    wrapper = (
+        f'. "{SC_SH}"\n'
+        f'mo_steering_has_unconsumed {json.dumps(run_id)} {json.dumps(role)}\n'
+        'echo "RC=$?"\n'
+    )
+    r = subprocess.run(["bash", "-c", wrapper], env=env,
+                       capture_output=True, text=True)
+    rc = int(r.stdout.strip().rsplit("RC=", 1)[1])
+    return rc, r.stderr
+
+
+def _bash_gate(env: dict, run_id: str, node_id: str = "checkpoint",
+               role: str = "any") -> int:
+    wrapper = (
+        f'. "{SC_SH}"\n'
+        f'mo_steering_checkpoint_gate {json.dumps(run_id)} {json.dumps(node_id)} {json.dumps(role)}\n'
+        'echo "RC=$?"\n'
+    )
+    r = subprocess.run(["bash", "-c", wrapper], env=env,
+                       capture_output=True, text=True)
+    return int(r.stdout.strip().rsplit("RC=", 1)[1])
+
+
+def _bash_call(env: dict, line: str) -> subprocess.CompletedProcess:
+    wrapper = f'. "{SC_SH}"\n{line}\n'
+    return subprocess.run(["bash", "-c", wrapper], env=env,
+                          capture_output=True, text=True)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) has_unconsumed empty run_id → rc=2 + stderr "run_id required"
+# ─────────────────────────────────────────────────────────────────────────────
+def test_has_unconsumed_empty_run_id_parity(tmp_path_factory, monkeypatch, capsys):
+    db, home = _init_db(tmp_path_factory)
+    env = _point_env(monkeypatch, db=db, home=home)
+
+    bash_rc, bash_err = _bash_has_unconsumed(env, "")
+    py_rc = sc.has_unconsumed("")
+    py_err = capsys.readouterr().err
+
+    assert bash_rc == py_rc == 2
+    assert "mo_steering_has_unconsumed: run_id required" in bash_err
+    assert "mo_steering_has_unconsumed: run_id required" in py_err
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) has_unconsumed missing db → rc=1
+# ─────────────────────────────────────────────────────────────────────────────
+def test_has_unconsumed_missing_db_parity(tmp_path_factory, monkeypatch):
+    home = tmp_path_factory.mktemp("nodb")
+    missing_db = str(home / "state.db")  # never created
+    assert not os.path.isfile(missing_db)
+    env = _point_env(monkeypatch, db=missing_db, home=str(home))
+
+    bash_rc, _ = _bash_has_unconsumed(env, "r-b")
+    py_rc = sc.has_unconsumed("r-b")
+
+    assert bash_rc == py_rc == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) has_unconsumed no-rows / seeded row / global NULL-run queue
+# ─────────────────────────────────────────────────────────────────────────────
+def test_has_unconsumed_rows_parity(tmp_path_factory, monkeypatch):
+    db, home = _init_db(tmp_path_factory)
+    env = _point_env(monkeypatch, db=db, home=home)
+
+    # no rows → both rc=1
+    assert _bash_has_unconsumed(env, "r-c")[0] == sc.has_unconsumed("r-c") == 1
+
+    # seed a row addressed to this run → both rc=0
+    _seed_row(db, run_id="r-c", role_target="any")
+    assert _bash_has_unconsumed(env, "r-c")[0] == sc.has_unconsumed("r-c") == 0
+
+    # a *different* run with only the run-scoped row present → still rc=1
+    assert _bash_has_unconsumed(env, "r-other")[0] == sc.has_unconsumed("r-other") == 1
+
+    # global NULL-run queue row is visible to any run → both rc=0
+    _seed_row(db, run_id=None, role_target="any", message="global")
+    assert _bash_has_unconsumed(env, "r-other")[0] == sc.has_unconsumed("r-other") == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) mark + status + clear round-trip; marker JSON byte-equivalent
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mark_status_clear_roundtrip_parity(tmp_path_factory, monkeypatch):
+    db, home = _init_db(tmp_path_factory)
+    bash_run_dir = str(tmp_path_factory.mktemp("d_bash_run"))
+    py_run_dir = str(tmp_path_factory.mktemp("d_py_run"))
+
+    # Bash side: mark, capture marker JSON, status JSON, then clear.
+    bash_env = {**os.environ, "MINI_ORK_DB": db, "MINI_ORK_HOME": home,
+                "MINI_ORK_RUN_DIR": bash_run_dir}
+    _bash_call(bash_env, 'mo_steering_checkpoint_mark "r-d" "node-7" "please advise"')
+    bash_sentinel = os.path.join(bash_run_dir, ".steering-checkpoint")
+    bash_marker = os.path.join(bash_run_dir, ".steering-checkpoint.json")
+    assert os.path.isfile(bash_sentinel) and os.path.isfile(bash_marker)
+    with open(bash_marker) as fh:
+        bash_marker_json = json.load(fh)
+    bash_status = json.loads(
+        _bash_call(bash_env, 'mo_steering_checkpoint_status "r-d"').stdout.strip()
+    )
+
+    # Python side: same operations against its own run dir.
+    _point_env(monkeypatch, db=db, home=home, run_dir=py_run_dir)
+    sc.mark("r-d", "node-7", "please advise")
+    py_sentinel = sc._sentinel_path("r-d")
+    py_marker = sc._marker_path("r-d")
+    assert os.path.isfile(py_sentinel) and os.path.isfile(py_marker)
+    with open(py_marker) as fh:
+        py_marker_json = json.load(fh)
+    py_status = sc.status("r-d")
+
+    # Marker JSON equal modulo requested_at_ms (wall-clock, ms-precision int);
+    # both sides derive it from int(time.time()*1000) so allow small drift.
+    assert abs(py_marker_json.pop("requested_at_ms")
+               - bash_marker_json.pop("requested_at_ms")) < 5000
+    assert py_marker_json == bash_marker_json == {
+        "awaiting_steering": True,
+        "run_id": "r-d",
+        "node_id": "node-7",
+        "reason": "please advise",
+    }
+
+    # status: same shape modulo sentinel_path (per-side run dir) + requested_at_ms.
+    for s in (bash_status, py_status):
+        s.pop("requested_at_ms", None)
+        s.pop("sentinel_path", None)
+    assert py_status == bash_status
+    assert py_status["awaiting"] is True
+
+    # clear removes both files on both sides.
+    _bash_call(bash_env, 'mo_steering_checkpoint_clear "r-d"')
+    assert not os.path.isfile(bash_sentinel) and not os.path.isfile(bash_marker)
+    sc.clear("r-d")
+    assert not os.path.isfile(py_sentinel) and not os.path.isfile(py_marker)
+
+    # status after clear → {"awaiting": false} on both sides.
+    bash_status_cleared = json.loads(
+        _bash_call(bash_env, 'mo_steering_checkpoint_status "r-d"').stdout.strip()
+    )
+    assert bash_status_cleared == sc.status("r-d") == {"awaiting": False}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) gate with steering present → rc=0 + marker cleared
+# ─────────────────────────────────────────────────────────────────────────────
+def test_gate_steering_present_parity(tmp_path_factory, monkeypatch):
+    db, home = _init_db(tmp_path_factory)
+    bash_run_dir = str(tmp_path_factory.mktemp("e_bash_run"))
+    py_run_dir = str(tmp_path_factory.mktemp("e_py_run"))
+    # Seed an unconsumed steering row so the gate is satisfied.
+    _seed_row(db, run_id="r-e", role_target="any")
+
+    bash_env = {**os.environ, "MINI_ORK_DB": db, "MINI_ORK_HOME": home,
+                "MINI_ORK_RUN_DIR": bash_run_dir}
+    bash_rc = _bash_gate(bash_env, "r-e")
+    assert not os.path.isfile(os.path.join(bash_run_dir, ".steering-checkpoint"))
+
+    _point_env(monkeypatch, db=db, home=home, run_dir=py_run_dir)
+    py_rc = sc.gate("r-e")
+    assert not os.path.isfile(sc._sentinel_path("r-e"))
+
+    assert bash_rc == py_rc == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) gate with no steering → rc=2 + marker JSON keys match
+# ─────────────────────────────────────────────────────────────────────────────
+def test_gate_no_steering_parity(tmp_path_factory, monkeypatch):
+    db, home = _init_db(tmp_path_factory)  # empty steering table
+    bash_run_dir = str(tmp_path_factory.mktemp("f_bash_run"))
+    py_run_dir = str(tmp_path_factory.mktemp("f_py_run"))
+
+    bash_env = {**os.environ, "MINI_ORK_DB": db, "MINI_ORK_HOME": home,
+                "MINI_ORK_RUN_DIR": bash_run_dir}
+    bash_rc = _bash_gate(bash_env, "r-f", "node-f")
+    with open(os.path.join(bash_run_dir, ".steering-checkpoint.json")) as fh:
+        bash_marker = json.load(fh)
+
+    _point_env(monkeypatch, db=db, home=home, run_dir=py_run_dir)
+    py_rc = sc.gate("r-f", "node-f")
+    with open(sc._marker_path("r-f")) as fh:
+        py_marker = json.load(fh)
+
+    assert bash_rc == py_rc == 2
+    assert sorted(py_marker) == sorted(bash_marker)
+    py_marker.pop("requested_at_ms")
+    bash_marker.pop("requested_at_ms")
+    assert py_marker == bash_marker == {
+        "awaiting_steering": True,
+        "run_id": "r-f",
+        "node_id": "node-f",
+        "reason": "awaiting human steering",
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) role-matching parity — including the '? = any' broadcast branch both ways
+# ─────────────────────────────────────────────────────────────────────────────
+def test_has_unconsumed_role_matching_parity(tmp_path_factory, monkeypatch):
+    db, home = _init_db(tmp_path_factory)
+    env = _point_env(monkeypatch, db=db, home=home)
+
+    # Row addressed specifically to 'planner'.
+    _seed_row(db, run_id="r-g", role_target="planner", message="for-planner")
+
+    def check(role: str) -> int:
+        bash_rc, _ = _bash_has_unconsumed(env, "r-g", role)
+        py_rc = sc.has_unconsumed("r-g", role)
+        assert bash_rc == py_rc, f"role={role}: bash={bash_rc} py={py_rc}"
+        return py_rc
+
+    # role='planner' → direct match → 0.
+    assert check("planner") == 0
+    # role='any'     → '? = any' broadcast branch matches the planner row → 0.
+    assert check("any") == 0
+    # role='reviewer'→ no planner match, no 'any'-targeted row, not broadcast → 1.
+    assert check("reviewer") == 1
+
+    # Inverse broadcast: an 'any'-targeted row is visible to a specific role.
+    _seed_row(db, run_id="r-g2", role_target="any", message="broadcast")
+    bash_rc, _ = _bash_has_unconsumed(env, "r-g2", "reviewer")
+    py_rc = sc.has_unconsumed("r-g2", "reviewer")
+    assert bash_rc == py_rc == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) DB-diff parity — 3 mixed run/role rows; identical subset per probe
+# ─────────────────────────────────────────────────────────────────────────────
+def test_has_unconsumed_mixed_rows_subset_parity(tmp_path_factory, monkeypatch):
+    db, home = _init_db(tmp_path_factory)
+    env = _point_env(monkeypatch, db=db, home=home)
+
+    # Three mixed rows: run-scoped planner, run-scoped reviewer, global 'any'.
+    _seed_row(db, run_id="r-h1", role_target="planner", message="h1-planner")
+    _seed_row(db, run_id="r-h2", role_target="reviewer", message="h2-reviewer")
+    _seed_row(db, run_id=None, role_target="any", message="h-global")
+
+    probes = [
+        ("r-h1", "planner"),   # own planner row + global any → 0
+        ("r-h1", "reviewer"),  # no reviewer row for r-h1, but global any → 0
+        ("r-h2", "reviewer"),  # own reviewer row + global any → 0
+        ("r-unknown", "any"),  # only the global any row is visible → 0
+        ("r-h1", "verifier"),  # planner row not matched, but global any → 0
+    ]
+    # Prove bash and python agree on EVERY probe (identical visible subset).
+    for run_id, role in probes:
+        bash_rc, _ = _bash_has_unconsumed(env, run_id, role)
+        py_rc = sc.has_unconsumed(run_id, role)
+        assert bash_rc == py_rc, f"probe=({run_id},{role}): bash={bash_rc} py={py_rc}"
+
+    # Now delete the global row and re-probe: r-unknown/verifier should flip to 1
+    # on BOTH sides (subset really is driven by the same WHERE clause).
+    con = sqlite3.connect(db)
+    con.execute("DELETE FROM operator_steering WHERE run_id IS NULL")
+    con.commit()
+    con.close()
+
+    for run_id, role, expected in [
+        ("r-h1", "planner", 0),    # still has its own planner row
+        ("r-unknown", "any", 1),   # global gone → nothing visible
+        ("r-h1", "verifier", 1),   # global gone, planner row not matched
+    ]:
+        bash_rc, _ = _bash_has_unconsumed(env, run_id, role)
+        py_rc = sc.has_unconsumed(run_id, role)
+        assert bash_rc == py_rc == expected, (
+            f"probe=({run_id},{role}): bash={bash_rc} py={py_rc} exp={expected}")


### PR DESCRIPTION
Completes all 10 leaf modules via autonomous mini-ork runs. steering_checkpoint, cross_epic_gradient, mid_node_injector, runs_tracker — each with a live-bash-subprocess parity test (30 cases). mid_node_injector + runs_tracker had real parity bugs the tests caught; re-dispatch fixed them. Bash unchanged (strangler-fig).