### PR TITLE
feat(python-migration): autonomous port of 5 lib modules (wave 3)

### DIFF
--- a/mini_ork/ported/gate_bootstrap.py
+++ b/mini_ork/ported/gate_bootstrap.py
@@ -1,0 +1,124 @@
+"""Auto-register the 5 oracle gates at framework boot — Python port of lib/gate_bootstrap.sh.
+
+Faithful port of mo_bootstrap_oracle_gates. Registers the 5 oracle gates
+(coalition, panel-health, synthesis-promote, stability, liveness) into the
+gate_registry table if not already present. Idempotent. Fail-open — rc=0
+even on partial failures (matches bash semantics).
+
+Two-phase insert-then-rename mirrors the bash sequence exactly so row-diff
+parity can be asserted against the live bash via sha256 row-dump equality:
+  (a) INSERT 5 candidate rows with UUID-suffixed gate_ids (matches the bash
+      gate_register output: gate-custom-<hex8>), gate_type='custom',
+      task_class_filter='' initially, safety per the bash roster
+      (coalition/panel-health/synthesis-promote/liveness=1; stability=0),
+      condition=<root>/gates/<name>.sh
+  (b) UPDATE OR IGNORE the 5 newly-inserted rows to stable oracle-* IDs,
+      DELETE the UUID rows
+  (c) UPDATE task_class_filter=NULL for all oracle-* rows (so gate_list's
+      "task_class_filter IS NULL OR task_class_filter=?" treats NULL as
+      "applies to ALL task_classes")
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+import uuid
+
+
+_DDL = """
+    CREATE TABLE IF NOT EXISTS gate_registry (
+        gate_id             TEXT PRIMARY KEY,
+        gate_type           TEXT NOT NULL,
+        condition           TEXT NOT NULL,
+        task_class_filter   TEXT,
+        safety              INTEGER NOT NULL DEFAULT 0,
+        active              INTEGER NOT NULL DEFAULT 1,
+        registered_at       INTEGER NOT NULL
+    )
+"""
+
+_ROSTER = (
+    # (gate_script_basename, safety_flag)
+    ("coalition.sh", 1),
+    ("panel-health.sh", 1),
+    ("synthesis-promote.sh", 1),
+    ("stability.sh", 0),
+    ("liveness.sh", 1),
+)
+
+_STABLE_IDS = {
+    "coalition.sh": "oracle-coalition",
+    "panel-health.sh": "oracle-panel-health",
+    "synthesis-promote.sh": "oracle-synthesis-promote",
+    "stability.sh": "oracle-stability",
+    "liveness.sh": "oracle-liveness",
+}
+
+
+def bootstrap_oracle_gates(db: str | None = None,
+                           root: str | None = None) -> int:
+    """mo_bootstrap_oracle_gates — register the 5 oracle gates if missing.
+
+    Args:
+        db:  Path to SQLite state DB. Falls back to $MINI_ORK_DB.
+        root: Path to mini-ork repo root. Falls back to $MINI_ORK_ROOT.
+
+    Returns:
+        Always 0 (fail-open). Reads $MINI_ORK_DB and $MINI_ORK_ROOT from
+        the env when not provided explicitly.
+    """
+    if db is None:
+        db = os.environ.get("MINI_ORK_DB", "")
+    if root is None:
+        root = os.environ.get("MINI_ORK_ROOT", "")
+    try:
+        if not db or not os.path.isfile(db):
+            return 0
+        if not root:
+            return 0
+        con = sqlite3.connect(db)
+        try:
+            con.execute(_DDL)
+            cur = con.execute(
+                "SELECT COUNT(*) FROM gate_registry WHERE gate_id LIKE 'oracle-%'"
+            ).fetchone()
+            if (cur[0] if cur else 0) >= 5:
+                return 0
+            now = int(time.time())
+            for basename, safety in _ROSTER:
+                cond = f"{root}/gates/{basename}"
+                gid = f"gate-custom-{uuid.uuid4().hex[:8]}"
+                con.execute(
+                    "INSERT OR IGNORE INTO gate_registry "
+                    "(gate_id, gate_type, condition, task_class_filter, "
+                    " safety, active, registered_at) "
+                    "VALUES (?, 'custom', ?, '', ?, 1, ?)",
+                    (gid, cond, int(safety), now),
+                )
+            for basename in _STABLE_IDS:
+                new_id = _STABLE_IDS[basename]
+                cond = f"{root}/gates/{basename}"
+                rows = con.execute(
+                    "SELECT gate_id FROM gate_registry WHERE condition=? "
+                    "AND gate_id NOT LIKE 'oracle-%'", (cond,)
+                ).fetchall()
+                for (old_id,) in rows:
+                    con.execute(
+                        "UPDATE OR IGNORE gate_registry SET gate_id=? "
+                        "WHERE gate_id=?", (new_id, old_id)
+                    )
+                    con.execute(
+                        "DELETE FROM gate_registry WHERE gate_id=?",
+                        (old_id,),
+                    )
+            con.execute(
+                "UPDATE gate_registry SET task_class_filter=NULL "
+                "WHERE gate_id LIKE 'oracle-%' AND task_class_filter=''"
+            )
+            con.commit()
+        finally:
+            con.close()
+    except Exception:
+        return 0
+    return 0

--- a/mini_ork/ported/gates_common.py
+++ b/mini_ork/ported/gates_common.py
@@ -1,0 +1,168 @@
+"""Mini-ork gate bootstrap — Python port of lib/gates_common.sh.
+
+Faithful port of the bash ``mo_grounded_rejection`` helper required on every
+gate fail/needs_revision verdict per HarnessBridge Technique 4
+(arxiv:2606.12882) and the 2026-06-15 audit Theme C finding. The reflector
+reads structured rows from ``grounded_rejections`` (per
+``db/migrations/0037_grounded_rejection.sql``) instead of re-extracting tuples
+from free-text rationale.
+
+Public API mirrors ``lib/gates_common.sh`` exactly:
+    tuple_json(concern, evidence, suggestion) -> str
+    emit(gate, verdict, concern, evidence_summary, suggestion,
+         evidence_trace_ids='[]', run_id=None) -> str | int
+
+Return-value contract (matches bash):
+    tuple_json → JSON string on success; raises ValueError on missing required
+                 args (bash returns rc=2 in that case).
+    emit       → hex id (str) on success; rc (int: 2/3/0) on failure.
+                 rc=2 argument error, rc=3 JSON validation error, rc=0 success
+                 OR table-absent no-op.
+
+Strangler-fig note: this co-exists with lib/gates_common.sh; the bash file is
+not modified by the port. The Python side uses sqlite3 ``?`` parameter binding
+instead of bash's triple-quoted heredoc, so it's stricter against input but
+the observable row content is identical to a successful bash emit.
+"""
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sqlite3
+import sys
+from datetime import datetime, timezone
+
+
+_VALID_VERDICTS = frozenset({"fail", "needs_revision", "indeterminate"})
+
+
+def _log(level: str, msg: str) -> None:
+    """Mirror of bash ``_mo_gr_log``: structured JSON line to stderr."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    sys.stderr.write(json.dumps({
+        "level": level,
+        "subsystem": "gates_common",
+        "ts": ts,
+        "msg": msg,
+    }, ensure_ascii=False) + "\n")
+
+
+def _resolve_db() -> str:
+    """Mirror of bash ``_mo_gr_db``: env MINI_ORK_DB wins, else
+    ${MINI_ORK_HOME:-pwd}/.mini-ork/state.db."""
+    db = os.environ.get("MINI_ORK_DB")
+    if db:
+        return db
+    home = os.environ.get("MINI_ORK_HOME") or os.getcwd()
+    return f"{home}/.mini-ork/state.db"
+
+
+def _table_exists(db: str) -> bool:
+    try:
+        con = sqlite3.connect(db)
+        try:
+            r = con.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='table' AND name='grounded_rejections' LIMIT 1"
+            ).fetchone()
+            return r is not None
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return False
+
+
+def _validate_verdict(v: str) -> bool:
+    return v in _VALID_VERDICTS
+
+
+def _validate_json_array(payload: str) -> bool:
+    """Mirror of bash ``_mo_gr_validate_json_array``: empty → ok; otherwise
+    must parse as a JSON array (top-level list)."""
+    if not payload:
+        return True
+    try:
+        v = json.loads(payload)
+    except (ValueError, TypeError):
+        return False
+    return isinstance(v, list)
+
+
+def tuple_json(concern: str, evidence: str, suggestion: str) -> str:
+    """Mirror of ``mo_grounded_rejection_tuple_json``.
+
+    Returns the canonical ``{concern, evidence, suggestion}`` JSON tuple
+    (ensure_ascii=False, matching bash). Raises ValueError on missing
+    required arg — bash returns rc=2 in that case; the test treats both as
+    "rejection on missing input".
+    """
+    if not concern or not evidence or not suggestion:
+        _log("error", "mo_grounded_rejection_tuple_json <concern> <evidence> <suggestion>")
+        raise ValueError(
+            "tuple_json requires non-empty concern, evidence, suggestion"
+        )
+    return json.dumps(
+        {"concern": concern, "evidence": evidence, "suggestion": suggestion},
+        ensure_ascii=False,
+    )
+
+
+def emit(gate: str, verdict: str, concern: str, evidence_summary: str,
+         suggestion: str, evidence_trace_ids: str = "[]",
+         run_id: str | None = None) -> str | int:
+    """Mirror of ``mo_grounded_rejection``.
+
+    Returns the hex id (str, 32 chars) on success; rc (int 2/3/0) on failure.
+    When the ``grounded_rejections`` table is absent, behaves as a no-op and
+    returns 0 (matches bash: warn-logged then rc=0).
+    """
+    if not gate or not verdict or not concern or not evidence_summary or not suggestion:
+        _log(
+            "error",
+            "mo_grounded_rejection <gate> <verdict> <concern> "
+            "<evidence_summary> <suggestion> [trace_ids_json] [run_id]",
+        )
+        return 2
+    if not _validate_verdict(verdict):
+        _log(
+            "error",
+            f"invalid verdict: {verdict} (must be fail|needs_revision|indeterminate)",
+        )
+        return 2
+    if not _validate_json_array(evidence_trace_ids):
+        _log("error", "evidence_trace_ids must be a JSON array")
+        return 3
+    db = _resolve_db()
+    if not _table_exists(db):
+        _log("warn", "grounded_rejections table absent; emit is a no-op. Run migrations.")
+        return 0
+
+    new_id = secrets.token_hex(16)
+    con = sqlite3.connect(db)
+    try:
+        con.execute(
+            """INSERT INTO grounded_rejections
+                 (id, gate_name, verdict, concern, evidence_trace_ids,
+                  evidence_summary, suggestion, run_id)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                new_id,
+                gate,
+                verdict,
+                concern,
+                evidence_trace_ids,
+                evidence_summary,
+                suggestion,
+                run_id if run_id else None,
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()
+    _log(
+        "info",
+        f"emitted grounded_rejection id={new_id} gate={gate} "
+        f"verdict={verdict} run={run_id or ''}",
+    )
+    return new_id

--- a/mini_ork/ported/mo_node_events.py
+++ b/mini_ork/ported/mo_node_events.py
@@ -1,0 +1,325 @@
+"""Node-events emit — Python port of lib/mo_node_events.sh.
+
+Faithful port of the run_events emission helpers used by mini-ork to power
+the per-node DAG status view in the observability UI. The Python port gives
+callers an in-process surface (no `python3` heredoc per call) and gives the
+parity test a stable target to byte-diff against the live bash.
+
+Co-existence model (strangler-fig): bash `lib/mo_node_events.sh` is the
+authoritative source. This module mirrors its surfaces exactly. Parity is
+enforced by `tests/unit/test_mo_node_events_py.py` (>=6 cases that drive
+the LIVE bash subprocess against a temp DB seeded by `db/init.sh` and diff
+the resulting `run_events` rows against the Python port byte-for-byte;
+floats 1e-6 on integer epoch columns).
+
+Schema citations:
+  - `run_events` base table  — db/migrations/0016_recursive_orchestration.sql
+      (event_id, run_id, parent_run_id, event_type, payload_json, created_at)
+  - `run_events.finish_reason`  — db/migrations/0021_error_taxonomy_finish_reasons.sql
+  - `run_events.last_heartbeat_at`  — db/migrations/0023_node_heartbeat_fuse.sql
+
+Pipeline map (bash function → Python):
+  _mo_now_ms              → _now_ms          (gdate → time.time_ns → seconds*1000)
+  mo_node_emit            → mo_node_emit     (required-arg guards + schema-aware insert)
+  mo_node_start           → mo_node_start    (model_lane convenience)
+  mo_node_end             → mo_node_end      (build_extra_json + delegate)
+  mo_emit_node_heartbeat  → mo_emit_node_heartbeat
+  mo_node_emit_end_trap   → mo_node_emit_end_trap
+        (signature drift: bash uses RETURN-trap + caller-scope vars; the port
+        takes them as explicit args. Bash callers cannot 1:1 swap.)
+
+Signature deltas vs bash (documented for callers):
+  - `mo_node_emit_end_trap`: bash reads `_mo_run_id`, `_mo_node_start_ms`,
+    `node_id`, `node_type`, `VERDICT`, `CONTEXT_FILE`, `IMPL_LOG`, `REVIEW_FILE`,
+    `MO_NODE_FINISH_REASON` from the caller's scope (RETURN-trap pattern).
+    Python has no caller scope, so the port takes them as explicit args. Bash
+    also auto-resolves artifact via `CONTEXT_FILE → IMPL_LOG → REVIEW_FILE`
+    chain; the port takes a single resolved `context_path` and the caller
+    must perform the chain.
+  - `_now_ms` is the public name of bash's `_mo_now_ms` (the leading
+    underscore is dropped to match Python idioms; the bash function name
+    is preserved in the docstring for grep parity).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import time
+from typing import Any
+
+__all__ = [
+    "mo_node_emit",
+    "mo_node_start",
+    "mo_node_end",
+    "mo_emit_node_heartbeat",
+    "mo_node_emit_end_trap",
+    "_now_ms",
+]
+
+
+# Mirror of bash default for the 5th positional: `'{\}}'` in single-quoted bash
+# produces the literal string `{}`. JSON-empty object.
+_DEFAULT_EXTRA_JSON = "{}"
+
+
+# Mirrors lib/mo_node_events.sh:56
+def _resolve_db() -> str | None:
+    """Return the state.db path the bash script would pick, or None if missing.
+
+    Resolution order (mirrors bash line 56):
+      $MINI_ORK_DB → $MINI_ORK_HOME/state.db → $(pwd)/.mini-ork/state.db
+    Returns None when the resolved path does not exist (caller must mirror
+    bash's silent no-op in `mo_node_emit`).
+    """
+    env_db = os.environ.get("MINI_ORK_DB")
+    if env_db:
+        return env_db
+    home = os.environ.get("MINI_ORK_HOME")
+    if home:
+        return os.path.join(home, "state.db")
+    return os.path.join(os.getcwd(), ".mini-ork", "state.db")
+
+
+# Mirrors lib/mo_node_events.sh:_mo_now_ms (gdate → python3 → date+%%s*1000)
+def _now_ms() -> int:
+    """Portable millisecond timestamp.
+
+    BSD `date` (macOS default) does NOT honor `%3N` — it silently emits the
+    literal "N" instead of failing, which poisons arithmetic. Prefer GNU
+    `gdate` (coreutils), fall back to `time.time_ns()`, then to seconds×1000
+    as a last-resort 1s-resolution fallback. Same pattern as
+    lib/llm-dispatch.sh::_mo_llm_now_ms.
+    """
+    gdate = subprocess.run(
+        ["gdate", "+%s%3N"], capture_output=True, text=True
+    )
+    if gdate.returncode == 0 and gdate.stdout.strip():
+        try:
+            return int(gdate.stdout.strip())
+        except ValueError:
+            pass
+    try:
+        return time.time_ns() // 1_000_000
+    except AttributeError:  # pragma: no cover (Py<3.7)
+        return int(time.time() * 1000)
+
+
+def _build_event_id(event_type: str, node_id: str, pid: int | None = None) -> str:
+    """Mirror bash line 59::
+
+        evt-${event_type}-${node_id}-$(date +%s%N 2>/dev/null || date +%s)-$$
+
+    `date +%s%N` works on GNU `date` (ns resolution); BSD `date` swallows
+    `%N` silently and emits `%s` (s resolution). The port uses
+    `time.time_ns()` (ns) with `time.time()` (s) fallback. `pid` defaults to
+    `os.getpid()` and mirrors bash's `$$` (current shell PID).
+    """
+    if pid is None:
+        pid = os.getpid()
+    try:
+        suffix = f"{time.time_ns()}"
+    except AttributeError:  # pragma: no cover (Py<3.7)
+        suffix = f"{int(time.time())}"
+    return f"evt-{event_type}-{node_id}-{suffix}-{pid}"
+
+
+def _table_columns(con: sqlite3.Connection, table: str) -> set[str]:
+    """Mirror bash line 83: PRAGMA table_info(run_events) column-name set."""
+    return {row[1] for row in con.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _default_extra_json() -> str:
+    """Mirror bash default `$5` of `mo_node_emit` (the literal `{}`)."""
+    return _DEFAULT_EXTRA_JSON
+
+
+def _build_extra_json(
+    duration_ms: int | str,
+    verdict: str = "",
+    artifact_path: str = "",
+    finish_reason: str = "",
+) -> str:
+    """Mirror bash lines 161-170 heredoc: always include `duration_ms` as int;
+    include verdict/artifact_path/finish_reason only when truthy. Output is
+    a JSON string (not a dict) so callers can pass it as `extra_json` to
+    `mo_node_emit`.
+    """
+    out: dict[str, Any] = {"duration_ms": int(duration_ms or 0)}
+    if verdict:
+        out["verdict"] = verdict
+    if artifact_path:
+        out["artifact_path"] = artifact_path
+    if finish_reason:
+        out["finish_reason"] = finish_reason
+    return json.dumps(out)
+
+
+def mo_node_emit(
+    run_id: str,
+    node_id: str,
+    node_type: str,
+    event_type: str,
+    extra_json: str = _DEFAULT_EXTRA_JSON,
+) -> int:
+    """Mirror lib/mo_node_events.sh::mo_node_emit (lines 45-103).
+
+    Required-arg guards emit the same stderr phrase as bash and return 0
+    (mirroring the bash `return 0` on guard miss). DB-missing is a silent
+    no-op. Schema-aware insert includes `finish_reason` and
+    `last_heartbeat_at` columns only when present in `run_events`. The
+    `last_heartbeat_at` write is further gated to `event_type in
+    ('node_start', 'node_heartbeat')` per migration 0023 semantics.
+    """
+    if not run_id:
+        print("mo_node_emit: run_id required", file=__import__("sys").stderr)
+        return 0
+    if not node_id:
+        print("mo_node_emit: node_id required", file=__import__("sys").stderr)
+        return 0
+    if not event_type:
+        print("mo_node_emit: event_type required", file=__import__("sys").stderr)
+        return 0
+
+    db = _resolve_db()
+    if not db or not os.path.isfile(db):
+        return 0  # silent no-op if state.db missing (e.g. uninitialized test)
+
+    # Mirror bash lines 67-78: parse extra_json, coerce non-dict, recover
+    # JSONDecodeError to `_raw` envelope.
+    try:
+        extra = json.loads(extra_json) if extra_json else {}
+        if not isinstance(extra, dict):
+            extra = {"_raw": str(extra)}
+    except json.JSONDecodeError:
+        extra = {"_raw": extra_json}
+
+    payload = {
+        "node_id": node_id,
+        "node_type": node_type,
+        **extra,
+    }
+
+    event_id = _build_event_id(event_type, node_id)
+    now_s = int(time.time())
+    heartbeat_ms = _now_ms()
+
+    con = sqlite3.connect(db, timeout=2.0)
+    try:
+        con.execute("PRAGMA busy_timeout = 2000")
+        cols = _table_columns(con, "run_events")
+        insert_cols = ["event_id", "run_id", "event_type", "payload_json", "created_at"]
+        values: list[Any] = [event_id, run_id, event_type, json.dumps(payload), now_s]
+        if "finish_reason" in cols:
+            insert_cols.append("finish_reason")
+            values.append(payload.get("finish_reason"))
+        if "last_heartbeat_at" in cols and event_type in ("node_start", "node_heartbeat"):
+            insert_cols.append("last_heartbeat_at")
+            values.append(heartbeat_ms)
+        placeholders = ",".join("?" for _ in insert_cols)
+        con.execute(
+            f"INSERT INTO run_events({', '.join(insert_cols)}) VALUES ({placeholders})",
+            values,
+        )
+        con.commit()
+    except sqlite3.Error:
+        # Mirror bash `2>/dev/null || true` — observability must never break
+        # execution. DB-missing/missing-table is the only no-op case we
+        # return 0 for above; once we open a connection, schema errors are
+        # surfaced as sqlite3.Error and swallowed to match bash's
+        # best-effort observability contract.
+        return 0
+    finally:
+        con.close()
+    return 0
+
+
+def mo_node_start(
+    run_id: str,
+    node_id: str,
+    node_type: str,
+    model_lane: str = "",
+) -> int:
+    """Mirror lib/mo_node_events.sh::mo_node_start (lines 107-114).
+
+    Builds `extra = {"model_lane": <lane>}` when non-empty; otherwise passes
+    the default `'{}'`. Delegates to `mo_node_emit` with `event_type='node_start'`.
+    """
+    extra = _default_extra_json()
+    if model_lane:
+        extra = json.dumps({"model_lane": model_lane})
+    return mo_node_emit(run_id, node_id, node_type, "node_start", extra)
+
+
+def mo_node_end(
+    run_id: str,
+    node_id: str,
+    node_type: str,
+    duration_ms: int | str,
+    verdict: str = "",
+    artifact_path: str = "",
+    finish_reason: str = "",
+) -> int:
+    """Mirror lib/mo_node_events.sh::mo_node_end (lines 157-172).
+
+    Builds the extra JSON via the same logic as the bash in-here python
+    (`duration_ms` always; verdict/artifact_path/finish_reason only when
+    truthy), then delegates to `mo_node_emit` with `event_type='node_end'`.
+    """
+    extra = _build_extra_json(duration_ms, verdict, artifact_path, finish_reason)
+    return mo_node_emit(run_id, node_id, node_type, "node_end", extra)
+
+
+def mo_emit_node_heartbeat(node_id: str, run_id: str) -> int:
+    """Mirror lib/mo_node_events.sh::mo_emit_node_heartbeat (lines 118-122).
+
+    `node_type` defaults to `$MO_NODE_TYPE` (env override) or the literal
+    `'heartbeat'`. `extra_json` is always the empty-object literal `'{}'`.
+    """
+    node_type = os.environ.get("MO_NODE_TYPE", "heartbeat")
+    return mo_node_emit(run_id, node_id, node_type, "node_heartbeat", _default_extra_json())
+
+
+def mo_node_emit_end_trap(
+    _run_id: str,
+    node_id: str,
+    node_type: str,
+    start_ms: int,
+    rc: int,
+    *,
+    context_path: str = "",
+    verdict: str = "",
+    finish_reason: str = "",
+) -> int:
+    """Mirror lib/mo_node_events.sh::mo_node_emit_end_trap (lines 131-153).
+
+    Signature drift vs bash: the bash function reads caller-scope vars
+    (`_mo_run_id`, `_mo_node_start_ms`, `node_id`, `node_type`, `VERDICT`,
+    `CONTEXT_FILE`, `IMPL_LOG`, `REVIEW_FILE`, `MO_NODE_FINISH_REASON`) via
+    the RETURN-trap pattern. Python has no caller scope, so callers must
+    thread them explicitly. Artifact resolution is collapsed to a single
+    `context_path` arg; the caller must perform the bash
+    `CONTEXT_FILE → IMPL_LOG → REVIEW_FILE` chain before invoking.
+
+    `finish_reason` defaulting mirrors bash lines 141-147: rc==0 → 'done',
+    rc!=0 → 'error', else the env-override `MO_NODE_FINISH_REASON` (which
+    the caller is expected to have already inlined into the `finish_reason`
+    arg — the port does not re-read the env to keep the surface explicit).
+
+    Early-return on empty `_run_id` / `node_id` / `node_type` (mirrors bash
+    lines 134-136). OTel piggyback (bash line 150) is intentionally NOT
+    ported — it depends on `lib/mo_otel.sh` which has no Python counterpart
+    in this port.
+    """
+    if not _run_id or not node_id or not node_type:
+        return 0
+
+    end_ms = _now_ms()
+    duration_ms = max(0, end_ms - start_ms)
+    artifact = context_path
+
+    if not finish_reason:
+        finish_reason = "done" if rc == 0 else "error"
+
+    return mo_node_end(_run_id, node_id, node_type, duration_ms, verdict, artifact, finish_reason)

--- a/mini_ork/ported/policy_store.py
+++ b/mini_ork/ported/policy_store.py
@@ -1,0 +1,161 @@
+"""Central backend selector for mini-ork brain libraries — Python port of lib/policy_store.sh.
+
+The store-port seam that ``lane_router``, ``process_reward``, and
+``gradient_extractor`` go through to learn whether the live store is
+SQLite (default; eng-team, preserved behavior) or Postgres (v0.2-pt36
+stub, intentionally aborting before any sqlite3 call so the real
+researcher-side PG impl can swap the stub without re-architecting
+callers).
+
+Co-existence model (strangler-fig): bash ``lib/policy_store.sh`` is the
+authoritative source and stays untouched. This module mirrors its
+public API 1:1 so Python callers get an in-process surface and
+``tests/unit/test_policy_store_py.py`` gets a stable target to byte-diff
+against the live bash subprocess.
+
+Public API (bash function → Python):
+  mo_store_backend                 → backend() -> str
+  mo_store_assert_sqlite           → assert_sqlite() -> None
+  mo_store_db_path                 → db_path() -> str
+  mo_store_py_connect_snippet      → py_connect_snippet() -> str
+  mo_store_py_pragmas_snippet      → py_pragmas_snippet() -> str
+
+Exit-code parity: bash returns 64 (EX_USAGE) for an unknown
+``MO_STORE_BACKEND`` and 78 (EX_CONFIG) for ``assert_sqlite`` on a
+non-sqlite backend. The Python port raises ``SystemExit(N)`` with the
+same integer so subprocess-style callers see an identical rc. Bare
+``ValueError`` / ``Exception`` would silently diverge — a caller doing
+``subprocess.run(..., check=False)`` on a Python wrapper would see rc=1
+instead of 64/78.
+
+Snippet byte-exactness: bash emits snippet lines via
+``printf '<literal>\\n'``. The Python port returns the EXACT same string
+(e.g. ``'import sqlite3\\ncon = sqlite3.connect(db)\\n'`` for sqlite,
+``'con.execute("PRAGMA busy_timeout=5000")\\n'`` for sqlite pragma).
+Returning as a string — NOT via ``print()`` — avoids Python's implicit
+trailing newline breaking byte-for-byte parity against the live bash
+subprocess.
+
+Default-value parity: bash uses ``${VAR:-default}`` (fires when VAR is
+unset OR empty). Python's ``os.environ.get("VAR", "default")`` only
+fires when VAR is unset. We use ``os.environ.get("VAR") or "default"``
+so empty-string env vars collapse to the default the same way they do
+in bash.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+__all__ = [
+    "backend",
+    "assert_sqlite",
+    "db_path",
+    "py_connect_snippet",
+    "py_pragmas_snippet",
+]
+
+
+def backend() -> str:
+    """Return the current backend name (``"sqlite"`` or ``"postgres"``).
+
+    Mirrors ``mo_store_backend``. Unknown values raise ``SystemExit(64)``
+    so a typo doesn't silently fall back to SQLite and mask a
+    misconfigured deployment.
+    """
+    b = os.environ.get("MO_STORE_BACKEND") or "sqlite"
+    if b == "sqlite":
+        return "sqlite"
+    if b == "postgres":
+        return "postgres"
+    sys.stderr.write(
+        f"policy_store: unknown MO_STORE_BACKEND={b} (expected sqlite|postgres)\n"
+    )
+    raise SystemExit(64)
+
+
+def db_path() -> str:
+    """Return the resolved DB file path.
+
+    Mirrors ``mo_store_db_path``. Resolution order matches the
+    historical ``STATE_DB`` convention in ``lane_router`` /
+    ``process_reward`` so SQLite-default callers see no change::
+
+        MO_STORE_DB → MINI_ORK_DB → ${MINI_ORK_HOME}/state.db
+                                       → ${PWD}/.mini-ork/state.db
+
+    Returned string has NO trailing newline (bash's ``printf '%s\\n'``
+    trailing newline is added by the caller at the shell boundary; the
+    Python port keeps the value clean for programmatic use).
+    """
+    mo_store_db = os.environ.get("MO_STORE_DB") or ""
+    if mo_store_db:
+        return mo_store_db
+    mini_ork_db = os.environ.get("MINI_ORK_DB") or ""
+    if mini_ork_db:
+        return mini_ork_db
+    mini_ork_home = os.environ.get("MINI_ORK_HOME") or ""
+    if mini_ork_home:
+        return f"{mini_ork_home}/state.db"
+    return f"{os.getcwd()}/.mini-ork/state.db"
+
+
+def assert_sqlite() -> None:
+    """Gate SQLite-direct callers behind the seam.
+
+    Mirrors ``mo_store_assert_sqlite``. Raises ``SystemExit(78)`` when
+    a non-sqlite backend is selected so a Postgres caller never
+    silently executes against the local ``.mini-ork/state.db``. Returns
+    ``None`` on the sqlite happy path (no output, mirroring bash's
+    rc=0 + silent exit).
+    """
+    b = backend()
+    if b != "sqlite":
+        sys.stderr.write(
+            f"policy_store: backend={b} is a stub in v0.2-pt36; "
+            "real impl lands researcher-side. "
+            "Set MO_STORE_BACKEND=sqlite for default behavior.\n"
+        )
+        raise SystemExit(78)
+    return None
+
+
+def py_connect_snippet() -> str:
+    """Return backend-aware Python connect code for ``python3 - <<PY`` heredocs.
+
+    Mirrors ``mo_store_py_connect_snippet``. SQLite emits the canonical
+    ``sqlite3.connect(db)`` open. Postgres emits a ``SystemExit`` before
+    any DB call so the real PG impl can replace the stub by editing
+    this single function.
+
+    Returned string is byte-exact with bash's ``printf '%s\\n'`` output
+    — callers can substitute via ``subprocess.run(..., text=True).stdout``
+    or compare directly in tests.
+    """
+    b = backend()
+    if b == "sqlite":
+        return "import sqlite3\ncon = sqlite3.connect(db)\n"
+    if b == "postgres":
+        return (
+            'raise SystemExit("policy_store: backend=postgres is a stub in '
+            "v0.2-pt36 (researcher-side impl pending). "
+            'Aborting before any PG call.")\n'
+        )
+    return ""
+
+
+def py_pragmas_snippet() -> str:
+    """Return backend-aware Python pragma code for ``python3 - <<PY`` heredocs.
+
+    Mirrors ``mo_store_py_pragmas_snippet``. For SQLite this sets
+    ``PRAGMA busy_timeout`` per-connection (see F-11/R1 audit note in
+    ``lib/db_open.sh``); for Postgres it's a no-op — the connect snippet
+    above aborts before this line runs.
+    """
+    b = backend()
+    if b == "sqlite":
+        busy_ms = os.environ.get("MO_SQLITE_BUSY_MS") or "5000"
+        return f'con.execute("PRAGMA busy_timeout={busy_ms}")\n'
+    if b == "postgres":
+        return ""
+    return ""

--- a/mini_ork/ported/profile_answerer.py
+++ b/mini_ork/ported/profile_answerer.py
@@ -1,0 +1,328 @@
+"""Profile-answerer — Python port of lib/profile_answerer.sh.
+
+Faithful port of `mo_answer_profile_questions`. The bash heredocs in
+`lib/profile_answerer.sh` (prompt builder at lines 26-53; parser at lines
+73-164) are PURE PYTHON already — they are inlined `python3 - <<'PY'`
+blocks. This module lifts them verbatim into a regular Python module with
+no behavior change, then mirrors the bash glue (arg validation, mkdir -p,
+llm_dispatch fallback chain).
+
+Co-existence model (strangler-fig): bash `lib/profile_answerer.sh` is the
+authoritative source. This module mirrors it exactly. Parity is enforced by
+`tests/unit/test_profile_answerer_py.py` (>=6 cases that invoke the live
+bash subprocess against a stubbed `llm_dispatch` and diff against the
+Python output byte-for-byte).
+
+Pipeline map (bash function → Python):
+  mo_answer_profile_questions:
+    arg validation                       → answer_profile_questions (ValueError /
+                                            FileNotFoundError, matching bash exit 2)
+    prompt builder (heredoc lines 26-53) → build_prompt
+    llm_dispatch (deepseek → kimi chain) → default dispatch: subprocess bash
+                                            re-invokes the same llm-dispatch.sh
+                                            for parity at the LLM boundary
+    parser (heredoc lines 73-164)        → parse_and_persist
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+__all__ = [
+    "build_prompt",
+    "parse_and_persist",
+    "answer_profile_questions",
+    "_strip_code_fences",
+    "_extract_balanced_json_object",
+    "_question_text",
+]
+
+
+# Mirrors lib/profile_answerer.sh:85 — `re.compile(r"^```(?:json|JSON)?\s*\n?|\n?```\s*$", re.MULTILINE)`.
+# Case-sensitive except for the explicit `JSON` branch. Mirroring bash's
+# alternation order and flags is load-bearing — `re.I` would over-strip
+# 'JSON' substrings inside prose.
+_FENCE_RE = re.compile(r"^```(?:json|JSON)?\s*\n?|\n?```\s*$", re.MULTILINE)
+
+
+def _strip_code_fences(raw: str) -> str:
+    """Mirror lib/profile_answerer.sh:85-86 fence-stripping.
+
+    Strips optional ```json / ```JSON / ``` openers and ``` closers. Most
+    instruction-tuned LLMs add fences for any structured payload even when
+    the prompt forbids them.
+    """
+    return _FENCE_RE.sub("", raw).strip()
+
+
+def _extract_balanced_json_object(text: str) -> str:
+    """Mirror lib/profile_answerer.sh:90-116 balanced-brace scanner.
+
+    Finds the FIRST `{` then walks forward tracking depth, skipping chars
+    inside strings (with backslash escape handling). Returns the substring
+    from start through the matching close brace. Returns the original text
+    on failure — the caller raises on JSONDecodeError if extraction also
+    fails.
+
+    The bash version emits `text[start:i + 1]` (inclusive close brace);
+    Python mirrors that byte-for-byte.
+    """
+    start = text.find("{")
+    if start == -1:
+        return text
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if esc:
+            esc = False
+            continue
+        if ch == "\\" and in_str:
+            esc = True
+            continue
+        if ch == '"':
+            in_str = not in_str
+            continue
+        if in_str:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return text
+
+
+def _question_text(item) -> str:
+    """Mirror lib/profile_answerer.sh:136-141 question_text helper.
+
+    str → return as-is; dict → return .text or .question or str(dict);
+    anything else → str(item).
+    """
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        return str(item.get("text") or item.get("question") or item)
+    return str(item)
+
+
+def build_prompt(kickoff_path: str | os.PathLike, questions_json: str) -> str:
+    """Mirror lib/profile_answerer.sh:25-53 prompt builder.
+
+    Reads the kickoff file as UTF-8, slices to [:20000] chars (matches
+    bash's `kickoff[:20000]` cap), parses `questions_json` with a graceful
+    fallback to [] on JSONDecodeError, then renders the fixed prompt
+    template with `json.dumps(questions, ensure_ascii=True)` (matches bash).
+
+    The template is byte-for-byte the heredoc body at lines 37-51.
+    """
+    kickoff = Path(kickoff_path).read_text(encoding="utf-8")[:20000]
+    try:
+        questions = json.loads(questions_json or "[]")
+    except json.JSONDecodeError:
+        questions = []
+
+    return (
+        "You answer mini-ork run profile questions for autonomous child runs.\n"
+        "\n"
+        'Return ONLY a strict JSON object with this exact shape:\n'
+        '{"answers":[{"question":"...","answer":"..."}],"auto_answered":true}\n'
+        "\n"
+        "Rules:\n"
+        "- Answer every question using the kickoff content.\n"
+        "- Keep answers concise and operational.\n"
+        "- Do not include markdown, prose, code fences, or extra keys.\n"
+        "\n"
+        "Kickoff:\n"
+        + kickoff
+        + "\n"
+        "\n"
+        "Questions JSON:\n"
+        + json.dumps(questions, ensure_ascii=True)
+        + "\n"
+    )
+
+
+def parse_and_persist(
+    raw: str,
+    questions_json: str,
+    out_path: str | os.PathLike,
+) -> dict:
+    """Mirror lib/profile_answerer.sh:73-164 parser + writer.
+
+    Args:
+        raw: raw LLM text (already the dispatch return value; will be stripped).
+        questions_json: the JSON-stringified questions list (matches the bash
+            contract — bash passes the same string the caller supplied).
+        out_path: file to write the validated answers JSON to. Parent
+            directory is created.
+
+    Returns:
+        The dict that was written to disk (`{"answers": [...], "auto_answered": True}`).
+
+    Raises:
+        SystemExit-equivalent RuntimeError if the LLM output is non-JSON
+            even after fence-strip + balanced-extraction (bash's
+            "profile answerer returned non-json output: ..." path).
+        RuntimeError if the LLM omitted one or more input questions
+            (bash's "profile answerer omitted question: ..." path).
+    """
+    raw = raw.strip()
+
+    # Strip optional markdown code fences.
+    raw = _strip_code_fences(raw)
+
+    # Parse; on failure, fall back to extracting the first balanced {...}.
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        salvaged = _extract_balanced_json_object(raw)
+        try:
+            parsed = json.loads(salvaged)
+        except json.JSONDecodeError as exc:
+            snippet = raw[:200].replace("\n", "\\n")
+            raise RuntimeError(
+                f"profile answerer returned non-json output: {exc} | "
+                f"raw_first_200={snippet!r}"
+            )
+
+    try:
+        questions = json.loads(questions_json or "[]")
+    except json.JSONDecodeError:
+        questions = []
+
+    question_lookup = {_question_text(q): _question_text(q) for q in questions}
+    answers: list[dict] = []
+    for item in parsed.get("answers") or []:
+        if not isinstance(item, dict):
+            continue
+        question = str(item.get("question") or "").strip()
+        answer = str(item.get("answer") or "").strip()
+        if question and answer:
+            answers.append(
+                {"question": question_lookup.get(question, question), "answer": answer}
+            )
+
+    if questions and len(answers) < len(questions):
+        answered = {a["question"] for a in answers}
+        for q in questions:
+            text = _question_text(q)
+            if text not in answered:
+                raise RuntimeError(f"profile answerer omitted question: {text}")
+
+    out = {"answers": answers, "auto_answered": True}
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2)
+        f.write("\n")
+    return out
+
+
+def _default_dispatch(prompt: str, *, repo_root: str | os.PathLike) -> str:
+    """Default dispatch: shell out to bash's llm_dispatch for parity at
+    the LLM boundary.
+
+    Mirrors lib/profile_answerer.sh:60-70 — primary call to
+    `llm_dispatch --model deepseek` with fallback to `llm_dispatch --model
+    kimi`. The empty-stdout check (bash's `|| [ -z "${raw// /}" ]`) is
+    preserved: deepseek under transient throttling sometimes exits 0 with
+    empty/whitespace output.
+
+    Args:
+        prompt: full prompt text (built by `build_prompt`).
+        repo_root: path to the mini-ork repo root (so the default dispatch
+            can find `lib/llm-dispatch.sh`).
+    """
+    bash_script = (
+        'set +e\n'
+        f'source "{repo_root}/lib/llm-dispatch.sh"\n'
+        f'raw=$(llm_dispatch '
+        f'--task-class "profile_answerer" '
+        f'--node-type "profile_answerer" '
+        f'--model "deepseek" '
+        f'--prompt-text "$1")\n'
+        f'rc=$?\n'
+        f'stripped=$(printf "%s" "$raw" | tr -d " \\t\\n\\r")\n'
+        f'if [ $rc -ne 0 ] || [ -z "$stripped" ]; then\n'
+        f'  raw=$(llm_dispatch '
+        f'--task-class "profile_answerer" '
+        f'--node-type "profile_answerer" '
+        f'--model "kimi" '
+        f'--prompt-text "$1") || raw=""\n'
+        f'fi\n'
+        f'printf "%s" "$raw"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", bash_script, "_", prompt],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def answer_profile_questions(
+    kickoff_path: str | os.PathLike,
+    questions_json: str,
+    out_path: str | os.PathLike,
+    *,
+    dispatch=None,
+    repo_root: str | os.PathLike | None = None,
+) -> dict:
+    """Mirror lib/profile_answerer.sh::mo_answer_profile_questions.
+
+    Args:
+        kickoff_path: path to the kickoff markdown file.
+        questions_json: JSON-stringified list of questions (str or list).
+        out_path: where to write the answers JSON. Parent dir is created.
+        dispatch: optional Callable[[str], str] taking the prompt text and
+            returning raw LLM text. Tests inject a captured real LLM
+            response; production callers should pass None to use the
+            default bash-subprocess fallback chain (deepseek → kimi).
+        repo_root: required when dispatch is None — path to the mini-ork
+            repo so the default dispatch can source lib/llm-dispatch.sh.
+
+    Returns:
+        The dict written to `out_path`.
+
+    Raises:
+        ValueError: any of kickoff_path / questions_json / out_path is
+            empty (bash exits 2 with `usage: ...` on stderr).
+        FileNotFoundError: kickoff_path is non-empty but the file does
+            not exist (bash exits 2 with `profile answerer kickoff not
+            found: ...` on stderr).
+        RuntimeError: the LLM output was non-JSON (after fence-strip +
+            balanced-extraction) or the LLM omitted one or more input
+            questions.
+    """
+    kickoff_path = str(kickoff_path) if kickoff_path else ""
+    questions_json = questions_json if isinstance(questions_json, str) else (
+        json.dumps(questions_json) if questions_json is not None else ""
+    )
+    out_path = str(out_path) if out_path else ""
+
+    if not kickoff_path or not questions_json or not out_path:
+        raise ValueError(
+            "usage: mo_answer_profile_questions <kickoff_path> <questions_json> <profile_answers_out_path>"
+        )
+    if not os.path.isfile(kickoff_path):
+        raise FileNotFoundError(f"profile answerer kickoff not found: {kickoff_path}")
+
+    prompt = build_prompt(kickoff_path, questions_json)
+
+    if dispatch is None:
+        if repo_root is None:
+            raise ValueError(
+                "repo_root is required when dispatch is None "
+                "(default dispatch shells to bash's llm-dispatch.sh)"
+            )
+        raw = _default_dispatch(prompt, repo_root=repo_root)
+    else:
+        raw = dispatch(prompt)
+
+    return parse_and_persist(raw, questions_json, out_path)

--- a/tests/unit/test_gate_bootstrap_py.py
+++ b/tests/unit/test_gate_bootstrap_py.py
@@ -1,0 +1,214 @@
+"""Parity gate: mini_ork.ported.gate_bootstrap vs lib/gate_bootstrap.sh.
+
+Live bash invocation via subprocess + direct Python import. Compares the final
+row content of the gate_registry table on fresh temp DBs seeded via db/init.sh.
+Row-set equality via sha256 of the sorted row dump — UUID gate_ids generated
+during the bash intermediate steps are non-deterministic across processes, so
+the comparison contract is the post-rename oracle-* rows only.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import gate_bootstrap as gb  # noqa: E402
+
+GB_SH = REPO / "lib" / "gate_bootstrap.sh"
+
+
+EXPECTED_STABLE_IDS = {
+    "oracle-coalition",
+    "oracle-panel-health",
+    "oracle-synthesis-promote",
+    "oracle-stability",
+    "oracle-liveness",
+}
+
+
+@pytest.fixture
+def db(tmp_path_factory):
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(REPO / "db" / "init.sh")],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def _row_dump(db: str) -> list[tuple]:
+    con = sqlite3.connect(db)
+    rows = con.execute(
+        "SELECT gate_id, gate_type, condition, "
+        "       CASE WHEN task_class_filter IS NULL THEN '' ELSE task_class_filter END, "
+        "       safety, active, registered_at "
+        "FROM gate_registry WHERE gate_id LIKE 'oracle-%' "
+        "ORDER BY gate_id"
+    ).fetchall()
+    con.close()
+    return [tuple(r) for r in rows]
+
+
+def _shape_dump(db: str) -> list[tuple]:
+    """Row shape excluding registered_at (process-clock-dependent across
+    subprocess boundaries; the load-bearing contract is id/type/cond/tcf/safety/active)."""
+    return [r[:-1] for r in _row_dump(db)]
+
+
+def _dump_hash(db: str) -> str:
+    canon = "\n".join(repr(r) for r in _shape_dump(db))
+    return hashlib.sha256(canon.encode()).hexdigest()
+
+
+def _bash_bootstrap(db: str, *, root: str | None = None,
+                    extra_env: dict | None = None) -> int:
+    env = {**os.environ, "MINI_ORK_DB": db}
+    if root is not None:
+        env["MINI_ORK_ROOT"] = root
+    if extra_env:
+        env.update(extra_env)
+    env.pop("MINI_ORK_ROOT", None) if root is None else None
+    cmd = f'. "{GB_SH}" && mo_bootstrap_oracle_gates; echo "RC=$?"'
+    r = subprocess.run(["bash", "-c", cmd], env=env,
+                       capture_output=True, text=True)
+    last = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else ""
+    try:
+        return int(last.split("=", 1)[1])
+    except (IndexError, ValueError):
+        return r.returncode
+
+
+def test_cold_bash_registers_five_oracle_gates(db):
+    rc = _bash_bootstrap(db, root=str(REPO))
+    assert rc == 0
+    ids = {r[0] for r in _row_dump(db)}
+    assert ids == EXPECTED_STABLE_IDS
+
+
+def test_cold_python_registers_five_oracle_gates(db):
+    rc = gb.bootstrap_oracle_gates(db=db, root=str(REPO))
+    assert rc == 0
+    ids = {r[0] for r in _row_dump(db)}
+    assert ids == EXPECTED_STABLE_IDS
+
+
+def test_warm_bash_idempotent(db):
+    assert _bash_bootstrap(db, root=str(REPO)) == 0
+    h1 = _dump_hash(db)
+    assert _bash_bootstrap(db, root=str(REPO)) == 0
+    h2 = _dump_hash(db)
+    assert h1 == h2
+    assert len(_row_dump(db)) == 5
+
+
+def test_warm_python_idempotent(db):
+    assert gb.bootstrap_oracle_gates(db=db, root=str(REPO)) == 0
+    h1 = _dump_hash(db)
+    assert gb.bootstrap_oracle_gates(db=db, root=str(REPO)) == 0
+    h2 = _dump_hash(db)
+    assert h1 == h2
+    assert len(_row_dump(db)) == 5
+
+
+def test_bash_vs_python_row_parity(db):
+    db_bash = db
+    db_py = db + ".py"
+    import shutil
+    shutil.copyfile(db_bash, db_py)
+    assert _bash_bootstrap(db_bash, root=str(REPO)) == 0
+    assert gb.bootstrap_oracle_gates(db=db_py, root=str(REPO)) == 0
+    h_bash = _dump_hash(db_bash)
+    h_py = _dump_hash(db_py)
+    assert h_bash == h_py, (h_bash, h_py, _row_dump(db_bash), _row_dump(db_py))
+    now = int(time.time())
+    for r in _row_dump(db_bash) + _row_dump(db_py):
+        assert now - 60 <= r[-1] <= now + 1, f"registered_at drift: {r}"
+
+
+def test_task_class_filter_is_sql_null(db):
+    assert gb.bootstrap_oracle_gates(db=db, root=str(REPO)) == 0
+    con = sqlite3.connect(db)
+    nulls = con.execute(
+        "SELECT COUNT(*) FROM gate_registry "
+        "WHERE gate_id LIKE 'oracle-%' AND task_class_filter IS NULL"
+    ).fetchone()[0]
+    empties = con.execute(
+        "SELECT COUNT(*) FROM gate_registry "
+        "WHERE gate_id LIKE 'oracle-%' AND task_class_filter = ''"
+    ).fetchone()[0]
+    con.close()
+    assert nulls == 5
+    assert empties == 0
+
+
+def test_safety_distribution(db):
+    assert gb.bootstrap_oracle_gates(db=db, root=str(REPO)) == 0
+    con = sqlite3.connect(db)
+    rows = con.execute(
+        "SELECT gate_id, safety FROM gate_registry WHERE gate_id LIKE 'oracle-%'"
+    ).fetchall()
+    con.close()
+    by_id = {r[0]: r[1] for r in rows}
+    assert by_id == {
+        "oracle-coalition": 1,
+        "oracle-panel-health": 1,
+        "oracle-synthesis-promote": 1,
+        "oracle-stability": 0,
+        "oracle-liveness": 1,
+    }
+    ones = sum(1 for v in by_id.values() if v == 1)
+    zeros = sum(1 for v in by_id.values() if v == 0)
+    assert (ones, zeros) == (4, 1)
+
+
+def test_db_unset_returns_zero_no_file_created(tmp_path):
+    target = tmp_path / "must_not_appear.db"
+    env = {k: v for k, v in os.environ.items()
+           if k not in {"MINI_ORK_DB", "MINI_ORK_ROOT"}}
+    r = subprocess.run(
+        ["bash", "-c",
+         f'. "{GB_SH}" && mo_bootstrap_oracle_gates; echo "RC=$?"'],
+        env=env, capture_output=True, text=True,
+    )
+    last = r.stdout.strip().splitlines()[-1] if r.stdout.strip() else "RC=-1"
+    assert last.startswith("RC=0")
+    assert not target.exists()
+
+    rc_py = gb.bootstrap_oracle_gates(db=None, root=str(REPO))
+    assert rc_py == 0
+    assert not (tmp_path / "state.db").exists()
+
+
+def test_registry_sh_missing_bash_returns_zero(db, tmp_path):
+    """Bash fail-open: when lib/gate_registry.sh can't be sourced (root points
+    to a dir that lacks it), the function returns 0 without writing anything."""
+    fake_root = tmp_path / "fake_root"
+    fake_root.mkdir()
+    rc = _bash_bootstrap(db, root=str(fake_root))
+    assert rc == 0
+    try:
+        rows = _row_dump(db)
+        assert rows == []
+    except sqlite3.OperationalError:
+        pass
+
+
+def test_root_missing_python_returns_zero(db):
+    rc = gb.bootstrap_oracle_gates(db=db, root="")
+    assert rc == 0
+    try:
+        assert _row_dump(db) == []
+    except sqlite3.OperationalError:
+        pass
+    rc2 = gb.bootstrap_oracle_gates(db=db, root="")
+    assert rc2 == 0

--- a/tests/unit/test_gates_common_py.py
+++ b/tests/unit/test_gates_common_py.py
@@ -1,0 +1,340 @@
+"""Parity gate: mini_ork.ported.gates_common vs lib/gates_common.sh.
+
+Each test invokes the LIVE bash subprocess (sourcing ``lib/gates_common.sh``
+in a single ``bash -c`` block so the function bodies are visible to the
+caller) against the same temp DB seeded by ``db/init.sh`` as the Python port.
+Parity is asserted on:
+  * tuple_json stdout shape (sorted-keys, ensure_ascii=False)
+  * emit rc + emitted hex id (32 chars)
+  * inserted ``grounded_rejections`` row content (JSON-serialised,
+    side-by-side diff modulo the random ``id``/wall-clock ``ts``)
+  * append-only trigger parity — provenance UPDATE blocked, allowed column
+    (``consumed_by_reflector_ts``) UPDATE permitted
+
+Env isolation mirrors ``tests/unit/test_steering_checkpoint_py.py``:
+``db/init.sh`` is invoked with ``MINI_ORK_HOME``/``MINI_ORK_DB`` redirected
+into a tmp path; the Python process is monkey-patched to the same env so
+``_resolve_db`` sees the same DB file the bash subprocess writes to.
+
+Seven cases (above the kickoff's ``>=6`` floor):
+  (a) tuple_json shape          — JSON keys + values match across bash/Python
+  (b) emit valid rejection       — rc, id shape, full-row payload parity
+  (c) invalid verdict rejected   — both rc=2
+  (d) invalid trace_ids rejected — both rc=3 (non-array JSON)
+  (e) append-only trigger       — UPDATE of provenance blocked on BOTH inserted
+                                   rows (bash-inserted + python-inserted), with
+                                   stderr containing ``immutable``
+  (f) consumed_by_reflector_ts   — UPDATE of the *non-provenance* column allowed
+                                   on both rows
+  (g) no-table no-op             — DROP TABLE → both emit calls return 0 with
+                                   no row written (matches bash warn-and-return-0)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import gates_common as gc  # noqa: E402
+
+GC_SH = REPO / "lib" / "gates_common.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures + bash subprocess helpers
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def env_db(tmp_path_factory, monkeypatch):
+    """Seed a tmp mini-ork SQLite DB via db/init.sh; point Python env there.
+
+    Returns (db_path, subprocess_env). The subprocess env already contains
+    MINI_ORK_HOME + MINI_ORK_DB so the bash helper resolves to the same DB
+    the Python port writes to. monkeypatch.setenv on the Python side keeps
+    ``_resolve_db`` returning the tmp DB even when the host shell pytest has
+    real MINI_ORK_* vars set.
+    """
+    home = tmp_path_factory.mktemp("gc_home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    monkeypatch.setenv("MINI_ORK_HOME", str(home))
+    monkeypatch.setenv("MINI_ORK_DB", dbp)
+    return dbp, {**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp}
+
+
+def _bash_call(env: dict, body: str) -> subprocess.CompletedProcess:
+    """Source lib/gates_common.sh and run ``body``. Return CompletedProcess.
+
+    Sourcing first ensures the bash ``mo_grounded_rejection*`` functions and
+    the ``_mo_gr_*`` helpers are in scope. Self-test block at the bottom of
+    lib/gates_common.sh is gated on ``BASH_SOURCE[0] == $0`` so it does NOT
+    fire when the file is sourced.
+    """
+    wrapper = f'. "{GC_SH}"\n{body}\n'
+    return subprocess.run(
+        ["bash", "-c", wrapper], env=env, capture_output=True, text=True,
+    )
+
+
+def _row(db: str, rid: str) -> dict | None:
+    con = sqlite3.connect(db)
+    try:
+        con.row_factory = sqlite3.Row
+        r = con.execute(
+            "SELECT * FROM grounded_rejections WHERE id = ?", (rid,)
+        ).fetchone()
+        return dict(r) if r else None
+    finally:
+        con.close()
+
+
+def _diff_row(d: dict) -> dict:
+    """Drop the random id + wall-clock ts so two rows can be compared."""
+    return {
+        "gate_name": d["gate_name"],
+        "verdict": d["verdict"],
+        "concern": d["concern"],
+        "evidence_summary": d["evidence_summary"],
+        "suggestion": d["suggestion"],
+        "evidence_trace_ids": d["evidence_trace_ids"],
+        "run_id": d["run_id"],
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) tuple_json shape — bash stdout keys + Python tuple_json() output match
+# ─────────────────────────────────────────────────────────────────────────────
+def test_tuple_json_shape_parity(env_db):
+    _, env = env_db
+    args = ("missing input", "evidence span", "wait for upstream")
+
+    # Bash side: tuple_json path has no separate env-side stdout aside from
+    # the JSON line (no DB touched); the bash _mo_gr_log error path is not
+    # triggered for non-empty args.
+    rb = _bash_call(
+        env, f'mo_grounded_rejection_tuple_json {json.dumps(args[0])} '
+              f'{json.dumps(args[1])} {json.dumps(args[2])}'
+    )
+    assert rb.returncode == 0, rb.stderr
+    bash_tuple = json.loads(rb.stdout.strip())
+
+    # Python side: in-process call returns the JSON string.
+    py_str = gc.tuple_json(*args)
+    py_tuple = json.loads(py_str)
+
+    # Same keys, same values, same ASCII-preserving order (bash prints the
+    # dict in the literal insertion order concern/evidence/suggestion;
+    # json.loads is order-preserving in 3.7+).
+    assert set(bash_tuple) == {"concern", "evidence", "suggestion"}
+    assert bash_tuple == py_tuple == {
+        "concern": args[0],
+        "evidence": args[1],
+        "suggestion": args[2],
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) emit valid rejection — rc=0 on both, full-row parity (modulo id/ts)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_emit_valid_parity(env_db):
+    db, env = env_db
+    gate = "coalition"
+    verdict = "fail"
+    concern = "panel missing third lens family"
+    evidence = "trace tr-7d2a1 shows only 2 of 3 families voted"
+    suggestion = "wait for kimi-lens retry or escalate to operator"
+    trace_ids = '["tr-7d2a1","tr-7d2a2"]'
+    run_id = "run-py-test-1"
+
+    # Bash path: returns rc=0 and writes the id to stdout (stderr is the JSON
+    # log line — strip that away).
+    rb = _bash_call(
+        env,
+        f'mo_grounded_rejection {json.dumps(gate)} {json.dumps(verdict)} '
+        f'{json.dumps(concern)} {json.dumps(evidence)} '
+        f'{json.dumps(suggestion)} {json.dumps(trace_ids)} '
+        f'{json.dumps(run_id)}',
+    )
+    assert rb.returncode == 0, rb.stderr
+    bash_id = rb.stdout.strip()
+    assert re.fullmatch(r"[0-9a-f]{32}", bash_id), bash_id
+
+    # Python path: returns the id directly.
+    py_id = gc.emit(
+        gate, verdict, concern, evidence, suggestion,
+        evidence_trace_ids=trace_ids, run_id=run_id,
+    )
+    assert isinstance(py_id, str)
+    assert re.fullmatch(r"[0-9a-f]{32}", py_id)
+    assert py_id != bash_id  # random hex; just sanity-check distinct
+
+    # Row-level parity (modulo id/ts). Both sides must have inserted into the
+    # shared tmp DB.
+    bash_row = _row(db, bash_id)
+    py_row = _row(db, py_id)
+    assert bash_row is not None and py_row is not None
+    assert _diff_row(bash_row) == _diff_row(py_row) == {
+        "gate_name": gate,
+        "verdict": verdict,
+        "concern": concern,
+        "evidence_summary": evidence,
+        "suggestion": suggestion,
+        "evidence_trace_ids": trace_ids,
+        "run_id": run_id,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) invalid verdict — bash + Python both return rc=2
+# ─────────────────────────────────────────────────────────────────────────────
+def test_invalid_verdict_rejected_parity(env_db):
+    _, env = env_db
+
+    rb = _bash_call(
+        env,
+        'mo_grounded_rejection "coalition" "catastrophic" "x" "y" "z" "[]" ""',
+    )
+    py_rc = gc.emit("coalition", "catastrophic", "x", "y", "z", "[]", "")
+
+    assert rb.returncode == 2
+    assert py_rc == 2
+    # Both sides log an "invalid verdict" error.
+    assert "invalid verdict" in rb.stderr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) invalid evidence_trace_ids JSON — both return rc=3
+# ─────────────────────────────────────────────────────────────────────────────
+def test_invalid_trace_ids_rejected_parity(env_db):
+    _, env = env_db
+
+    rb = _bash_call(
+        env,
+        'mo_grounded_rejection "coalition" "fail" "x" "y" "z" "not-json" ""',
+    )
+    py_rc = gc.emit("coalition", "fail", "x", "y", "z", "not-json", "")
+
+    assert rb.returncode == 3
+    assert py_rc == 3
+    assert "must be a JSON array" in rb.stderr or "JSON" in rb.stderr
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) append-only trigger blocks UPDATE of provenance — BOTH inserted rows
+# ─────────────────────────────────────────────────────────────────────────────
+def test_trigger_blocks_provenance_update_parity(env_db):
+    db, env = env_db
+
+    rb = _bash_call(
+        env,
+        'mo_grounded_rejection "coalition" "fail" '
+        '"concern-original" "ev-sum" "sug" "[]" ""',
+    )
+    bash_id = rb.stdout.strip()
+    py_id = gc.emit("coalition", "fail", "concern-original", "ev-sum", "sug")
+    assert isinstance(py_id, str)
+
+    # Trigger is defined on the table for both rows (they live in the same
+    # DB); no need to repeat on the Python-inserted row alone — a single
+    # UPDATE blocked per row proves the trigger fires.
+    for rid in (bash_id, py_id):
+        con = sqlite3.connect(db)
+        try:
+            with pytest.raises(sqlite3.IntegrityError) as ei:
+                con.execute(
+                    "UPDATE grounded_rejections SET concern='hacked' "
+                    "WHERE id = ?", (rid,),
+                )
+            assert "immutable" in str(ei.value).lower()
+        finally:
+            con.close()
+    assert bash_id and py_id  # both emitted before the failed UPDATE
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) consumed_by_reflector_ts is updatable — non-provenance column permits
+#     UPDATE; rc=0 on the direct UPDATE (no trigger fires).
+# ─────────────────────────────────────────────────────────────────────────────
+def test_consumed_by_reflector_ts_updatable_parity(env_db):
+    db, env = env_db
+
+    rb = _bash_call(
+        env,
+        'mo_grounded_rejection "coalition" "fail" "c" "e" "s" "[]" ""',
+    )
+    bash_id = rb.stdout.strip()
+    py_id = gc.emit("coalition", "fail", "c", "e", "s")
+    assert isinstance(py_id, str)
+
+    # Allowed column: rc=0 (exit code of the subprocess wrapper), no error.
+    for rid in (bash_id, py_id):
+        con = sqlite3.connect(db)
+        try:
+            con.execute(
+                "UPDATE grounded_rejections "
+                "SET consumed_by_reflector_ts = strftime('%s','now') "
+                "WHERE id = ?", (rid,),
+            )
+            con.commit()
+        except sqlite3.IntegrityError as e:
+            pytest.fail(
+                f"trigger unexpectedly fired on consumed_by_reflector_ts "
+                f"UPDATE: {e} (rid={rid})"
+            )
+        finally:
+            con.close()
+
+    # Confirm both rows actually transitioned to consumed.
+    for rid in (bash_id, py_id):
+        row = _row(db, rid)
+        assert row is not None
+        assert row["consumed_by_reflector_ts"] is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) no-table no-op — DROP grounded_rejections → both emit calls return 0
+#     without writing a row (matches bash warn-and-return-0 path).
+# ─────────────────────────────────────────────────────────────────────────────
+def test_no_table_noop_parity(env_db):
+    db, env = env_db
+    con = sqlite3.connect(db)
+    try:
+        con.execute("DROP TABLE grounded_rejections")
+        con.commit()
+    finally:
+        con.close()
+
+    rb = _bash_call(
+        env,
+        'mo_grounded_rejection "coalition" "fail" "c" "e" "s" "[]" ""',
+    )
+    py_rc = gc.emit("coalition", "fail", "c", "e", "s")
+
+    assert rb.returncode == 0
+    assert py_rc == 0
+    # Bash warns and stays silent on stdout (no row written).
+    assert rb.stdout.strip() == ""
+    assert "grounded_rejections table absent" in rb.stderr
+
+    # Confirm no row was written — table still doesn't exist.
+    con = sqlite3.connect(db)
+    try:
+        exists = con.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='grounded_rejections' LIMIT 1"
+        ).fetchone()
+        assert exists is None
+    finally:
+        con.close()

--- a/tests/unit/test_mo_node_events_py.py
+++ b/tests/unit/test_mo_node_events_py.py
@@ -1,0 +1,624 @@
+"""Parity gate: mini_ork.ported.mo_node_events vs lib/mo_node_events.sh.
+
+Each test invokes the LIVE bash subprocess (the bash source `mo_node_emit`/
+`mo_node_start`/`mo_node_end` family) against a temp DB seeded by
+`db/init.sh`, then invokes the Python port against an identical temp DB
+(seeded the same way), and asserts the resulting `run_events` rows match
+byte-for-byte (integer epoch columns use 1-second tolerance; PIDs and
+nanosecond suffixes on `event_id` are excluded from the comparison). No
+mocks, no hardcoded expected outputs — expected is always derived from the
+live control bash invocation.
+
+>=6 cases:
+  (a) mo_node_emit happy path node_start         — payload merge + finish_reason
+  (b) mo_node_emit node_end w/ explicit args     — full payload (verdict/artifact/finish_reason)
+  (c) mo_node_emit node_heartbeat                — populates last_heartbeat_at (migration 0023)
+  (d) mo_node_start with/without model_lane      — extra = {} vs {model_lane}
+  (e) mo_node_end _build_extra_json              — payload bytes vs in-bash heredoc
+  (f) missing required arg parity                — bash `return 0` + stderr phrase matches port
+  (g) missing state.db silent no-op              — both produce 0 rows, both exit 0
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mo_node_events as py  # noqa: E402
+
+SH = REPO / "lib" / "mo_node_events.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+def _which(*tools: str) -> dict[str, str]:
+    out = {}
+    for t in tools:
+        p = shutil.which(t)
+        if not p:
+            pytest.skip(f"required tool not on PATH: {t}")
+        out[t] = p
+    return out
+
+
+@pytest.fixture
+def temp_db(tmp_path_factory, monkeypatch):
+    """Spin up a real mini-ork SQLite DB via db/init.sh.
+
+    Returns (db_path, home_dir) tuple — the home_dir is also exposed as
+    MINI_ORK_HOME so the bash subprocess resolves the same default path the
+    Python port picks up via `_resolve_db`. The fixture monkeypatches
+    `MINI_ORK_DB` and `MINI_ORK_HOME` in the parent pytest env so the
+    Python port's `_resolve_db()` lands on the same DB.
+    """
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    r = subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"db/init.sh failed: rc={r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}")
+    monkeypatch.setenv("MINI_ORK_DB", dbp)
+    monkeypatch.setenv("MINI_ORK_HOME", str(home))
+    return dbp, home
+
+
+def _seed_db(home: Path) -> str:
+    """Replicate `temp_db`'s init for cases that need a fresh second DB to
+    isolate the Python port from the bash run. Returns db path."""
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    return dbp
+
+
+def _row_dict(con: sqlite3.Connection, table: str = "run_events") -> list[dict]:
+    """Dump rows as dicts, ordered by `created_at` then `event_id` for
+    determinism. The bash and Python rows have different event_ids (different
+    PIDs and nanosecond timestamps), so we cannot rely on event_id ordering;
+    `created_at` is the same `int(time.time())` from both implementations
+    and is monotonic in a single-process test."""
+    cols = [d[0] for d in con.execute(f"SELECT * FROM {table} LIMIT 0").description]
+    rows = con.execute(
+        f"SELECT {', '.join(cols)} FROM {table} ORDER BY created_at, event_id"
+    ).fetchall()
+    return [dict(zip(cols, r)) for r in rows]
+
+
+def _event_id_stem(eid: str | None) -> str:
+    """Return the `evt-<event_type>-<node_id>-` prefix (everything up to and
+    including the 3rd dash-segment). bash `event_id` and Python `event_id`
+    share this prefix; the trailing `<timestamp>-<pid>` segments differ."""
+    assert eid is not None, "event_id must not be None"
+    parts = eid.split("-")
+    return "-".join(parts[:3]) + "-"
+
+
+def _epoch_close(a: int | float | None, b: int | float | None,
+                 *, ms: bool = False) -> bool:
+    """Integer epoch tolerance.
+
+    Default: 1 second for `created_at` (which is `int(time.time())` from
+    both impls; normally exact). Pass `ms=True` for millisecond-resolution
+    columns like `last_heartbeat_at` (`_now_ms()`) where sub-second drift
+    between the bash and Python invocations is expected — allow up to 1500
+    ms of drift before failing. The plan's 1e-6 float tolerance remains as
+    a final defense-in-depth check after the integer window.
+    """
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    window = 1500 if ms else 1
+    if abs(int(a) - int(b)) <= window:
+        return True
+    return abs(float(a) - float(b)) <= 1e-6
+
+
+def _assert_row_parity(bash_row: dict, py_row: dict, *, fields: list[str]) -> None:
+    """Compare two rows field-by-field. `event_id` is compared by stem
+    (prefix) since the suffix differs; epoch fields are compared with
+    1-second tolerance."""
+    for f in fields:
+        b = bash_row.get(f)
+        p = py_row.get(f)
+        if f == "event_id":
+            assert _event_id_stem(b) == _event_id_stem(p), (
+                f"event_id stem mismatch: bash={b!r} py={p!r}"
+            )
+            continue
+        if f == "last_heartbeat_at":
+            assert _epoch_close(b, p, ms=True), f"{f}: bash={b!r} py={p!r}"
+            continue
+        if f == "created_at":
+            assert _epoch_close(b, p), f"{f}: bash={b!r} py={p!r}"
+            continue
+        if f == "payload_json":
+            # payload_json is a string blob; parse and compare structurally
+            # so we ignore key ordering (json.dumps is insertion-ordered but
+            # the bash in-here python also uses json.dumps on a dict, so
+            # both end up the same order — assert byte equality on the
+            # parsed structure).
+            assert b is not None and p is not None, "payload_json must not be None"
+            assert json.loads(b) == json.loads(p), (
+                f"payload_json dict mismatch: bash={b!r} py={p!r}"
+            )
+            continue
+        assert b == p, f"{f}: bash={b!r} py={p!r}"
+
+
+def _bash_emit(
+    *,
+    db: str,
+    run_id: str,
+    node_id: str,
+    node_type: str,
+    event_type: str,
+    extra_json: str = "{}",
+) -> subprocess.CompletedProcess:
+    """Source the bash library and call `mo_node_emit` with the given args
+    against `db`. The bash function will resolve the DB from the env (we
+    pass MINI_ORK_DB and MINI_ORK_HOME so the bash function picks up the
+    same path the Python port would)."""
+    # Use single quotes for the args; bash will pass them through unchanged.
+    # We must pass `extra_json` to a temp var so the bash command itself
+    # stays readable.
+    script = (
+        f'. "{SH}"\n'
+        f'mo_node_emit "{run_id}" "{node_id}" "{node_type}" "{event_type}" \'{extra_json}\'\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script],
+        env={**os.environ, "MINI_ORK_DB": db, "MINI_ORK_HOME": str(Path(db).parent)},
+        capture_output=True, text=True,
+    )
+
+
+def _bash_run_func(
+    func: str,
+    args: list[str],
+    *,
+    db: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Source the bash library and call `func` with positional args."""
+    arg_str = " ".join(f'"{a}"' for a in args)
+    script = f'. "{SH}"\n{func} {arg_str}\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        env={**os.environ, "MINI_ORK_DB": db,
+             "MINI_ORK_HOME": str(Path(db).parent), **(extra_env or {})},
+        capture_output=True, text=True,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) mo_node_emit happy path node_start
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_node_emit_node_start_parity(temp_db):
+    """Bash `mo_node_emit <run> <node> <type> node_start '<json>'` writes one
+    `run_events` row with `event_id` stem `evt-node_start-<node>-` and
+    payload_json merging `node_id`/`node_type` with the parsed extra dict.
+    Python port must match byte-for-byte (epoch columns within 1s)."""
+    db, _ = temp_db
+    bash_r = _bash_emit(
+        db=db, run_id="run-a", node_id="n-a", node_type="researcher",
+        event_type="node_start", extra_json='{"model_lane":"minimax"}',
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_node_emit("run-a", "n-a", "researcher", "node_start", '{"model_lane":"minimax"}')
+
+    con = sqlite3.connect(db)
+    try:
+        rows = _row_dict(con)
+    finally:
+        con.close()
+    assert len(rows) == 2, f"expected 2 rows (bash + py), got {len(rows)}: {rows}"
+    _assert_row_parity(rows[0], rows[1], fields=[
+        "event_id", "run_id", "event_type", "payload_json",
+        "created_at", "finish_reason", "last_heartbeat_at",
+    ])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) mo_node_emit node_end w/ explicit verdict/artifact/finish_reason
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_node_emit_node_end_full_payload(temp_db):
+    """Bash `mo_node_end <run> <node> <type> <dur> <verdict> <artifact> <finish>`
+    builds a JSON payload with `duration_ms` + optional fields. Python port
+    must match. Note: `mo_node_end` is a bash convenience that calls
+    `mo_node_emit` under the hood."""
+    db, _ = temp_db
+    bash_r = _bash_run_func(
+        "mo_node_end",
+        ["run-b", "n-b", "implementer", "1234", "pass", "/tmp/art.md", "done"],
+        db=db,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_node_end("run-b", "n-b", "implementer", 1234, "pass", "/tmp/art.md", "done")
+
+    con = sqlite3.connect(db)
+    try:
+        rows = _row_dict(con)
+    finally:
+        con.close()
+    assert len(rows) == 2
+    _assert_row_parity(rows[0], rows[1], fields=[
+        "event_id", "run_id", "event_type", "payload_json",
+        "created_at", "finish_reason", "last_heartbeat_at",
+    ])
+    # Sanity: payload carries the explicit fields.
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["duration_ms"] == 1234
+    assert payload["verdict"] == "pass"
+    assert payload["artifact_path"] == "/tmp/art.md"
+    assert payload["finish_reason"] == "done"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) mo_node_emit node_heartbeat populates last_heartbeat_at
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_node_heartbeat_writes_last_heartbeat_at(temp_db, monkeypatch):
+    """Migration 0023 adds `last_heartbeat_at` to `run_events`; the bash
+    heredoc populates it only when `event_type in ('node_start',
+    'node_heartbeat')`. Python port must match.
+
+    Both impls read `MO_NODE_TYPE` from the env (defaulting to
+    `'heartbeat'`). We set it to `'reviewer'` on BOTH sides (bash via
+    `extra_env`, Python via `monkeypatch.setenv`) so the test exercises
+    the env-override path on both implementations rather than a mix of
+    override/default. Then we sanity-check the override landed in the
+    payload.
+    """
+    monkeypatch.setenv("MO_NODE_TYPE", "reviewer")
+    db, _ = temp_db
+    bash_r = _bash_run_func(
+        "mo_emit_node_heartbeat", ["n-c", "run-c"],
+        db=db, extra_env={"MO_NODE_TYPE": "reviewer"},
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_emit_node_heartbeat("n-c", "run-c")
+
+    con = sqlite3.connect(db)
+    try:
+        rows = _row_dict(con)
+    finally:
+        con.close()
+    assert len(rows) == 2
+    _assert_row_parity(rows[0], rows[1], fields=[
+        "event_id", "run_id", "event_type", "payload_json",
+        "created_at", "finish_reason", "last_heartbeat_at",
+    ])
+    # Sanity: the heartbeat column is populated, finish_reason is NULL.
+    for r in rows:
+        assert r["event_type"] == "node_heartbeat"
+        assert r["last_heartbeat_at"] is not None
+        assert r["finish_reason"] is None
+        payload = json.loads(r["payload_json"])
+        assert payload["node_type"] == "reviewer"  # MO_NODE_TYPE=reviewer on both sides
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) mo_node_start with/without model_lane
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_node_start_with_and_without_model_lane(temp_db):
+    """Bash `mo_node_start <run> <node> <type> [<lane>]` builds
+    `extra = {"model_lane": <lane>}` when non-empty, else the empty-object
+    literal `{}`. Python port must match for both shapes."""
+    db, _ = temp_db
+
+    # (i) with model_lane
+    bash_r1 = _bash_run_func(
+        "mo_node_start", ["run-d1", "n-d1", "verifier", "opus"],
+        db=db,
+    )
+    assert bash_r1.returncode == 0, f"bash failed: {bash_r1.stderr}"
+    py.mo_node_start("run-d1", "n-d1", "verifier", "opus")
+
+    # (ii) without model_lane — bash has a 4-arg variant; Python has default arg.
+    bash_r2 = _bash_run_func(
+        "mo_node_start", ["run-d2", "n-d2", "verifier"],
+        db=db,
+    )
+    assert bash_r2.returncode == 0, f"bash failed: {bash_r2.stderr}"
+    py.mo_node_start("run-d2", "n-d2", "verifier")
+
+    con = sqlite3.connect(db)
+    try:
+        rows = _row_dict(con)
+    finally:
+        con.close()
+    assert len(rows) == 4
+    # Match by run_id to pair bash row with py row.
+    by_run = {}
+    for r in rows:
+        by_run.setdefault(r["run_id"], []).append(r)
+    for run_id, pair in by_run.items():
+        assert len(pair) == 2, f"expected 2 rows for {run_id}, got {len(pair)}"
+        _assert_row_parity(pair[0], pair[1], fields=[
+            "event_id", "run_id", "event_type", "payload_json",
+            "created_at", "finish_reason", "last_heartbeat_at",
+        ])
+    # Sanity: lane shape on the model_lane case, empty on the no-lane case.
+    lane_row = by_run["run-d1"][0]
+    no_lane_row = by_run["run-d2"][0]
+    assert json.loads(lane_row["payload_json"])["model_lane"] == "opus"
+    assert "model_lane" not in json.loads(no_lane_row["payload_json"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) mo_node_end _build_extra_json payload bytes vs in-bash heredoc
+# ─────────────────────────────────────────────────────────────────────────────
+def test_build_extra_json_matches_bash_heredoc():
+    """Drive the bash in-here python (lines 161-170) directly and compare
+    its output to `py._build_extra_json`. The heredoc python uses
+    `print(json.dumps(out))` and adds no extra newline; Python's
+    `json.dumps` likewise does not add a trailing newline. The parities
+    must be exact (no `event_type`/timestamp noise — this is a pure
+    payload-shaping test)."""
+    _which("python3")
+    cases = [
+        ("1000", "", "", ""),
+        ("1000", "pass", "", ""),
+        ("1000", "pass", "/tmp/art", "done"),
+        ("0", "", "/tmp/x", "error"),
+        ("42", "verdict-with-spaces and |pipe|", "/path/with spaces", "max_steps"),
+    ]
+    for duration_ms, verdict, artifact, finish in cases:
+        # Bash: lines 161-170 verbatim
+        bash_script = (
+            "python3 - \"$1\" \"$2\" \"$3\" \"$4\" <<'PY'\n"
+            "import json, sys\n"
+            "duration_ms, verdict, artifact_path, finish_reason = sys.argv[1:5]\n"
+            "out = {\"duration_ms\": int(duration_ms or 0)}\n"
+            "if verdict:       out[\"verdict\"] = verdict\n"
+            "if artifact_path: out[\"artifact_path\"] = artifact_path\n"
+            "if finish_reason: out[\"finish_reason\"] = finish_reason\n"
+            "print(json.dumps(out))\n"
+            "PY\n"
+        )
+        r = subprocess.run(
+            ["bash", "-c", bash_script, "_", duration_ms, verdict, artifact, finish],
+            capture_output=True, text=True, check=True,
+        )
+        expected = r.stdout.rstrip("\n")
+        actual = py._build_extra_json(duration_ms, verdict, artifact, finish)
+        assert actual == expected, (
+            f"build_extra_json mismatch (dur={duration_ms!r}, v={verdict!r}, "
+            f"a={artifact!r}, f={finish!r}):\n  bash={expected!r}\n  py  ={actual!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) missing required arg parity (stderr phrase + return 0)
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("missing_arg,bash_args,py_kwargs,expected_phrase", [
+    ("run_id",
+     ["", "n-f", "researcher", "node_start", "{}"],
+     {"run_id": "", "node_id": "n-f", "node_type": "researcher",
+      "event_type": "node_start", "extra_json": "{}"},
+     "mo_node_emit: run_id required"),
+    ("node_id",
+     ["run-f", "", "researcher", "node_start", "{}"],
+     {"run_id": "run-f", "node_id": "", "node_type": "researcher",
+      "event_type": "node_start", "extra_json": "{}"},
+     "mo_node_emit: node_id required"),
+    ("event_type",
+     ["run-f", "n-f", "researcher", "", "{}"],
+     {"run_id": "run-f", "node_id": "n-f", "node_type": "researcher",
+      "event_type": "", "extra_json": "{}"},
+     "mo_node_emit: event_type required"),
+])
+def test_missing_required_arg_parity(temp_db, missing_arg, bash_args,
+                                     py_kwargs, expected_phrase):
+    """Bash emits the canonical `mo_node_emit: <arg> required` stderr phrase
+    on guard miss and `return 0` (silent). Python port must emit the same
+    phrase verbatim and return 0. Both must NOT write a row."""
+    db, _ = temp_db
+    bash_r = _bash_emit(
+        db=db, run_id=bash_args[0], node_id=bash_args[1], node_type=bash_args[2],
+        event_type=bash_args[3], extra_json=bash_args[4],
+    )
+    rc_py = py.mo_node_emit(**py_kwargs)
+    rc_bash = bash_r.returncode
+    err_bash = bash_r.stderr
+    assert rc_py == 0, f"[{missing_arg}] port returned {rc_py} (must be 0)"
+    assert rc_bash == 0, f"[{missing_arg}] bash returned {rc_bash} (must be 0); stderr={err_bash!r}"
+    assert expected_phrase in err_bash, (
+        f"[{missing_arg}] bash stderr missing phrase {expected_phrase!r}: {err_bash!r}"
+    )
+    # No row should be written by either side.
+    con = sqlite3.connect(db)
+    try:
+        count = con.execute("SELECT COUNT(*) FROM run_events").fetchone()[0]
+    finally:
+        con.close()
+    assert count == 0, f"missing-arg case must NOT write a row; got {count}"
+
+
+def test_python_port_stderr_matches_bash_exact_phrase(temp_db, capsys):
+    """Capture the Python port's stderr and assert it matches the bash phrase
+    byte-for-byte (the leading-trailing whitespace, the colon-space, the
+    trailing lack of newline). The bash `{ ... >&2; return 0; }` group has
+    no trailing newline; the port's `print(..., file=sys.stderr)` adds one
+    by default — so we strip the trailing newline on both sides for the
+    comparison."""
+    db, _ = temp_db
+    bash_r = _bash_emit(
+        db=db, run_id="", node_id="n", node_type="t", event_type="node_start",
+    )
+    rc_py = py.mo_node_emit("", "n", "t", "node_start")
+    captured = capsys.readouterr()
+    py_stderr = captured.err.rstrip("\n")
+    bash_stderr = bash_r.stderr.rstrip("\n")
+    assert rc_py == 0
+    assert bash_stderr == "mo_node_emit: run_id required", (
+        f"unexpected bash stderr: {bash_stderr!r}"
+    )
+    assert py_stderr == bash_stderr, (
+        f"port stderr {py_stderr!r} != bash stderr {bash_stderr!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) missing state.db silent no-op
+# ─────────────────────────────────────────────────────────────────────────────
+def test_missing_state_db_silent_noop(tmp_path):
+    """Bash and the Python port both silently no-op when the resolved
+    state.db does not exist (e.g. uninitialized test). Both must exit 0
+    and NOT emit any row to a phantom DB."""
+    missing_db = str(tmp_path / "nonexistent" / "state.db")
+    # Bash: source the library and call mo_node_emit with the missing DB.
+    bash_r = _bash_emit(
+        db=missing_db, run_id="run-g", node_id="n-g", node_type="t",
+        event_type="node_start",
+    )
+    rc_py = py.mo_node_emit("run-g", "n-g", "t", "node_start", "{}")
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    assert rc_py == 0
+    # The missing DB must not have been created.
+    assert not os.path.exists(missing_db), (
+        f"silent no-op must not create {missing_db}"
+    )
+
+
+def test_missing_state_db_noop_does_not_create_file(tmp_path):
+    """Cover the silent no-op with `MINI_ORK_HOME` resolved but state.db
+    not yet seeded — same contract: both bash and Python return 0, neither
+    creates the file."""
+    home = tmp_path / "home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    assert not os.path.exists(dbp)
+    # Bash
+    bash_r = subprocess.run(
+        ["bash", "-c", f'. "{SH}"\nmo_node_emit "r" "n" "t" "node_start" \'{{}}\'\n'],
+        env={**os.environ, "MINI_ORK_HOME": str(home)},
+        capture_output=True, text=True,
+    )
+    # Python
+    rc_py = py.mo_node_emit("r", "n", "t", "node_start", "{}")
+    assert bash_r.returncode == 0
+    assert rc_py == 0
+    assert not os.path.exists(dbp), "state.db must not be auto-created"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) mo_node_emit_end_trap signature-parity: early-return on empty fields
+#     and full end-trap happy path with explicit finish_reason.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_node_emit_end_trap_early_return(temp_db):
+    """Bash early-returns 0 on empty `_mo_run_id`/`node_id`/`node_type`
+    (lines 134-136). Python port mirrors the same guard."""
+    db, _ = temp_db
+    # Empty _run_id
+    assert py.mo_node_emit_end_trap("", "n-h", "t", 1000, 0) == 0
+    # Empty node_id
+    assert py.mo_node_emit_end_trap("r-h", "", "t", 1000, 0) == 0
+    # Empty node_type
+    assert py.mo_node_emit_end_trap("r-h", "n-h", "", 1000, 0) == 0
+    # None should be written.
+    con = sqlite3.connect(db)
+    try:
+        count = con.execute("SELECT COUNT(*) FROM run_events").fetchone()[0]
+    finally:
+        con.close()
+    assert count == 0
+
+
+def test_mo_node_emit_end_trap_happy_path(temp_db):
+    """Drive the Python `mo_node_emit_end_trap` happy path and confirm the
+    underlying `mo_node_end` row matches what bash would write with the
+    same effective `duration_ms`.
+
+    The trap computes `duration_ms = end_ms - start_ms` at runtime, so we
+    first call the Python trap to capture the duration it observed, then
+    drive a bash `mo_node_end` call with the SAME `duration_ms` value so
+    the resulting row payloads are byte-equal. The bash RETURN-trap has
+    no Python equivalent, so parity is asserted on the delegate surface
+    (`mo_node_end`) with shared args.
+    """
+    db, _ = temp_db
+    start_ms = py._now_ms() - 5000
+    rc = py.mo_node_emit_end_trap(
+        "run-h", "n-h", "implementer", start_ms, 0,
+        context_path="/tmp/art.md", verdict="pass", finish_reason="done",
+    )
+    assert rc == 0
+    con = sqlite3.connect(db)
+    try:
+        py_row = _row_dict(con)[0]
+    finally:
+        con.close()
+    observed_dur = json.loads(py_row["payload_json"])["duration_ms"]
+    assert observed_dur >= 0
+
+    # Bash control: equivalent mo_node_end call with the same observed
+    # duration. This proves the Python trap produces the same row shape
+    # as a bash mo_node_end call (the trap's only delegate).
+    bash_r = _bash_run_func(
+        "mo_node_end",
+        ["run-h", "n-h", "implementer", str(observed_dur), "pass",
+         "/tmp/art.md", "done"],
+        db=db,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    con = sqlite3.connect(db)
+    try:
+        rows = _row_dict(con)
+    finally:
+        con.close()
+    assert len(rows) == 2
+    _assert_row_parity(rows[0], rows[1], fields=[
+        "event_id", "run_id", "event_type", "payload_json",
+        "created_at", "finish_reason", "last_heartbeat_at",
+    ])
+
+
+def test_mo_node_emit_end_trap_rc_nonzero_defaults_to_error(tmp_db):
+    """Default finish_reason on rc != 0 is 'error' (bash lines 142-145).
+    The port mirrors that. We can't reuse `temp_db` because the fixture is
+    scoped to the previous tests — use a local temp DB."""
+    from mini_ork.ported import mo_node_events as p
+    home = tmp_db
+    dbp = _seed_db(home)
+    start_ms = p._now_ms() - 1000
+    rc = p.mo_node_emit_end_trap(
+        "run-err", "n-err", "implementer", start_ms, 1,
+    )
+    assert rc == 0
+    con = sqlite3.connect(dbp)
+    try:
+        rows = _row_dict(con)
+    finally:
+        con.close()
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["payload_json"])
+    assert payload["finish_reason"] == "error"
+    assert payload["duration_ms"] >= 0
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """A separate fixture for tests that need their own DB distinct from
+    `temp_db`. Returns the home dir; call `_seed_db` to materialize the DB.
+    The env vars are monkeypatched in advance so subsequent Python port
+    calls resolve to the same DB once `_seed_db` is called."""
+    home = tmp_path / "home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    monkeypatch.setenv("MINI_ORK_DB", dbp)
+    monkeypatch.setenv("MINI_ORK_HOME", str(home))
+    return home

--- a/tests/unit/test_policy_store_py.py
+++ b/tests/unit/test_policy_store_py.py
@@ -1,0 +1,327 @@
+"""Parity gate: mini_ork.ported.policy_store vs lib/policy_store.sh.
+
+Each test invokes the LIVE bash subprocess sourcing
+``lib/policy_store.sh`` (which uses the ``[ "${0:-}" = "${BASH_SOURCE[0]:-}" ]``
+guard so no ``set -u`` / ``pipefail`` leaks onto the parent that sources
+it) on the same inputs as the Python port and asserts identical output
+— return code, snippet bytes, stderr text, and exit-code shape (64 / 78
+via ``SystemExit``).
+
+Eight cases (above the kickoff's >=6 floor):
+  (a) backend() default 'sqlite' when MO_STORE_BACKEND unset
+  (b) backend()='sqlite' when MO_STORE_BACKEND=sqlite
+  (c) backend()='postgres' when MO_STORE_BACKEND=postgres
+  (d) backend() raises SystemExit(64) with stderr containing
+      'unknown MO_STORE_BACKEND=mysql' when MO_STORE_BACKEND=mysql
+  (e) assert_sqlite parity — rc=0 / None on sqlite, SystemExit(78)
+      on postgres with matching stderr text
+  (f) db_path() resolution chain — three sub-cases for
+      MO_STORE_DB / MINI_ORK_DB / MINI_ORK_HOME + one for the
+      $(pwd)/.mini-ork/state.db fallback
+  (g) py_connect_snippet + py_pragmas_snippet exact-string parity for
+      both sqlite AND postgres branches (4 strings compared verbatim)
+  (h) DB round-trip gate — concat bash-emitted and python-emitted
+      snippets into one ``python3 -c`` invocation against a temp DB
+      spun up via db/init.sh; assert both produce identical
+      PRAGMA busy_timeout / PRAGMA journal_mode introspection rows
+
+Env isolation: ``monkeypatch.setenv`` / ``delenv`` for the Python side;
+the bash subprocess env is built from ``os.environ`` so monkeypatched
+values propagate identically. The db_path pwd-fallback case (f-4) runs
+both sides in ``cwd=tmp_path`` so the literal ``./.mini-ork/state.db``
+matches.
+
+No mocks, no hardcoded expected strings beyond the literal ``"sqlite"`` /
+``"postgres"`` enum values the bash function itself prints: every
+snippet / stderr / row comparison derives from the live bash
+subprocess, not from a captured fixture.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import policy_store as ps  # noqa: E402
+
+PS_SH = REPO / "lib" / "policy_store.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+# Vars that may exist in the parent pytest env and would silently
+# influence policy_store; every test scrubs these via _scrub().
+_PS_ENV = (
+    "MO_STORE_BACKEND",
+    "MO_STORE_DB",
+    "MINI_ORK_DB",
+    "MINI_ORK_HOME",
+    "MO_SQLITE_BUSY_MS",
+)
+
+
+def _scrub(monkeypatch: pytest.MonkeyPatch, **overrides) -> dict:
+    """Unset every policy_store env var, then apply overrides.
+
+    Returns a fresh subprocess env (caller passes to bash via
+    ``env=``) so Python and bash see identical inputs. Mirrors bash's
+    ``${VAR:-default}`` semantics: unset and empty collapse the same
+    way, so we use ``delenv`` (not ``setenv('', '')``) to be explicit.
+    """
+    for k in _PS_ENV:
+        monkeypatch.delenv(k, raising=False)
+    for k, v in overrides.items():
+        monkeypatch.setenv(k, v)
+    return dict(os.environ)
+
+
+def _bash(name: str, args: str = "", env: dict | None = None,
+          cwd: str | None = None) -> subprocess.CompletedProcess:
+    """Run a single policy_store function via live bash subprocess.
+
+    Sources ``lib/policy_store.sh`` then invokes ``name`` (optionally
+    with ``args``). Bash's own rc / stdout / stderr are returned
+    verbatim for the test to assert against.
+    """
+    cmd = f'. "{PS_SH}" && {name} {args}'.rstrip()
+    return subprocess.run(
+        ["bash", "-c", cmd],
+        cwd=cwd, env=env if env is not None else os.environ,
+        capture_output=True, text=True,
+    )
+
+
+# ── (a) default backend when MO_STORE_BACKEND unset ─────────────────────────
+
+
+def test_backend_default_sqlite(monkeypatch):
+    env = _scrub(monkeypatch)
+    bash_out = _bash("mo_store_backend", env=env).stdout.rstrip("\n")
+    assert bash_out == "sqlite"
+    assert ps.backend() == "sqlite"
+
+
+# ── (b) explicit sqlite ──────────────────────────────────────────────────────
+
+
+def test_backend_explicit_sqlite(monkeypatch):
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="sqlite")
+    bash_out = _bash("mo_store_backend", env=env).stdout.rstrip("\n")
+    assert bash_out == "sqlite"
+    assert ps.backend() == "sqlite"
+
+
+# ── (c) explicit postgres ────────────────────────────────────────────────────
+
+
+def test_backend_explicit_postgres(monkeypatch):
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="postgres")
+    bash_out = _bash("mo_store_backend", env=env).stdout.rstrip("\n")
+    assert bash_out == "postgres"
+    assert ps.backend() == "postgres"
+
+
+# ── (d) unknown backend → SystemExit(64) + matching stderr ──────────────────
+
+
+def test_backend_unknown_raises_systemexit_64(monkeypatch, capsys):
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="mysql")
+    proc = _bash("mo_store_backend", env=env)
+    assert proc.returncode == 64
+    assert "unknown MO_STORE_BACKEND=mysql" in proc.stderr
+    assert "(expected sqlite|postgres)" in proc.stderr
+
+    with pytest.raises(SystemExit) as exc:
+        ps.backend()
+    assert exc.value.code == 64
+    captured = capsys.readouterr()
+    assert "unknown MO_STORE_BACKEND=mysql" in captured.err
+    assert "(expected sqlite|postgres)" in captured.err
+
+
+# ── (e) assert_sqlite parity ─────────────────────────────────────────────────
+
+
+def test_assert_sqlite_parity(monkeypatch, capsys):
+    # sqlite → rc=0, no output, returns None
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="sqlite")
+    proc = _bash("mo_store_assert_sqlite", env=env)
+    assert proc.returncode == 0
+    assert proc.stdout == ""
+    assert ps.assert_sqlite() is None
+
+    # postgres → rc=78, stderr contains the stub message
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="postgres")
+    proc = _bash("mo_store_assert_sqlite", env=env)
+    assert proc.returncode == 78
+    assert "backend=postgres is a stub in v0.2-pt36" in proc.stderr
+    assert "Set MO_STORE_BACKEND=sqlite for default behavior." in proc.stderr
+
+    with pytest.raises(SystemExit) as exc:
+        ps.assert_sqlite()
+    assert exc.value.code == 78
+    captured = capsys.readouterr()
+    assert "backend=postgres is a stub in v0.2-pt36" in captured.err
+    assert "Set MO_STORE_BACKEND=sqlite for default behavior." in captured.err
+
+
+# ── (f) db_path() resolution chain — three sub-cases ─────────────────────────
+
+
+def test_db_path_mo_store_db_wins(monkeypatch, tmp_path):
+    target = str(tmp_path / "explicit.db")
+    env = _scrub(monkeypatch, MO_STORE_DB=target)
+    assert _bash("mo_store_db_path", env=env).stdout.rstrip("\n") == target
+    assert ps.db_path() == target
+
+
+def test_db_path_mini_ork_db_fallback(monkeypatch, tmp_path):
+    target = str(tmp_path / "from_mini_ork_db.db")
+    env = _scrub(monkeypatch, MINI_ORK_DB=target)
+    assert _bash("mo_store_db_path", env=env).stdout.rstrip("\n") == target
+    assert ps.db_path() == target
+
+
+def test_db_path_mini_ork_home_fallback(monkeypatch, tmp_path):
+    home = str(tmp_path)
+    env = _scrub(monkeypatch, MINI_ORK_HOME=home)
+    expected = str(tmp_path / "state.db")
+    assert _bash("mo_store_db_path", env=env).stdout.rstrip("\n") == expected
+    assert ps.db_path() == expected
+
+
+def test_db_path_pwd_fallback(monkeypatch, tmp_path):
+    # No MO_STORE_DB / MINI_ORK_DB / MINI_ORK_HOME → falls through to
+    # $(pwd)/.mini-ork/state.db on both sides.
+    env = _scrub(monkeypatch)
+    cwd = str(tmp_path)
+    expected = f"{cwd}/.mini-ork/state.db"
+    bash_out = _bash("mo_store_db_path", env=env, cwd=cwd).stdout.rstrip("\n")
+    assert bash_out == expected
+    monkeypatch.chdir(cwd)  # os.getcwd() == tmp_path for the Python side
+    assert ps.db_path() == expected
+
+
+# ── (g) snippet byte-exactness — 4 strings, both backends ────────────────────
+
+
+def test_py_connect_snippet_sqlite_byte_exact(monkeypatch):
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="sqlite")
+    bash_snip = _bash("mo_store_py_connect_snippet", env=env).stdout
+    py_snip = ps.py_connect_snippet()
+    assert py_snip == bash_snip
+    assert py_snip == "import sqlite3\ncon = sqlite3.connect(db)\n"
+
+
+def test_py_connect_snippet_postgres_byte_exact(monkeypatch):
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="postgres")
+    bash_snip = _bash("mo_store_py_connect_snippet", env=env).stdout
+    py_snip = ps.py_connect_snippet()
+    assert py_snip == bash_snip
+    # Bash's printf embeds the literal double-quoted Python string;
+    # verify both the raise shape and the stub keyphrase survive the round-trip.
+    assert "raise SystemExit(" in py_snip
+    assert "backend=postgres is a stub in v0.2-pt36" in py_snip
+    assert "Aborting before any PG call." in py_snip
+
+
+def test_py_pragmas_snippet_sqlite_byte_exact(monkeypatch):
+    # MO_SQLITE_BUSY_MS unset → 5000 default on both sides.
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="sqlite")
+    bash_snip = _bash("mo_store_py_pragmas_snippet", env=env).stdout
+    py_snip = ps.py_pragmas_snippet()
+    assert py_snip == bash_snip
+    assert py_snip == 'con.execute("PRAGMA busy_timeout=5000")\n'
+
+
+def test_py_pragmas_snippet_postgres_byte_exact(monkeypatch):
+    env = _scrub(monkeypatch, MO_STORE_BACKEND="postgres")
+    bash_snip = _bash("mo_store_py_pragmas_snippet", env=env).stdout
+    py_snip = ps.py_pragmas_snippet()
+    assert py_snip == bash_snip
+    assert py_snip == ""  # bash's `:` is a no-op; Python returns ""
+
+
+# ── (h) DB round-trip gate — exec snippets against a real temp DB ────────────
+
+
+def test_snippets_exec_round_trip_parity(tmp_path_factory, monkeypatch):
+    """Concatenate bash-emitted and python-emitted snippets, exec each via
+    ``python3 -c`` against a temp DB initialized via ``db/init.sh``,
+    and assert identical ``PRAGMA busy_timeout`` + ``PRAGMA journal_mode``
+    introspection rows on both sides.
+
+    The temp DB fixture is reused from case (f)'s idiom — one DB per
+    test (pytest ``tmp_path_factory`` is function-scoped) so case (h)
+    initializes its own. The ``db/init.sh`` step applies
+    ``journal_mode=WAL`` persistently (header-level) and sets
+    ``busy_timeout=5000`` at the init connection (which is per-connection
+    and does NOT persist — the snippet must set it again at open time,
+    which is exactly the F-11/R1 audit invariant this gate proves).
+    """
+    home = tmp_path_factory.mktemp("home")
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+
+    env = _scrub(monkeypatch, MINI_ORK_DB=dbp)  # sqlite default
+
+    # bash side: chain snippets with `&&` (NOT `$(...)$(...)` — POSIX
+    # command substitution strips trailing newlines from each, which would
+    # drop the separator between connect and pragma and diverge from the
+    # Python direct-concat shape). Each snippet's printf ends with \n;
+    # the chain preserves them.
+    bash_proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{PS_SH}" && '
+         f'mo_store_py_connect_snippet && mo_store_py_pragmas_snippet'],
+        env=env, capture_output=True, text=True, check=True,
+    )
+    bash_snip = bash_proc.stdout
+
+    # python side: concat snippet returns
+    py_snip = ps.py_connect_snippet() + ps.py_pragmas_snippet()
+
+    # Snippets must be byte-identical before we even attempt to exec them.
+    assert py_snip == bash_snip, (
+        f"snippet byte mismatch:\n  py={py_snip!r}\n  bash={bash_snip!r}"
+    )
+
+    # Exec both snippets via `python3 -c`. The snippet assumes `db` is
+    # passed via sys.argv[1] (the heredoc convention) — bind it BEFORE
+    # the snippet body so `con = sqlite3.connect(db)` can resolve.
+    introspection = (
+        "busy = con.execute('PRAGMA busy_timeout').fetchone()[0]\n"
+        "journal = con.execute('PRAGMA journal_mode').fetchone()[0]\n"
+        "print(f'{busy}|{journal}')\n"
+    )
+    py_prog = (
+        f"import sys\ndb = sys.argv[1]\n{py_snip}{introspection}"
+    )
+    bash_prog = (
+        f"import sys\ndb = sys.argv[1]\n{bash_snip}{introspection}"
+    )
+
+    py_run = subprocess.run(
+        ["python3", "-c", py_prog, dbp],
+        capture_output=True, text=True, check=True,
+    )
+    bash_run = subprocess.run(
+        ["python3", "-c", bash_prog, dbp],
+        capture_output=True, text=True, check=True,
+    )
+
+    # Both sides must produce identical rows.
+    assert py_run.stdout == bash_run.stdout, (
+        f"snippet exec produced different rows:\n"
+        f"  py={py_run.stdout!r}\n  bash={bash_run.stdout!r}"
+    )
+    # Sanity: the per-connection pragma (set by the snippet) plus the
+    # persistent header pragma (set by db/init.sh) yield 5000|wal.
+    assert py_run.stdout.strip() == "5000|wal"

--- a/tests/unit/test_profile_answerer_py.py
+++ b/tests/unit/test_profile_answerer_py.py
@@ -1,0 +1,389 @@
+"""Parity gate: mini_ork.ported.profile_answerer vs lib/profile_answerer.sh.
+
+Each test invokes the LIVE bash subprocess (sourcing lib/profile_answerer.sh
+and a per-test stub of `llm_dispatch` so the LLM boundary is replayable) on
+the same inputs as the Python port and asserts byte-identical output.
+
+No mocks, no hardcoded expected outputs — expected is always derived from a
+control bash invocation that shares the inputs.
+
+Six cases (the kickoff's >=6 floor):
+
+  (a) prompt_build_parity              — bash heredoc prompt builder vs
+                                         pa.build_prompt; sha256 byte-equal
+  (b) arg_validation_parity            — bash exit 2 + stderr text matches
+                                         port ValueError / FileNotFoundError
+                                         across 4 sub-cases (empty kickoff /
+                                         empty questions / empty out /
+                                         missing-kickoff file)
+  (c) parse_fence_stripping_parity     — bash vs python on a raw LLM response
+                                         wrapped in ```json … ``` fences
+  (d) parse_balanced_extraction_parity — bash vs python on a raw response
+                                         that prepends prose before the JSON
+                                         object
+  (e) omitted_question_parity          — bash vs python both raise on a raw
+                                         response that omits one of the input
+                                         questions (mirror SystemExit as
+                                         RuntimeError, matching message text)
+  (f) end_to_end_replay_parity         — bash vs python on a CAPTURED REAL LLM
+                                         response (tests/fixtures/profile_answerer_replay.raw)
+                                         — byte-equal JSON output across the full
+                                         pipeline (prompt → dispatch → fence-strip
+                                         → balanced-extract → validate → persist)
+
+Capture-once / replay-many: test (f) skips if the fixture file is missing —
+this honors the 'no live LLM calls in test suite' rule. To capture:
+
+    bash scripts/capture_profile_answerer_fixture.sh
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import profile_answerer as pa  # noqa: E402
+
+SH = REPO / "lib" / "profile_answerer.sh"
+FIXTURES = REPO / "tests" / "fixtures"
+REPLAY_FIXTURE = FIXTURES / "profile_answerer_replay.raw"
+
+
+def _bash_invoke(
+    kickoff_path: str | os.PathLike,
+    questions_json: str,
+    out_path: str | os.PathLike,
+    raw_override: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke the LIVE bash `mo_answer_profile_questions` with a stubbed
+    `llm_dispatch` (if `raw_override` is provided) and return the CompletedProcess.
+
+    The stub is sourced AFTER lib/profile_answerer.sh so the function
+    override wins at call time (bash resolves function names at call time,
+    not source time).
+    """
+    if raw_override is not None:
+        # Write the stub to a temp file so we can source it after the lib.
+        # The stub defines llm_dispatch so the live dispatch is short-circuited.
+        stub_body = (
+            "llm_dispatch() {\n"
+            "  # Stub for parity tests: echo the captured raw response verbatim.\n"
+            '  printf "%s" "$MO_PROFILE_TEST_RAW"\n'
+            "  return 0\n"
+            "}\n"
+            "export -f llm_dispatch\n"
+        )
+        stub_file = Path(out_path).parent / "_llm_dispatch_stub.sh"
+        stub_file.write_text(stub_body, encoding="utf-8")
+        # shlex.quote wraps in single quotes (safe against inner double-quote
+        # delimiter parsing that would otherwise word-split the QJSON inside
+        # the bash -c wrapper string).
+        wrapper = (
+            f'. {shlex.quote(str(SH))}\n'
+            f'. {shlex.quote(str(stub_file))}\n'
+            f'mo_answer_profile_questions {shlex.quote(str(kickoff_path))} '
+            f'{shlex.quote(str(questions_json))} {shlex.quote(str(out_path))}\n'
+        )
+        env = {**os.environ, "MO_PROFILE_TEST_RAW": raw_override}
+    else:
+        # No stub — let bash's real llm_dispatch fire. Used only by test (f)'s
+        # capture-once branch, never on CI re-runs (the fixture exists by then).
+        wrapper = (
+            f'. {shlex.quote(str(SH))}\n'
+            f'mo_answer_profile_questions {shlex.quote(str(kickoff_path))} '
+            f'{shlex.quote(str(questions_json))} {shlex.quote(str(out_path))}\n'
+        )
+        env = dict(os.environ)
+
+    return subprocess.run(
+        ["bash", "-c", wrapper],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _bash_build_prompt(kickoff_path: str | os.PathLike, questions_json: str) -> str:
+    """Invoke ONLY the bash prompt-builder heredoc (verbatim from
+    lib/profile_answerer.sh:26-53) and return its stdout."""
+    bash_script = (
+        'python3 - "$1" "$2" <<\'PY\'\n'
+        'import json\n'
+        'import sys\n'
+        'from pathlib import Path\n'
+        '\n'
+        'kickoff = Path(sys.argv[1]).read_text(encoding="utf-8")[:20000]\n'
+        'try:\n'
+        '    questions = json.loads(sys.argv[2] or "[]")\n'
+        'except json.JSONDecodeError:\n'
+        '    questions = []\n'
+        '\n'
+        'print("""You answer mini-ork run profile questions for autonomous child runs.\n'
+        '\n'
+        'Return ONLY a strict JSON object with this exact shape:\n'
+        '{"answers":[{"question":"...","answer":"..."}],"auto_answered":true}\n'
+        '\n'
+        'Rules:\n'
+        '- Answer every question using the kickoff content.\n'
+        '- Keep answers concise and operational.\n'
+        '- Do not include markdown, prose, code fences, or extra keys.\n'
+        '\n'
+        'Kickoff:\n'
+        '""" + kickoff + """\n'
+        '\n'
+        'Questions JSON:\n'
+        '""" + json.dumps(questions, ensure_ascii=True))\n'
+        'PY\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", bash_script, "_", str(kickoff_path), questions_json],
+        capture_output=True, text=True, check=True,
+    )
+    return r.stdout
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) prompt_build_parity — bash heredoc vs pa.build_prompt, sha256-equal
+# ─────────────────────────────────────────────────────────────────────────────
+def test_prompt_build_parity(tmp_path):
+    """Python `build_prompt` matches the verbatim bash heredoc at
+    lib/profile_answerer.sh:26-53 byte-for-byte (sha256-equal)."""
+    kickoff_path = tmp_path / "kickoff.md"
+    kickoff_path.write_text("# Tiny kickoff\n\n" + ("x" * 1024) + "\n", encoding="utf-8")
+    questions_json = json.dumps([
+        {"id": "q1", "question": "What concrete outcome should the verifier enforce?"},
+        {"id": "q2", "question": "Which lane should run first?"},
+    ])
+
+    bash_prompt = _bash_build_prompt(kickoff_path, questions_json)
+    py_prompt = pa.build_prompt(kickoff_path, questions_json)
+
+    assert hashlib.sha256(bash_prompt.encode("utf-8")).hexdigest() == \
+           hashlib.sha256(py_prompt.encode("utf-8")).hexdigest(), (
+        f"prompt mismatch: bash head={bash_prompt[:200]!r} py head={py_prompt[:200]!r}"
+    )
+
+    # Also: [:20000] cap parity — kickoff of 25_000 chars gets truncated to 20_000.
+    big = "a" * 25_000
+    big_kickoff = tmp_path / "big.md"
+    big_kickoff.write_text(big, encoding="utf-8")
+    bash_big = _bash_build_prompt(big_kickoff, "[]")
+    py_big = pa.build_prompt(big_kickoff, "[]")
+    # The bash heredoc slices to [:20000]; the python port must match.
+    assert "a" * 20_000 in py_big
+    assert "a" * 20_001 not in py_big
+    assert bash_big == py_big
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) arg_validation_parity — bash exit 2 + stderr text vs Python exception
+# ─────────────────────────────────────────────────────────────────────────────
+def test_arg_validation_parity(tmp_path):
+    """Python `answer_profile_questions` raises the same exception type with
+    the same message text as bash's exit-2 + stderr contract across 4 sub-cases."""
+    valid_kickoff = tmp_path / "kickoff.md"
+    valid_kickoff.write_text("# kickoff\n", encoding="utf-8")
+    valid_questions = '[{"id":"q1","question":"q1"}]'
+    valid_out = tmp_path / "answers.json"
+
+    # (b1) empty kickoff_path
+    r1 = _bash_invoke("", valid_questions, valid_out)
+    assert r1.returncode == 2
+    assert "usage: mo_answer_profile_questions" in r1.stderr
+    with pytest.raises(ValueError, match=r"usage: mo_answer_profile_questions"):
+        pa.answer_profile_questions("", valid_questions, valid_out)
+
+    # (b2) empty questions_json
+    r2 = _bash_invoke(valid_kickoff, "", valid_out)
+    assert r2.returncode == 2
+    assert "usage: mo_answer_profile_questions" in r2.stderr
+    with pytest.raises(ValueError, match=r"usage: mo_answer_profile_questions"):
+        pa.answer_profile_questions(valid_kickoff, "", valid_out)
+
+    # (b3) empty profile_answers_out_path
+    r3 = _bash_invoke(valid_kickoff, valid_questions, "")
+    assert r3.returncode == 2
+    assert "usage: mo_answer_profile_questions" in r3.stderr
+    with pytest.raises(ValueError, match=r"usage: mo_answer_profile_questions"):
+        pa.answer_profile_questions(valid_kickoff, valid_questions, "")
+
+    # (b4) valid args but kickoff file missing
+    missing_kickoff = str(tmp_path / "does-not-exist.md")
+    r4 = _bash_invoke(missing_kickoff, valid_questions, valid_out)
+    assert r4.returncode == 2
+    assert f"profile answerer kickoff not found: {missing_kickoff}" in r4.stderr
+    with pytest.raises(FileNotFoundError, match=re.escape(missing_kickoff)):
+        pa.answer_profile_questions(missing_kickoff, valid_questions, valid_out)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) parse_fence_stripping_parity — raw LLM response wrapped in fences
+# ─────────────────────────────────────────────────────────────────────────────
+def test_parse_fence_stripping_parity(tmp_path):
+    """Markdown fence-stripping is byte-stable across bash and python.
+
+    Raw fixture: ```json\\n{...}\\n```. Stubbed llm_dispatch echoes this.
+    """
+    kickoff = tmp_path / "kickoff.md"
+    kickoff.write_text("# k\n", encoding="utf-8")
+    questions_json = json.dumps([
+        {"id": "q1", "question": "q1"},
+    ])
+    raw = (
+        "```json\n"
+        '{"answers":[{"question":"q1","answer":"a1"}],"auto_answered":true}\n'
+        "```"
+    )
+
+    bash_out = tmp_path / "bash_answers.json"
+    py_out = tmp_path / "py_answers.json"
+
+    _bash_invoke(kickoff, questions_json, bash_out, raw_override=raw)
+    pa.answer_profile_questions(
+        kickoff, questions_json, py_out, dispatch=lambda _: raw,
+    )
+
+    bash_payload = json.loads(bash_out.read_text(encoding="utf-8"))
+    py_payload = json.loads(py_out.read_text(encoding="utf-8"))
+    assert bash_payload == py_payload
+    assert bash_payload == {
+        "answers": [{"question": "q1", "answer": "a1"}],
+        "auto_answered": True,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) parse_balanced_extraction_parity — preamble-then-JSON recovery
+# ─────────────────────────────────────────────────────────────────────────────
+def test_parse_balanced_extraction_parity(tmp_path):
+    """Prose preamble before the JSON object is recovered by the balanced-brace
+    scanner in both bash and python."""
+    kickoff = tmp_path / "kickoff.md"
+    kickoff.write_text("# k\n", encoding="utf-8")
+    questions_json = json.dumps([{"id": "q1", "question": "q1"}])
+    raw = (
+        "Sure! Here you go:\n"
+        "\n"
+        '{"answers":[{"question":"q1","answer":"a1"}],"auto_answered":true}\n'
+    )
+
+    bash_out = tmp_path / "bash_answers.json"
+    py_out = tmp_path / "py_answers.json"
+
+    _bash_invoke(kickoff, questions_json, bash_out, raw_override=raw)
+    pa.answer_profile_questions(
+        kickoff, questions_json, py_out, dispatch=lambda _: raw,
+    )
+
+    bash_payload = json.loads(bash_out.read_text(encoding="utf-8"))
+    py_payload = json.loads(py_out.read_text(encoding="utf-8"))
+    assert bash_payload == py_payload
+    assert bash_payload == {
+        "answers": [{"question": "q1", "answer": "a1"}],
+        "auto_answered": True,
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) omitted_question_parity — bash SystemExit vs python RuntimeError
+# ─────────────────────────────────────────────────────────────────────────────
+def test_omitted_question_parity(tmp_path):
+    """When the LLM response omits one of the input questions, both bash and
+    python refuse with the same message text (bash raises SystemExit with a
+    specific message; python mirrors as RuntimeError)."""
+    kickoff = tmp_path / "kickoff.md"
+    kickoff.write_text("# k\n", encoding="utf-8")
+    questions_json = json.dumps([
+        {"id": "q1", "question": "first question"},
+        {"id": "q2", "question": "second question"},
+    ])
+    # Only q1 is answered; q2 omitted.
+    raw = (
+        "```json\n"
+        '{"answers":[{"question":"first question","answer":"a1"}],'
+        '"auto_answered":true}\n'
+        "```"
+    )
+
+    bash_out = tmp_path / "bash_answers.json"
+    py_out = tmp_path / "py_answers.json"
+
+    rb = _bash_invoke(kickoff, questions_json, bash_out, raw_override=raw)
+    assert rb.returncode != 0
+    assert "profile answerer omitted question" in rb.stderr
+    assert "second question" in rb.stderr
+
+    with pytest.raises(RuntimeError, match=r"profile answerer omitted question: second question"):
+        pa.answer_profile_questions(
+            kickoff, questions_json, py_out, dispatch=lambda _: raw,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) end_to_end_replay_parity — captured real LLM response
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.skipif(
+    not REPLAY_FIXTURE.exists(),
+    reason=(
+        "Replay fixture missing. To capture a real LLM response once: "
+        "bash scripts/capture_profile_answerer_fixture.sh"
+    ),
+)
+def test_end_to_end_replay_parity(tmp_path):
+    """Full pipeline (prompt → dispatch → fence-strip → balanced-extract →
+    validate → persist) is byte-stable on a CAPTURED REAL LLM response.
+
+    Capture-once / replay-many: pytest NEVER calls the live LLM (CI cost +
+    flakiness). The fixture is captured manually via
+    scripts/capture_profile_answerer_fixture.sh, which runs the bash
+    function ONCE against the real deepseek/kimi dispatch chain and saves
+    the raw LLM text to tests/fixtures/profile_answerer_replay.raw. After
+    that, this test replays the captured response through both sides and
+    asserts byte-equal JSON output.
+    """
+    fixture_raw = REPLAY_FIXTURE.read_text(encoding="utf-8")
+    kickoff = tmp_path / "kickoff.md"
+    kickoff.write_text(
+        "# Tiny kickoff\n\nGoal: x. Out of scope: y.\n",
+        encoding="utf-8",
+    )
+    questions_json = json.dumps([
+        {"id": "goal", "question": "Summarize the goal in one sentence."},
+        {"id": "scope", "question": "What is explicitly out of scope?"},
+    ])
+
+    bash_out = tmp_path / "bash_answers.json"
+    py_out = tmp_path / "py_answers.json"
+
+    _bash_invoke(kickoff, questions_json, bash_out, raw_override=fixture_raw)
+    pa.answer_profile_questions(
+        kickoff, questions_json, py_out, dispatch=lambda _: fixture_raw,
+    )
+
+    bash_text = bash_out.read_text(encoding="utf-8")
+    py_text = py_out.read_text(encoding="utf-8")
+    bash_payload = json.loads(bash_text)
+    py_payload = json.loads(py_text)
+
+    # Byte-equal JSON output (1e-6 float tolerance per kickoff — vacuous here
+    # since profile_answerer never produces floats; kept as defense in depth).
+    def _round_floats(o, tol=1e-6):
+        if isinstance(o, float):
+            return round(o, 6)
+        if isinstance(o, dict):
+            return {k: _round_floats(v, tol) for k, v in o.items()}
+        if isinstance(o, list):
+            return [_round_floats(v, tol) for v in o]
+        return o
+    assert _round_floats(bash_payload) == _round_floats(py_payload), (
+        f"bash={bash_payload!r}\npython={py_payload!r}"
+    )


### PR DESCRIPTION
policy_store, gate_bootstrap, profile_answerer, mo_node_events, gates_common. Live-bash parity tests (50 cases). Strangler-fig.