### PR TITLE
feat(python-migration): port lane_helpers + panel_bias (wave 6)

### DIFF
--- a/mini_ork/ported/lane_helpers.py
+++ b/mini_ork/ported/lane_helpers.py
@@ -1,0 +1,332 @@
+"""Lane-helpers — Python port of ``lib/lane-helpers.sh``.
+
+Faithful Python port of the six bash functions in
+``lib/lane-helpers.sh`` (lane predicate, budget flag, cache flag,
+capability assertion, cache-stats aggregation, claude --print wrapper).
+The bash source is the authoritative spec and stays byte-identical
+(strangler-fig invariant); this module gives Python callers an
+in-process target and gives ``tests/unit/test_lane_helpers_py.py`` a
+stable surface to byte-diff against the LIVE bash subprocess (no mocks,
+no hardcoded outputs).
+
+Co-existence model (strangler-fig): ``lib/lane-helpers.sh`` is not
+modified by this port. The Python port mirrors its CLI semantics
+exactly. Parity is enforced by
+``tests/unit/test_lane_helpers_py.py`` (>=6 live-bash-subprocess cases
+that drive ``bash lib/lane-helpers.sh <op>`` / ``bash -c '. … && mo_<op>'``
+on identical inputs and diff the resulting flags, stderr, exit codes,
+and cache-stats.json byte-for-byte).
+
+Pipeline map (bash function → Python):
+  mo_lane_is_free(lane)              → lane_is_free(lane) -> bool
+  (case glm|kimi|minimax)            (frozenset of free lanes)
+  mo_emit_budget_flag <arr> …        → emit_budget_flag(lane, val) -> list[str]
+  (local -n; out=(--max-budget-usd …)) (returns [] when free, [flag, val] when paid)
+  mo_emit_cache_flags <arr>          → emit_cache_flags() -> list[str]
+  (one-shot claude --help probe +     (module-level _CACHE_FLAG_SUPPORTED var;
+   _MO_CACHE_FLAG_SUPPORTED env var)  one-shot probe via _PROBE_DONE flag)
+  mo_assert_lane_capability <lane>   → assert_lane_capability(lane) -> None
+  (heredoc python3; stderr <cap>)    (raises RuntimeError(<cap>); reuses
+                                       mini_ork.ported.config_resolve
+                                       for yaml path resolution; same
+                                       external observable)
+  mo_aggregate_cache_stats <dir>     → aggregate_cache_stats(iter_dir) -> dict
+  (grep -oE + jq -n to write JSON)   (Python regex + json.dumps to
+                                       cache-stats.json; same shape)
+  mo_claude_print <prompt> [extra]   → claude_print(prompt, *extra) -> CP
+  (claude --print --permission-mode  (subprocess.run of the same argv;
+   bypassPermissions --output-format  returns CompletedProcess so caller
+   … $@ $PROMPT)                      can inspect stdout/stderr/rc)
+
+Public surface:
+    lane_is_free(lane) -> bool
+    emit_budget_flag(lane, val) -> list[str]
+    emit_cache_flags() -> list[str]
+    assert_lane_capability(lane) -> None
+    aggregate_cache_stats(iter_dir: str) -> dict
+    claude_print(prompt, *extra, max_turns=40, output_format="text") -> CompletedProcess
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+
+import yaml
+
+from mini_ork.ported import config_resolve
+
+__all__ = [
+    "lane_is_free",
+    "emit_budget_flag",
+    "emit_cache_flags",
+    "assert_lane_capability",
+    "aggregate_cache_stats",
+    "claude_print",
+]
+
+_FREE_LANES = frozenset({"glm", "kimi", "minimax"})
+_CACHE_FLAG = "--exclude-dynamic-system-prompt-sections"
+
+# Module-level cache for the one-shot ``claude --help`` probe.
+# Mirrors bash's `_MO_CACHE_FLAG_SUPPORTED` env var: probe once per
+# process, then return the same result for the rest of the run. The
+# test harness can ``monkeypatch.setattr`` this to force a re-probe.
+_CACHED_SUPPORTED: bool | None = None
+_PROBE_DONE: bool = False
+
+# JSON output shape for ``mo_aggregate_cache_stats``. ``hit_rate`` and
+# ``estimated_usd_saved`` are floats (4dp); everything else is integer.
+_SAVED_USD_PER_TOKEN = 0.9 * 3 / 1_000_000  # 0.1× of $3/M input
+# bash's `grep -oE '"<key>":[0-9]+' | awk -F: '{s+=$2} END{print s+0}'`
+_CACHE_CREATION_RE = re.compile(r'"cache_creation_input_tokens":(\d+)')
+_CACHE_READ_RE = re.compile(r'"cache_read_input_tokens":(\d+)')
+_INPUT_TOKENS_RE = re.compile(r'"input_tokens":(\d+)')
+
+# Full Claude Code flag set used by ``mo_claude_print`` — mirrors
+# ``lib/lane-helpers.sh`` lines 242-249 exactly.
+_CLAUDE_BASE = [
+    "--print",
+    "--permission-mode", "bypassPermissions",
+    "--output-format", "{format}",
+    "--max-turns", "{max_turns}",
+]
+
+
+def lane_is_free(lane: str) -> bool:
+    """Mirror ``mo_lane_is_free`` — True for glm/kimi/minimax, False otherwise.
+
+    Bash:
+
+        case "$lane" in
+            glm|kimi|minimax) return 0 ;;
+            *) return 1 ;;
+        esac
+    """
+    return lane in _FREE_LANES
+
+
+def emit_budget_flag(lane: str, val: str) -> list[str]:
+    """Mirror ``mo_emit_budget_flag`` — empty list when free, flag pair when paid.
+
+    Bash:
+
+        out=()
+        if mo_lane_is_free "$lane"; then return 0; fi
+        out=(--max-budget-usd "$val")
+
+    Caller passes ``val`` as a string (matches bash's positional arg
+    shape — the bash function takes a pre-resolved string, not a number).
+    """
+    if lane_is_free(lane):
+        return []
+    return ["--max-budget-usd", str(val)]
+
+
+def emit_cache_flags() -> list[str]:
+    """Mirror ``mo_emit_cache_flags`` — feature-detect the cache flag once.
+
+    Bash probes ``claude --help`` for the
+    ``--exclude-dynamic-system-prompt-sections`` flag, caches the result
+    in the env var ``_MO_CACHE_FLAG_SUPPORTED`` for the rest of the
+    process, and short-circuits when ``MO_PROMPT_CACHE_DISABLED=1``.
+    Returns the empty list on either disable path.
+    """
+    global _CACHED_SUPPORTED, _PROBE_DONE
+
+    if os.environ.get("MO_PROMPT_CACHE_DISABLED") == "1":
+        return []
+
+    if not _PROBE_DONE:
+        try:
+            r = subprocess.run(
+                ["claude", "--help"],
+                capture_output=True, text=True, timeout=10,
+            )
+            _CACHED_SUPPORTED = (_CACHE_FLAG in (r.stdout or ""))
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            _CACHED_SUPPORTED = False
+        _PROBE_DONE = True
+
+    if _CACHED_SUPPORTED:
+        return [_CACHE_FLAG]
+    return []
+
+
+def _read_yaml(path: str) -> dict:
+    """Load a yaml file → dict (empty dict on missing or empty)."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    return data or {}
+
+
+def _resolve_capability_yaml_paths() -> tuple[str, str, bool]:
+    """Resolve the (run-dir-first agents.yaml, fallback agents.yaml) pair.
+
+    Mirrors ``mo_assert_lane_capability`` lines 113-119. The bash source
+    calls ``mo_resolve_agents_yaml`` to find the primary, then computes
+    a fallback at ``$MINI_ORK_ROOT/config/agents.yaml`` (or the primary
+    itself when the fallback is missing). We reuse the existing
+    ``resolve_agents_yaml()`` Python helper, redirecting its stdout so
+    the parity test doesn't see the bare path echo (which the bash
+    version also suppresses — it's called inside a ``$(…)`` capture).
+    """
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        config_resolve.resolve_agents_yaml()
+    primary = buf.getvalue().rstrip("\n")
+
+    primary_exists = os.path.isfile(primary)
+    root = os.environ.get("MINI_ORK_ROOT", "")
+    fallback = os.path.join(root, "config", "agents.yaml") if root else ""
+    if not (fallback and os.path.isfile(fallback)):
+        fallback = primary
+    return primary, fallback, primary_exists
+
+
+def assert_lane_capability(lane: str) -> None:
+    """Mirror ``mo_assert_lane_capability`` — raise ``RuntimeError`` on missing.
+
+    Bash exits 1 and prints the first missing capability token to stderr
+    when the resolved lane family lacks one of the
+    ``MO_LANE_REQUIRES_CAPABILITY``-listed capabilities. Empty
+    requirements are a no-op (returns 0 / None). An empty lane arg
+    produces the literal stderr token ``"lane"`` and exit 1.
+
+    The Python port raises ``RuntimeError(<token>)`` with the same
+    first-missing-cap token bash emits — the parity test asserts on
+    ``rc=1`` + stderr phrase, not on the internal call shape.
+    """
+    required = os.environ.get("MO_LANE_REQUIRES_CAPABILITY", "")
+    if not required:
+        return
+    if not lane:
+        raise RuntimeError("lane")
+
+    agents_yaml, fallback_yaml, exists = _resolve_capability_yaml_paths()
+    if not exists:
+        raise RuntimeError("capabilities")
+
+    cfg = _read_yaml(agents_yaml)
+    fallback_cfg = _read_yaml(fallback_yaml)
+    lanes = cfg.get("lanes") or {}
+    capabilities = cfg.get("capabilities") or fallback_cfg.get("capabilities") or {}
+    family = str(lanes.get(lane) or lane).strip()
+    family_caps = capabilities.get(family) or {}
+
+    missing: list[str] = []
+    for raw in required.split(","):
+        name = raw.strip()
+        if not name:
+            continue
+        if family_caps.get(name) is not True:
+            missing.append(name)
+    if missing:
+        raise RuntimeError(missing[0])
+
+
+def aggregate_cache_stats(iter_dir: str) -> dict:
+    """Mirror ``mo_aggregate_cache_stats`` — scan ``*.log`` files, write JSON.
+
+    Bash iterates ``<iter_dir>/*.log`` and sums three token counts via
+    ``grep -oE '"<key>":[0-9]+' | awk -F: '{s+=$2} END{print s+0}'``,
+    then writes ``<iter_dir>/cache-stats.json`` with a ``jq -n`` template.
+
+    Returns 1 / no write when ``iter_dir`` is not a directory. The
+    written JSON has the exact same keys + value shapes (compact form,
+    no indent) as bash's ``jq -n`` output — the parity test diffs the
+    two JSON files byte-for-byte modulo path fields and float rounding.
+    """
+    if not os.path.isdir(iter_dir):
+        raise FileNotFoundError(f"not a directory: {iter_dir}")
+    stats_file = os.path.join(iter_dir, "cache-stats.json")
+
+    creation = 0
+    read = 0
+    uncached = 0
+    file_count = 0
+    per_file: list[dict] = []
+
+    for name in sorted(os.listdir(iter_dir)):
+        if not name.endswith(".log"):
+            continue
+        log = os.path.join(iter_dir, name)
+        if not os.path.isfile(log):
+            continue
+        with open(log, "r", encoding="utf-8", errors="replace") as fh:
+            text = fh.read()
+        c = sum(int(m) for m in _CACHE_CREATION_RE.findall(text))
+        r = sum(int(m) for m in _CACHE_READ_RE.findall(text))
+        u = sum(int(m) for m in _INPUT_TOKENS_RE.findall(text))
+        creation += c
+        read += r
+        uncached += u
+        file_count += 1
+        per_file.append({
+            "file": name,
+            "cache_creation": c,
+            "cache_read": r,
+            "uncached": u,
+        })
+
+    saved = round(read * _SAVED_USD_PER_TOKEN, 4)
+    total = creation + read + uncached
+    hit_rate = round(read / total, 4) if total > 0 else 0
+    payload = {
+        "cache_creation_tokens": creation,
+        "cache_read_tokens": read,
+        "uncached_input_tokens": uncached,
+        "hit_rate": hit_rate,
+        "estimated_usd_saved": saved,
+        "log_files_scanned": file_count,
+        "per_file": per_file,
+    }
+    # bash's `jq -n ... > file` writes compact JSON (no indent). The
+    # parity test byte-diffs against bash's output, so we use
+    # ``json.dumps`` default (no indent) + ``sort_keys=False`` to
+    # preserve insertion order.
+    with open(stats_file, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(payload))
+    return payload
+
+
+def claude_print(
+    prompt: str,
+    *extra: str,
+    max_turns: int = 40,
+    output_format: str = "text",
+) -> subprocess.CompletedProcess:
+    """Mirror ``mo_claude_print`` — canonical ``claude --print`` wrapper.
+
+    Bash argv order (line 242-249 of ``lib/lane-helpers.sh``)::
+
+        claude \
+            --print \
+            --permission-mode bypassPermissions \
+            --output-format "$_format" \
+            --max-turns "$_max_turns" \
+            "${_cache_flags[@]}" \
+            "$@" \
+            "$prompt"
+
+    The Python port constructs the same argv list, interspersing cache
+    flags (via ``emit_cache_flags()``) between the fixed flags and the
+    caller's extra args + prompt. Returns the raw
+    ``subprocess.CompletedProcess`` so callers can inspect rc/stdout/
+    stderr — the bash version passes the exit code through to the
+    caller; the Python version preserves that by NOT calling
+    ``check=True``.
+    """
+    if not prompt:
+        raise ValueError("prompt required")
+    cache_flags = emit_cache_flags()
+    base = [
+        arg.format(format=output_format, max_turns=max_turns)
+        for arg in _CLAUDE_BASE
+    ]
+    argv = ["claude", *base, *cache_flags, *extra, prompt]
+    return subprocess.run(argv, capture_output=True, text=True)

--- a/mini_ork/ported/panel_bias.py
+++ b/mini_ork/ported/panel_bias.py
@@ -1,0 +1,296 @@
+"""panel_bias — Python port of lib/panel_bias.sh.
+
+Faithful port of the bash panel-bias helpers in ``lib/panel_bias.sh`` that
+anonymize, rank-aggregate, and permute-order adversarial-panel review
+artifacts. The bash script is the authoritative source — this module
+gives Python callers an in-process target and gives
+``tests/unit/test_panel_bias_py.py`` a stable surface to byte-diff
+against the LIVE bash subprocess (no mocks, no hardcoded outputs).
+
+Co-existence model (strangler-fig): bash ``lib/panel_bias.sh`` stays
+byte-identical. The Python port mirrors its CLI semantics exactly. Parity
+is enforced by ``tests/unit/test_panel_bias_py.py`` (>=6 live-subprocess
+cases that drive ``bash lib/panel_bias.sh <func> <args>`` on identical
+inputs and diff the resulting files + stderr text + exit codes).
+
+Pipeline map (bash → Python):
+  panel_anonymize <reports_dir> <out_dir> [seed]
+      ls -1 + grep '^lens-.*\\.md$'   →  _list_lens_files (sorted LC_ALL=C)
+  bash  awk 'BEGIN{srand(seed)} {rand(), $0}'
+      | LC_ALL=C sort -n | cut -f2-   →  _shuffle_lines (random.seed + key sort)
+  bash  _PB_LABELS=(A..Z)             →  _LABELS (constant)
+  bash  cp src resp-<LABEL>.md        →  panel_anonymize (shutil.copy2)
+  bash  jq -s 'add' label pairs       →  panel_anonymize (json merge)
+  bash  ${out_dir}.label_map.json     →  panel_anonymize (sibling path)
+
+  panel_rank_aggregate <xrank_dir> <label_map>
+  bash  grep '^FINAL RANKING:' | head -n1
+                                       →  _iter_rankings
+  bash  Borda = Σ (N-1-p)              →  panel_rank_aggregate (per-label)
+  bash  mean_rank = mean(1-indexed pos)→  panel_rank_aggregate (per-label)
+  bash  sort_by(-.borda, .mean_rank, .family)
+                                       →  panel_rank_aggregate (Python tuple sort)
+  bash  <xrank_dir>/panel-rank-aggregate.json
+                                       →  panel_rank_aggregate (output path)
+
+  panel_permute_order <reports_dir> [seed]
+  bash  for f in *.md                 →  panel_permute_order (glob one level)
+  bash  | _pb_shuffle_lines seed      →  panel_permute_order (_shuffle_lines)
+
+RNG parity note: bash uses ``awk 'BEGIN{srand(seed)}'`` which is a
+platform-specific linear-congruential generator with 20-digit precision.
+Python's ``random.seed(seed); random.random()`` is Mersenne Twister. The
+two generators produce DIFFERENT sequences for the same seed — the
+parity test asserts equivalence of downstream OUTPUTS (file presence,
+byte-content, label_map keys/families, borda/mean_rank values, sort
+order) NOT raw RNG order. panel_permute_order uses random.seed for its
+own determinism; the parity test asserts Python-vs-Python determinism
+(same seed → identical order, different seeds → different orders) plus
+multiset preservation, NOT byte-equality with bash.
+
+Public surface (mirrors bash function names exactly):
+    panel_anonymize(reports_dir, out_dir, seed=0) -> dict
+    panel_rank_aggregate(xrank_dir, label_map) -> list[dict]
+    panel_permute_order(reports_dir, seed=0) -> list[str]
+"""
+from __future__ import annotations
+
+import json
+import os
+import random
+import shutil
+from pathlib import Path
+from typing import Dict, List
+
+__all__ = [
+    "panel_anonymize",
+    "panel_rank_aggregate",
+    "panel_permute_order",
+    "_list_lens_files",
+    "_shuffle_lines",
+    "_iter_rankings",
+]
+
+# A..Z for label assignment (panel sizes are typically 3-7 families).
+# Mirrors bash _PB_LABELS=(A B C D E F G H I J K L M N O P Q R S T U V W X Y Z).
+_LABELS: tuple[str, ...] = tuple(chr(ord("A") + i) for i in range(26))
+
+# Precision used for the mean_rank output value. Mirrors bash
+# `awk 'BEGIN{printf "%.4f", s/c}'` — 4 fractional digits.
+_MEAN_RANK_PRECISION = 4
+
+# Sort comparator emitted by panel_rank_aggregate:
+#   borda DESC, mean_rank ASC, family ASC.
+# bash uses `jq -s 'sort_by(-.borda, .mean_rank, .family)'` which sorts
+# ascending on each key — the minus on borda flips it to DESC.
+
+
+def _list_lens_files(reports_dir: str) -> List[str]:
+    """Mirror bash: ``LC_ALL=C ls -1 "$reports_dir" | grep -E '^lens-.*\\.md$'``.
+
+    Sort is LC_ALL=C (byte-wise) — Python's default ``sorted()`` already
+    uses Unicode code points which for ASCII filenames matches C-locale
+    ordering. Returns the bare basenames (not full paths).
+    """
+    p = Path(reports_dir)
+    if not p.is_dir():
+        raise FileNotFoundError(f"panel_anonymize: reports_dir not found: {reports_dir}")
+    return sorted(
+        name for name in os.listdir(reports_dir)
+        if name.startswith("lens-") and name.endswith(".md")
+        and (p / name).is_file()
+    )
+
+
+def _shuffle_lines(lines: List[str], seed: int) -> List[str]:
+    """Mirror bash: ``awk -v s=$seed 'BEGIN{srand(s)} {printf "%020.18f\\t%s\\n", rand(), $0}' | LC_ALL=C sort -n | cut -f2-``.
+
+    Bash uses awk's RNG with 20-digit zero-padded rand keys then a
+    numeric sort. Python uses Mersenne Twister via ``random.seed`` —
+    the downstream permutation differs from bash but the function is
+    deterministic in-process (same seed → same output) and produces a
+    uniform permutation of the input. See module docstring for why
+    parity tests don't byte-compare raw orderings.
+    """
+    rng = random.Random(seed)
+    return sorted(lines, key=lambda _line: rng.random())
+
+
+def _iter_rankings(xrank_dir: str) -> List[List[str]]:
+    """Yield one ``tokens`` list per reviewer file in ``xrank_dir``.
+
+    Mirror bash lines 180-200: glob every file at the top level of
+    ``xrank_dir``, take the FIRST ``^FINAL RANKING:`` line, strip the
+    prefix, split on whitespace. Files with no matching line are skipped
+    (no yield).
+    """
+    p = Path(xrank_dir)
+    if not p.is_dir():
+        raise FileNotFoundError(f"panel_rank_aggregate: xrank_dir not found: {xrank_dir}")
+    out: List[List[str]] = []
+    for entry in sorted(p.iterdir()):
+        if not entry.is_file():
+            continue
+        ranking: str | None = None
+        with entry.open("r", encoding="utf-8", errors="replace") as fh:
+            for raw in fh:
+                line = raw.rstrip("\n")
+                if line.startswith("FINAL RANKING:"):
+                    ranking = line[len("FINAL RANKING:"):].strip()
+                    break
+        if not ranking:
+            continue
+        tokens = ranking.split()
+        if not tokens:
+            continue
+        out.append(tokens)
+    if not out:
+        raise ValueError(
+            f"panel_rank_aggregate: no reviewer file with '^FINAL RANKING:' line in {xrank_dir}"
+        )
+    return out
+
+
+def panel_anonymize(reports_dir: str, out_dir: str, seed: int = 0) -> Dict[str, str]:
+    """Anonymize lens-*.md → resp-<LABEL>.md and emit sibling label_map.json.
+
+    Mirror bash ``panel_anonymize``:
+      1. Glob ``lens-*.md`` under ``reports_dir`` (sorted LC_ALL=C).
+      2. Shuffle via ``_shuffle_lines(seed)``.
+      3. For each file in shuffled order, assign label A, B, C, ...
+         (up to 26). Byte-copy to ``<out_dir>/resp-<LABEL>.md``.
+      4. Build a label_map {label: family} and write it to
+         ``${out_dir}.label_map.json`` (sibling — NEVER inside out_dir).
+
+    Returns the label_map dict. Raises:
+      FileNotFoundError  reports_dir missing or no lens-*.md files
+      ValueError         more than 26 families
+      OSError            filesystem copy failure
+    """
+    if not os.path.isdir(reports_dir):
+        raise FileNotFoundError(f"panel_anonymize: reports_dir not found: {reports_dir}")
+
+    families = _list_lens_files(reports_dir)
+    if not families:
+        raise FileNotFoundError(f"panel_anonymize: no lens-*.md in {reports_dir}")
+
+    if len(families) > len(_LABELS):
+        raise ValueError(
+            f"panel_anonymize: more than {len(_LABELS)} families unsupported (got {len(families)})"
+        )
+
+    shuffled = _shuffle_lines(families, seed)
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    label_map_path = f"{out_dir}.label_map.json"
+
+    label_map: Dict[str, str] = {}
+    for i, family_file in enumerate(shuffled):
+        label = _LABELS[i]
+        # bash: family=$(printf '%s' "${f#lens-}"); family=${family%.md}
+        family = family_file[len("lens-"):]
+        if family.endswith(".md"):
+            family = family[:-len(".md")]
+        src = os.path.join(reports_dir, family_file)
+        dst = os.path.join(out_dir, f"resp-{label}.md")
+        shutil.copy2(src, dst)
+        label_map[label] = family
+
+    with open(label_map_path, "w", encoding="utf-8") as fh:
+        json.dump(label_map, fh)
+        fh.write("\n")
+    return label_map
+
+
+def panel_rank_aggregate(xrank_dir: str, label_map_path: str) -> List[Dict[str, object]]:
+    """Aggregate Borda + mean_rank per label from reviewer ``FINAL RANKING:`` lines.
+
+    Mirror bash ``panel_rank_aggregate``:
+      1. Read every ``FINAL RANKING:`` line in ``xrank_dir``.
+      2. For each token (label) at 0-indexed position p in a ranking of
+         length N:
+           borda     += N - 1 - p
+           pos_sum   += p + 1      (1-indexed position)
+           count     += 1
+      3. mean_rank = pos_sum / count, formatted to 4 decimal places
+         (mirrors bash ``awk 'BEGIN{printf "%.4f", s/c}'``).
+      4. Sort: borda DESC, mean_rank ASC, family ASC. De-anonymize via
+         label_map lookup (label missing → family="unknown", matches
+         bash's `${family:-unknown}` fallback).
+      5. Emit ``<xrank_dir>/panel-rank-aggregate.json`` (JSON array).
+
+    Returns the sorted list of dicts. Raises:
+      FileNotFoundError  xrank_dir or label_map missing
+      ValueError         no reviewer file with FINAL RANKING line
+    """
+    if not os.path.isdir(xrank_dir):
+        raise FileNotFoundError(f"panel_rank_aggregate: xrank_dir not found: {xrank_dir}")
+    if not os.path.isfile(label_map_path):
+        raise FileNotFoundError(f"panel_rank_aggregate: label_map not found: {label_map_path}")
+
+    with open(label_map_path, "r", encoding="utf-8") as fh:
+        label_map: Dict[str, str] = json.load(fh)
+
+    rankings = _iter_rankings(xrank_dir)
+
+    label_borda: Dict[str, int] = {}
+    label_pos_sum: Dict[str, int] = {}
+    label_count: Dict[str, int] = {}
+
+    for tokens in rankings:
+        n = len(tokens)
+        for pos, tok in enumerate(tokens):
+            label_borda[tok] = label_borda.get(tok, 0) + (n - 1 - pos)
+            label_pos_sum[tok] = label_pos_sum.get(tok, 0) + (pos + 1)
+            label_count[tok] = label_count.get(tok, 0) + 1
+
+    entries: List[Dict[str, object]] = []
+    for label, borda in label_borda.items():
+        count = label_count[label]
+        if count <= 0:
+            continue
+        mean_rank_raw = label_pos_sum[label] / count
+        # bash emits 4 fractional digits via awk printf "%.4f". Mirror
+        # exactly so the parity test sees byte-equal JSON numbers.
+        mean_rank = float(f"{mean_rank_raw:.{_MEAN_RANK_PRECISION}f}")
+        family = label_map.get(label, "unknown")
+        entries.append({
+            "label": label,
+            "family": family,
+            "borda": int(borda),
+            "mean_rank": mean_rank,
+        })
+
+    # Sort: borda DESC, mean_rank ASC, family ASC. Python tuple sort is
+    # ascending on each key, so negate borda for the DESC component.
+    # Explicit casts satisfy strict type checkers (Dict[str, object]
+    # loses the int/float narrowing needed for sort key arithmetic).
+    entries.sort(key=lambda e: (-int(str(e["borda"])), float(str(e["mean_rank"])), str(e["family"])))
+
+    out_file = os.path.join(xrank_dir, "panel-rank-aggregate.json")
+    with open(out_file, "w", encoding="utf-8") as fh:
+        json.dump(entries, fh)
+        fh.write("\n")
+    return entries
+
+
+def panel_permute_order(reports_dir: str, seed: int = 0) -> List[str]:
+    """Return a seed-deterministic permutation of ``*.md`` basenames under ``reports_dir``.
+
+    Mirror bash ``panel_permute_order``: one-level (non-recursive) glob
+    of ``*.md`` files; basename only (via parameter expansion in bash,
+    ``Path.name`` here); shuffled by seed; printed one per line to
+    stdout in bash, returned as a list here.
+
+    Returns the list of basenames in shuffled order. Raises:
+      FileNotFoundError  reports_dir missing.
+    """
+    if not os.path.isdir(reports_dir):
+        raise FileNotFoundError(f"panel_permute_order: reports_dir not found: {reports_dir}")
+
+    basenames = [
+        entry.name
+        for entry in Path(reports_dir).iterdir()
+        if entry.is_file() and entry.name.endswith(".md")
+    ]
+    basenames.sort()  # glob order is unspecified; sort for stable output of the unsorted input.
+    return _shuffle_lines(basenames, seed)

--- a/tests/unit/test_lane_helpers_py.py
+++ b/tests/unit/test_lane_helpers_py.py
@@ -1,0 +1,591 @@
+"""Parity gate: ``mini_ork.ported.lane_helpers`` vs ``lib/lane-helpers.sh``.
+
+Each test invokes the LIVE ``bash lib/lane-helpers.sh <op>`` subprocess
+(or ``bash -c '. lib/lane-helpers.sh && mo_<op> …'`` for ops that
+require ``local -n`` semantics) on identical inputs as the Python port
+and asserts byte-identical flag arrays, stderr text, exit codes, and
+``cache-stats.json`` content. No mocks, no hardcoded outputs beyond
+what bash itself emits.
+
+Eight cases (above the kickoff's >=6 floor):
+  (a) lane_is_free                 — 5 lanes (free vs paid) parametrised
+  (b) emit_budget_flag             — free lane returns [], paid returns [--max-budget-usd, <val>]
+  (c) emit_cache_flags feature-detect — PATH-shim fake `claude --help` echoes
+                                       the cache flag → both return [flag]
+  (d) emit_cache_flags disabled    — MO_PROMPT_CACHE_DISABLED=1 → both return []
+  (e) assert_lane_capability OK    — capabilities satisfied → exit 0
+  (f) assert_lane_capability fail  — missing capability → exit 1 + stderr
+                                       contains the first missing cap token
+  (g) aggregate_cache_stats happy  — 3 fixture logs → byte-diff cache-stats.json
+                                       modulo per_file[].file + saved_usd float
+                                       tolerance (1e-6)
+  (h) aggregate_cache_stats empty  — zero-log dir → both still write a valid
+                                       JSON with zeros + hit_rate:0 + per_file:[]
+
+``mo_claude_print`` is intentionally NOT live-parity-tested under the
+standard recipe — bash's ``claude --print`` is non-deterministic
+(network calls, model output), and the plan explicitly documents this
+gap. The function is exercised via in-process argv-shape verification
+inside the (c)/(d) emit_cache_flags tests (the cache_flags are produced
+by the same code path claude_print uses).
+
+Environment isolation:
+  The shell pytest runs in often has MINI_ORK_HOME / MINI_ORK_ROOT /
+  MINI_ORK_RUN_DIR / MO_LANE_REQUIRES_CAPABILITY /
+  MO_PROMPT_CACHE_DISABLED set to whatever the operator exported. Each
+  test pops the relevant vars and re-applies only its own overrides so
+  pytest's arbitrary collection order cannot leak a prior test's env
+  into the next.
+
+Strangler-fig co-existence: ``lib/lane-helpers.sh`` is byte-identical
+before and after this test exists.
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import lane_helpers as lh  # noqa: E402
+
+LIB = REPO / "lib" / "lane-helpers.sh"
+
+# Env vars that the bash source reads; each parity test pops them
+# before applying its own overrides.
+_ENV_KEYS = (
+    "MINI_ORK_HOME",
+    "MINI_ORK_ROOT",
+    "MINI_ORK_RUN_DIR",
+    "MO_LANE_REQUIRES_CAPABILITY",
+    "MO_PROMPT_CACHE_DISABLED",
+)
+
+
+def _which(*tools: str) -> dict[str, str]:
+    out = {}
+    for t in tools:
+        p = shutil.which(t)
+        if not p:
+            pytest.skip(f"required tool not on PATH: {t}")
+        out[t] = p
+    return out
+
+
+def _clean_env() -> dict:
+    """Return os.environ minus the lane-helper-sensitive vars."""
+    env = os.environ.copy()
+    for k in _ENV_KEYS:
+        env.pop(k, None)
+    return env
+
+
+def _bash_lane_is_free(lane: str, env: dict) -> bool:
+    """Invoke bash's mo_lane_is_free; return True when exit 0."""
+    r = subprocess.run(
+        ["bash", "-c",
+         f'. "{LIB}" >/dev/null 2>&1; mo_lane_is_free "$1"',
+         "--", lane],
+        env=env, capture_output=True, text=True,
+    )
+    return r.returncode == 0
+
+
+def _bash_emit_budget_flag(lane: str, val: str, env: dict) -> list[str]:
+    """Drive ``mo_emit_budget_flag`` via bash, capturing the resulting array.
+
+    bash's ``local -n`` requires the array name to be visible in the
+    function's scope, so we source the lib, declare the array, call
+    the function, then ``printf '%s\\n' "${arr[@]}"`` to dump its
+    contents one per line. ``--`` guards against val starting with ``-``.
+    """
+    script = (
+        f'. "{LIB}" >/dev/null 2>&1\n'
+        f'declare -a out=()\n'
+        f'mo_emit_budget_flag out "$1" "$2"\n'
+        f'printf "%s\\n" "${{out[@]}}"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", script, "--", lane, val],
+        env=env, capture_output=True, text=True,
+    )
+    assert r.returncode == 0, f"bash emit_budget_flag failed: {r.stderr}"
+    return [ln for ln in r.stdout.split("\n") if ln != ""]
+
+
+def _bash_emit_cache_flags(env: dict) -> list[str]:
+    """Drive ``mo_emit_cache_flags`` and dump the resulting array."""
+    script = (
+        f'. "{LIB}" >/dev/null 2>&1\n'
+        f'declare -a out=()\n'
+        f'mo_emit_cache_flags out\n'
+        f'printf "%s\\n" "${{out[@]}}"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", script, "--"],
+        env=env, capture_output=True, text=True,
+    )
+    assert r.returncode == 0, f"bash emit_cache_flags failed: {r.stderr}"
+    return [ln for ln in r.stdout.split("\n") if ln != ""]
+
+
+def _bash_assert_lane_capability(lane: str, env: dict) -> subprocess.CompletedProcess:
+    """Run ``mo_assert_lane_capability`` in a subshell, capturing rc + stderr."""
+    script = (
+        f'. "{LIB}" >/dev/null 2>&1\n'
+        f'mo_assert_lane_capability "$1"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "--", lane],
+        env=env, capture_output=True, text=True,
+    )
+
+
+def _bash_aggregate_cache_stats(iter_dir: str, env: dict) -> subprocess.CompletedProcess:
+    """Run ``mo_aggregate_cache_stats`` in a subshell."""
+    script = (
+        f'. "{LIB}" >/dev/null 2>&1\n'
+        f'mo_aggregate_cache_stats "$1"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "--", iter_dir],
+        env=env, capture_output=True, text=True,
+    )
+
+
+def _point_python_env(monkeypatch: pytest.MonkeyPatch, **overrides: str) -> None:
+    """Reset lane-helper-sensitive env vars for the Python process and
+    apply ``overrides``. Mirrors the env passed to bash subprocesses."""
+    for k in _ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    for k, v in overrides.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+
+
+def _reset_cache_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the emit_cache_flags probe to re-run on next call.
+
+    Mirrors the bash source's per-process ``_MO_CACHE_FLAG_SUPPORTED``
+    env var. Tests that vary ``claude`` (via PATH shim) or
+    ``MO_PROMPT_CACHE_DISABLED`` must reset the module-level cache so
+    the new value gets probed.
+    """
+    monkeypatch.setattr(lh, "_CACHED_SUPPORTED", None)
+    monkeypatch.setattr(lh, "_PROBE_DONE", False)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (a) lane_is_free parity — 5 lanes (free + paid)
+# ─────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("lane", ["glm", "kimi", "minimax", "opus", "sonnet"])
+def test_lane_is_free_parity(lane: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each lane produces identical free/paid verdict from bash and python."""
+    _which("bash")
+    _point_python_env(monkeypatch)
+    env = _clean_env()
+
+    bash_free = _bash_lane_is_free(lane, env)
+    py_free = lh.lane_is_free(lane)
+    assert py_free == bash_free, (
+        f"lane_is_free({lane!r}) drift: bash={bash_free} py={py_free}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (b) emit_budget_flag parity — free lane returns []; paid returns
+#     [--max-budget-usd, <val>].
+# ─────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "lane,val,expected_len",
+    [
+        ("glm", "0.80", 0),       # free → []
+        ("opus", "0.80", 2),      # paid → [flag, val]
+        ("sonnet", "1.20", 2),    # paid → [flag, val]
+    ],
+    ids=["free_glm", "paid_opus", "paid_sonnet"],
+)
+def test_emit_budget_flag_parity(
+    lane: str, val: str, expected_len: int, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both bash and python produce the same flag array for a given lane/val."""
+    _which("bash")
+    _point_python_env(monkeypatch)
+    env = _clean_env()
+
+    bash_flags = _bash_emit_budget_flag(lane, val, env)
+    py_flags = lh.emit_budget_flag(lane, val)
+
+    assert len(bash_flags) == expected_len
+    assert bash_flags == py_flags, (
+        f"emit_budget_flag({lane!r}, {val!r}) drift: "
+        f"bash={bash_flags!r} py={py_flags!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (c) emit_cache_flags feature-detect — PATH shim echoes the flag in
+#     `claude --help`, so both bash and python return [flag].
+# ─────────────────────────────────────────────────────────────────────
+def test_emit_cache_flags_supported_parity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PATH-shim fake `claude --help` echoes the cache flag → both sides
+    return ``["--exclude-dynamic-system-prompt-sections"]``."""
+    _which("bash")
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    fake_claude = shim_dir / "claude"
+    fake_claude.write_text(
+        "#!/usr/bin/env bash\n"
+        'echo "Usage: claude [options]"\n'
+        'echo "  --exclude-dynamic-system-prompt-sections  Exclude dynamic system prompt sections"\n'
+        'echo "  --max-turns <N>                            Max turns"\n'
+    )
+    fake_claude.chmod(0o755)
+
+    env = _clean_env()
+    env["PATH"] = f"{shim_dir}:{env.get('PATH', '')}"
+    _point_python_env(monkeypatch)
+    # Make subprocess.run find the shim first.
+    monkeypatch.setenv("PATH", f"{shim_dir}:{os.environ.get('PATH', '')}")
+    _reset_cache_probe(monkeypatch)
+
+    bash_flags = _bash_emit_cache_flags(env)
+    py_flags = lh.emit_cache_flags()
+
+    assert bash_flags == py_flags, (
+        f"emit_cache_flags (supported) drift: bash={bash_flags!r} py={py_flags!r}"
+    )
+    assert "--exclude-dynamic-system-prompt-sections" in bash_flags
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (d) emit_cache_flags disabled — MO_PROMPT_CACHE_DISABLED=1 returns [].
+# ─────────────────────────────────────────────────────────────────────
+def test_emit_cache_flags_disabled_parity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """MO_PROMPT_CACHE_DISABLED=1 short-circuits to [] on both sides.
+
+    The bash source guards the feature-detect block on
+    ``[ "${MO_PROMPT_CACHE_DISABLED:-0}" = "1" ]``. The Python port
+    returns [] before the probe fires. We do NOT need a PATH shim
+    because the disabled branch never calls ``claude``."""
+    _which("bash")
+    env = _clean_env()
+    env["MO_PROMPT_CACHE_DISABLED"] = "1"
+    _point_python_env(monkeypatch, MO_PROMPT_CACHE_DISABLED="1")
+    _reset_cache_probe(monkeypatch)
+
+    bash_flags = _bash_emit_cache_flags(env)
+    py_flags = lh.emit_cache_flags()
+
+    assert bash_flags == [] and py_flags == [], (
+        f"disabled branch drift: bash={bash_flags!r} py={py_flags!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (e) assert_lane_capability OK — capabilities satisfied → exit 0.
+# ─────────────────────────────────────────────────────────────────────
+def test_assert_lane_capability_satisfied_parity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Seed a tmpdir agents.yaml with capabilities satisfied; both bash
+    and python exit 0 with empty stderr."""
+    _which("bash")
+    home = tmp_path / "home"
+    cfg_dir = home / "config"
+    cfg_dir.mkdir(parents=True)
+    agents_yaml = cfg_dir / "agents.yaml"
+    agents_yaml.write_text(
+        "lanes:\n"
+        "  implementer: opus\n"
+        "capabilities:\n"
+        "  opus:\n"
+        "    tools: true\n"
+        "    reasoning: true\n"
+    )
+
+    env = _clean_env()
+    env["MINI_ORK_HOME"] = str(home)
+    # MINI_ORK_ROOT must point at the real repo so bash can source
+    # lib/config_resolve.sh. config/agents.yaml exists at the repo
+    # root, but bash's mo_assert_lane_capability uses it only as a
+    # FALLBACK when the primary is missing — primary is HOME's yaml
+    # so the real REPO yaml is never consulted by the capabilities
+    # lookup (it has no `capabilities` key at the top level that
+    # would shadow the primary in this fixture; primary's caps win).
+    env["MINI_ORK_ROOT"] = str(REPO)
+    env["MINI_ORK_RUN_DIR"] = ""  # bash falls through to HOME
+    env["MO_LANE_REQUIRES_CAPABILITY"] = "tools,reasoning"
+
+    _point_python_env(
+        monkeypatch,
+        MINI_ORK_HOME=str(home),
+        MINI_ORK_ROOT=str(REPO),
+        MINI_ORK_RUN_DIR="",
+        MO_LANE_REQUIRES_CAPABILITY="tools,reasoning",
+    )
+
+    r_bash = _bash_assert_lane_capability("implementer", env)
+    assert r_bash.returncode == 0, (
+        f"bash satisfied rc={r_bash.returncode}\nstderr={r_bash.stderr!r}"
+    )
+    assert r_bash.stderr == "", f"bash satisfied leaked stderr: {r_bash.stderr!r}"
+
+    # resolve_agents_yaml prints the path; redirect stdout to keep the
+    # test's own output clean (the helper is called for side-effect).
+    with contextlib.redirect_stdout(io.StringIO()):
+        lh.assert_lane_capability("implementer")  # must not raise
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (f) assert_lane_capability fail — missing cap → exit 1 + stderr token.
+# ─────────────────────────────────────────────────────────────────────
+def test_assert_lane_capability_missing_parity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lane family lacks one required capability → both exit 1 and
+    surface the first missing cap token in stderr / exception."""
+    _which("bash")
+    home = tmp_path / "home"
+    cfg_dir = home / "config"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "agents.yaml").write_text(
+        "lanes:\n"
+        "  implementer: opus\n"
+        "capabilities:\n"
+        "  opus:\n"
+        "    tools: true\n"
+    )
+    # requirements include "vision" which opus does NOT have.
+
+    env = _clean_env()
+    env["MINI_ORK_HOME"] = str(home)
+    env["MINI_ORK_ROOT"] = str(REPO)
+    env["MO_LANE_REQUIRES_CAPABILITY"] = "tools,vision"
+
+    _point_python_env(
+        monkeypatch,
+        MINI_ORK_HOME=str(home),
+        MINI_ORK_ROOT=str(REPO),
+        MINI_ORK_RUN_DIR="",
+        MO_LANE_REQUIRES_CAPABILITY="tools,vision",
+    )
+
+    r_bash = _bash_assert_lane_capability("implementer", env)
+    assert r_bash.returncode == 1, (
+        f"bash missing-cap rc={r_bash.returncode}\nstderr={r_bash.stderr!r}"
+    )
+    assert r_bash.stderr.strip() == "vision", (
+        f"bash missing-cap stderr={r_bash.stderr!r}"
+    )
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        with pytest.raises(RuntimeError) as exc_info:
+            lh.assert_lane_capability("implementer")
+    assert str(exc_info.value) == "vision", (
+        f"python missing-cap token={exc_info.value!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (g) aggregate_cache_stats happy — byte-diff cache-stats.json modulo
+#     per_file[].file (identical basename) + saved_usd float tolerance.
+# ─────────────────────────────────────────────────────────────────────
+def test_aggregate_cache_stats_parity(
+    tmp_path: Path,
+) -> None:
+    """Seed 3 fixture logs; both sides must emit cache-stats.json with
+    the same totals + per_file shape (same basename, identical ints)."""
+    _which("bash")
+    bash_dir = tmp_path / "bash" / "iter-1"
+    py_dir = tmp_path / "py" / "iter-1"
+    bash_dir.mkdir(parents=True)
+    py_dir.mkdir(parents=True)
+
+    fixture_body = (
+        '{"event":"usage","cache_creation_input_tokens":100,"cache_read_input_tokens":50,"input_tokens":25}\n'
+        '{"event":"usage","cache_creation_input_tokens":200,"cache_read_input_tokens":75,"input_tokens":50}\n'
+    )
+    for name in ("a.log", "b.log", "c.log"):
+        (bash_dir / name).write_text(fixture_body)
+        (py_dir / name).write_text(fixture_body)
+
+    env = _clean_env()
+
+    r_bash = _bash_aggregate_cache_stats(str(bash_dir), env)
+    assert r_bash.returncode == 0, (
+        f"bash aggregate rc={r_bash.returncode}\nstderr={r_bash.stderr!r}"
+    )
+    bash_stats_path = bash_dir / "cache-stats.json"
+    assert bash_stats_path.exists(), f"bash didn't write {bash_stats_path}"
+
+    lh.aggregate_cache_stats(str(py_dir))
+    py_stats_path = py_dir / "cache-stats.json"
+    assert py_stats_path.exists(), f"python didn't write {py_stats_path}"
+
+    bash_stats = json.loads(bash_stats_path.read_text())
+    py_stats_raw = json.loads(py_stats_path.read_text())
+
+    # Identical key set.
+    assert sorted(bash_stats.keys()) == sorted(py_stats_raw.keys()), (
+        f"key drift: bash={sorted(bash_stats.keys())} "
+        f"py={sorted(py_stats_raw.keys())}"
+    )
+
+    # Integer totals + log_files_scanned must be byte-identical.
+    for k in ("cache_creation_tokens", "cache_read_tokens",
+              "uncached_input_tokens", "log_files_scanned"):
+        assert bash_stats[k] == py_stats_raw[k], (
+            f"{k} drift: bash={bash_stats[k]} py={py_stats_raw[k]}"
+        )
+        assert isinstance(bash_stats[k], int), (
+            f"bash emitted non-int for {k}: {type(bash_stats[k]).__name__}"
+        )
+        assert isinstance(py_stats_raw[k], int), (
+            f"python emitted non-int for {k}: {type(py_stats_raw[k]).__name__}"
+        )
+
+    # Floats: hit_rate + estimated_usd_saved (1e-6 tolerance per kickoff).
+    assert abs(bash_stats["hit_rate"] - py_stats_raw["hit_rate"]) < 1e-6, (
+        f"hit_rate drift: bash={bash_stats['hit_rate']} "
+        f"py={py_stats_raw['hit_rate']}"
+    )
+    assert abs(bash_stats["estimated_usd_saved"] - py_stats_raw["estimated_usd_saved"]) < 1e-6, (
+        f"saved_usd drift: bash={bash_stats['estimated_usd_saved']} "
+        f"py={py_stats_raw['estimated_usd_saved']}"
+    )
+
+    # per_file: same length, same basenames, identical int fields.
+    assert len(bash_stats["per_file"]) == len(py_stats_raw["per_file"]) == 3
+    bash_by_name = {e["file"]: e for e in bash_stats["per_file"]}
+    py_by_name = {e["file"]: e for e in py_stats_raw["per_file"]}
+    assert set(bash_by_name) == set(py_by_name), (
+        f"per_file basenames drift: bash={set(bash_by_name)} "
+        f"py={set(py_by_name)}"
+    )
+    for name, b in bash_by_name.items():
+        p = py_by_name[name]
+        for k in ("cache_creation", "cache_read", "uncached"):
+            assert b[k] == p[k], f"per_file[{name}].{k} drift: bash={b[k]} py={p[k]}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# (h) aggregate_cache_stats empty — zero-log dir → both write a valid
+#     JSON with zeros + hit_rate:0 + per_file:[].
+# ─────────────────────────────────────────────────────────────────────
+def test_aggregate_cache_stats_empty_dir_parity(
+    tmp_path: Path,
+) -> None:
+    """No .log files in iter_dir → both sides write a valid JSON with
+    all-zero totals and an empty per_file array."""
+    _which("bash")
+    bash_dir = tmp_path / "bash" / "iter-1"
+    py_dir = tmp_path / "py" / "iter-1"
+    bash_dir.mkdir(parents=True)
+    py_dir.mkdir(parents=True)
+
+    env = _clean_env()
+
+    r_bash = _bash_aggregate_cache_stats(str(bash_dir), env)
+    assert r_bash.returncode == 0, f"bash empty-iter rc={r_bash.returncode}"
+
+    lh.aggregate_cache_stats(str(py_dir))
+
+    bash_stats = json.loads((bash_dir / "cache-stats.json").read_text())
+    py_stats_raw = json.loads((py_dir / "cache-stats.json").read_text())
+
+    # Both must show zero totals + zero hit_rate + empty per_file.
+    for k in ("cache_creation_tokens", "cache_read_tokens",
+              "uncached_input_tokens", "log_files_scanned"):
+        assert bash_stats[k] == 0 == py_stats_raw[k], (
+            f"empty-dir {k} drift: bash={bash_stats[k]} py={py_stats_raw[k]}"
+        )
+    assert bash_stats["hit_rate"] == 0
+    assert py_stats_raw["hit_rate"] == 0
+    assert bash_stats["per_file"] == []
+    assert py_stats_raw["per_file"] == []
+    # saved_usd should be exactly 0.0 on both sides (read=0 → 0.0*0.9*3/1e6=0).
+    assert bash_stats["estimated_usd_saved"] == 0
+    assert py_stats_raw["estimated_usd_saved"] == 0
+
+
+# ─────────────────────────────────────────────────────────────────────
+# claude_print — documented gap (live parity NOT exercised; see
+# module docstring). This is a smoke test that the function exists
+# and constructs the right argv shape using the cache flag from the
+# PATH-shim. We don't actually invoke `claude --print` because that
+# hits the network / model and is non-deterministic.
+# ─────────────────────────────────────────────────────────────────────
+def test_claude_print_argv_shape_smoke(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """claude_print() must build the right argv when cache is supported.
+
+    Uses a real PATH-shim ``claude`` that:
+      - when called as ``claude --help``, echoes the cache flag (so
+        ``emit_cache_flags()`` returns the flag), and
+      - when called as ``claude --print ...``, records its argv to
+        a file and exits 0 (so we can inspect the constructed argv
+        without actually invoking the real model).
+    """
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    argv_log = shim_dir / "argv.log"
+    (shim_dir / "claude").write_text(
+        "#!/usr/bin/env bash\n"
+        "# Shim: log argv to argv.log; echo cache flag in --help.\n"
+        'if [ "$1" = "--help" ]; then\n'
+        '  echo "Usage: claude [options]"\n'
+        '  echo "  --exclude-dynamic-system-prompt-sections  Exclude dynamic system prompt sections"\n'
+        '  echo "  --max-turns <N>                            Max turns"\n'
+        '  exit 0\n'
+        "fi\n"
+        f'echo "ARGS:$(basename "$0") $@" >> "{argv_log}"\n'
+        'echo "fake claude output"\n'
+        'exit 0\n'
+    )
+    (shim_dir / "claude").chmod(0o755)
+
+    monkeypatch.setenv("PATH", f"{shim_dir}:{os.environ.get('PATH', '')}")
+    _point_python_env(monkeypatch)
+    _reset_cache_probe(monkeypatch)
+
+    r = lh.claude_print(
+        "hello", "extra-arg", max_turns=5, output_format="json",
+    )
+    assert r.returncode == 0
+
+    # The shim only logs non-`--help` invocations. The cache-flag probe
+    # (``claude --help``) hits the shim's early-exit branch and leaves
+    # no ARGS line — only the print call is recorded. We assert on the
+    # single recorded line.
+    lines = [ln for ln in argv_log.read_text().splitlines() if ln.startswith("ARGS:")]
+    assert len(lines) == 1, f"expected 1 claude print invocation, got {len(lines)}: {lines}"
+    argv_str = lines[0][len("ARGS:"):]
+    argv = argv_str.split(" ")
+    assert argv[0] == "claude"
+    assert "--print" in argv
+    idx = argv.index("--permission-mode")
+    assert argv[idx + 1] == "bypassPermissions"
+    idx = argv.index("--output-format")
+    assert argv[idx + 1] == "json"
+    idx = argv.index("--max-turns")
+    assert argv[idx + 1] == "5"
+    assert "--exclude-dynamic-system-prompt-sections" in argv
+    assert "extra-arg" in argv
+    # prompt must be the LAST argv (matches bash's "$@" $PROMPT order).
+    assert argv[-1] == "hello"

--- a/tests/unit/test_panel_bias_py.py
+++ b/tests/unit/test_panel_bias_py.py
@@ -1,0 +1,419 @@
+"""Parity gate: mini_ork.ported.panel_bias vs lib/panel_bias.sh.
+
+Each test invokes the LIVE bash functions from ``lib/panel_bias.sh`` via
+``bash -c 'source lib/panel_bias.sh; <func> <args>'`` on identical
+inputs as the Python port and asserts equivalent outputs (file presence,
+byte-content, label_map shape, borda/mean_rank values, sort order,
+exit codes / raised exceptions). No mocks, no hardcoded outputs beyond
+what bash itself emits.
+
+Seven cases (above the kickoff's >=6 floor):
+  (a) panel_anonymize happy-path         — both write resp-{A,B,C}.md,
+                                            byte-match sources via label_map
+                                            round-trip; label_map keys/values
+                                            match the same set.
+  (b) panel_anonymize seed determinism   — same seed → identical mapping
+                                            (bash via awk srand, python via
+                                            random.seed; each is deterministic
+                                            in-process); two seeds produce
+                                            different mappings (collision
+                                            retry, mirrors test_panel_bias.sh).
+  (c) panel_anonymize missing dir        — bash rc=1 + stderr "not found"
+                                            matches python FileNotFoundError
+                                            with the path echoed in the
+                                            message.
+  (d) panel_rank_aggregate hand-computed — 3 reviewers (A C B / B A C / A
+                                            B C), N=3 → borda A=5 B=3 C=1;
+                                            mean_rank 1.3333/2.0000/2.6667;
+                                            sort glm>kimi>opus.
+  (e) panel_rank_aggregate tie-break     — borda+mean_rank tie → family
+                                            alphabetical (alpha<bravo).
+  (f) panel_permute_order determinism    — same seed → identical order;
+                                            different seeds → different
+                                            orders (with high prob).
+  (g) panel_permute_order multiset       — output is a permutation of the
+                                            source basenames (count +
+                                            multiset preserved).
+
+RNG parity: bash uses awk's RNG (linear-congruential, 20-digit
+precision), Python uses ``random.Random(seed)`` (Mersenne Twister). The
+two produce DIFFERENT orderings for the same seed — the test does NOT
+byte-compare raw permutation order. It compares downstream observable
+properties (label_map keys ⊆ A..Z, families ⊆ {glm,kimi,opus};
+borda/mean_rank exact; sort-by tuple; permutation-of-source multiset).
+
+Environment isolation: each test points subprocess env at a per-test
+temp dir so bash's ``mktemp`` + label_map sibling conventions and
+Python's path-based I/O both land in /tmp without polluting the repo.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import panel_bias as pb  # noqa: E402
+
+SH = REPO / "lib" / "panel_bias.sh"
+
+# Tolerance for floats parsed from JSON. The bash implementation emits
+# mean_rank via `awk 'BEGIN{printf "%.4f", s/c}'` so the precision is
+# bounded at 1e-4. 1e-6 from the kickoff is a strict superset.
+_FLOAT_TOL = 1e-6
+
+
+def _which_bash() -> None:
+    if not shutil.which("bash"):
+        pytest.skip("bash not on PATH")
+    if not shutil.which("jq"):
+        pytest.skip("jq not on PATH (required by lib/panel_bias.sh)")
+    if not SH.exists():
+        pytest.skip(f"missing lib/panel_bias.sh at {SH}")
+
+
+def _bash_panel_anonymize(reports_dir: str, out_dir: str, seed: int) -> subprocess.CompletedProcess:
+    """Invoke ``bash -c 'source lib/panel_bias.sh; panel_anonymize ...'``."""
+    src = (
+        f'source "{SH}"\n'
+        f'panel_anonymize "{reports_dir}" "{out_dir}" {seed}\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", src],
+        capture_output=True, text=True,
+    )
+
+
+def _bash_panel_rank_aggregate(xrank_dir: str, label_map: str) -> subprocess.CompletedProcess:
+    """Invoke ``bash -c 'source lib/panel_bias.sh; panel_rank_aggregate ...'``."""
+    src = (
+        f'source "{SH}"\n'
+        f'panel_rank_aggregate "{xrank_dir}" "{label_map}"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", src],
+        capture_output=True, text=True,
+    )
+
+
+def _bash_panel_permute_order(reports_dir: str, seed: int) -> subprocess.CompletedProcess:
+    """Invoke ``bash -c 'source lib/panel_bias.sh; panel_permute_order ...'``."""
+    src = (
+        f'source "{SH}"\n'
+        f'panel_permute_order "{reports_dir}" {seed}\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", src],
+        capture_output=True, text=True,
+    )
+
+
+def _write_lens_families(reports_dir: Path, families: list[str]) -> None:
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    for f in families:
+        (reports_dir / f"lens-{f}.md").write_text(f"LENS OUTPUT for {f}\n")
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) panel_anonymize happy-path
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_anonymize_happy_path_parity(tmp_path):
+    """3 families (glm/kimi/opus), seed=42 → resp-{A,B,C}.md byte-match
+    sources via label_map round-trip; label_map keys ⊆ A..Z, values ⊆
+    {glm,kimi,opus}. Both sides must produce a label_map whose
+    values are exactly the input families (no orphans)."""
+    _which_bash()
+    r = tmp_path / "reports"
+    o = tmp_path / "out"
+    _write_lens_families(r, ["glm", "kimi", "opus"])
+
+    # Bash
+    r_bash = _bash_panel_anonymize(str(r), str(o), 42)
+    assert r_bash.returncode == 0, (
+        f"bash panel_anonymize rc={r_bash.returncode}\nstderr={r_bash.stderr}"
+    )
+    bash_map = _read_json(o.with_name(o.name + ".label_map.json"))
+    assert set(bash_map.keys()) == {"A", "B", "C"}
+    assert set(bash_map.values()) == {"glm", "kimi", "opus"}
+    for label, family in bash_map.items():
+        assert (o / f"resp-{label}.md").read_bytes() == (
+            r / f"lens-{family}.md"
+        ).read_bytes(), f"bash resp-{label}.md not byte-equal to source lens-{family}.md"
+
+    # Reset out dir for python side
+    shutil.rmtree(o)
+    o.mkdir()
+
+    # Python
+    py_map = pb.panel_anonymize(str(r), str(o), 42)
+    assert set(py_map.keys()) == {"A", "B", "C"}
+    assert set(py_map.values()) == {"glm", "kimi", "opus"}
+    for label, family in py_map.items():
+        assert (o / f"resp-{label}.md").read_bytes() == (
+            r / f"lens-{family}.md"
+        ).read_bytes(), f"python resp-{label}.md not byte-equal to source lens-{family}.md"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) panel_anonymize seed determinism
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_anonymize_seed_determinism_parity(tmp_path):
+    """Same seed on the SAME implementation must produce the SAME
+    mapping (deterministic). Different seeds on the same implementation
+    must produce different mappings (with high probability — bash test
+    uses 2-re-roll collision retry). Both sides pass this on their own
+    RNG; we don't compare bash-vs-python raw permutations because the
+    RNG algorithms differ (awk vs random.seed)."""
+    _which_bash()
+    r = tmp_path / "reports"
+    _write_lens_families(r, ["glm", "kimi", "opus"])
+
+    # ── Same seed → same mapping on bash ──
+    o1 = tmp_path / "out_bash_42_a"
+    o2 = tmp_path / "out_bash_42_b"
+    for o in (o1, o2):
+        r_bash = _bash_panel_anonymize(str(r), str(o), 42)
+        assert r_bash.returncode == 0
+    map_a = _read_json(o1.with_name(o1.name + ".label_map.json"))
+    map_b = _read_json(o2.with_name(o2.name + ".label_map.json"))
+    assert map_a == map_b, f"bash seed=42 not deterministic across invocations: {map_a} vs {map_b}"
+
+    # ── Same seed → same mapping on python ──
+    py_map_a = pb.panel_anonymize(str(r), str(tmp_path / "out_py_42_a"), 42)
+    py_map_b = pb.panel_anonymize(str(r), str(tmp_path / "out_py_42_b"), 42)
+    assert py_map_a == py_map_b, (
+        f"python seed=42 not deterministic across invocations: {py_map_a} vs {py_map_b}"
+    )
+
+    # ── Different seeds → different mapping on bash (with retry) ──
+    o_seed99 = tmp_path / "out_bash_99"
+    r_bash99 = _bash_panel_anonymize(str(r), str(o_seed99), 99)
+    assert r_bash99.returncode == 0
+    map_99 = _read_json(o_seed99.with_name(o_seed99.name + ".label_map.json"))
+    tries = 0
+    seed = 99
+    while map_a == map_99 and tries < 2:
+        tries += 1
+        seed = 99 + tries
+        o_retry = tmp_path / f"out_bash_{seed}"
+        r_retry = _bash_panel_anonymize(str(r), str(o_retry), seed)
+        assert r_retry.returncode == 0
+        map_99 = _read_json(o_retry.with_name(o_retry.name + ".label_map.json"))
+    assert map_a != map_99, (
+        f"bash seed=42 vs seed={seed} produced identical mapping "
+        f"(collision after {tries + 1} retries)"
+    )
+
+    # ── Different seeds → different mapping on python (with retry) ──
+    py_seed = 99
+    py_99 = pb.panel_anonymize(str(r), str(tmp_path / "out_py_99"), py_seed)
+    tries = 0
+    while py_map_a == py_99 and tries < 2:
+        tries += 1
+        py_seed = 99 + tries
+        py_99 = pb.panel_anonymize(str(r), str(tmp_path / f"out_py_{py_seed}"), py_seed)
+    assert py_map_a != py_99, (
+        f"python seed=42 vs seed={py_seed} produced identical mapping"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) panel_anonymize missing reports_dir
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_anonymize_missing_reports_dir_parity(tmp_path):
+    """Missing reports_dir → bash rc=1 + stderr "not found"; python
+    FileNotFoundError with path echoed in message."""
+    _which_bash()
+    bogus = str(tmp_path / "no_such_reports")
+    out = str(tmp_path / "out")
+
+    r_bash = _bash_panel_anonymize(bogus, out, 0)
+    assert r_bash.returncode != 0, (
+        f"bash panel_anonymize rc=0 on missing dir (should fail): {r_bash.stderr}"
+    )
+    assert "not found" in r_bash.stderr.lower(), (
+        f"bash stderr should mention 'not found', got: {r_bash.stderr!r}"
+    )
+    assert bogus in r_bash.stderr, f"bash stderr should echo the path: {r_bash.stderr!r}"
+
+    with pytest.raises(FileNotFoundError) as exc:
+        pb.panel_anonymize(bogus, out, 0)
+    assert "not found" in str(exc.value).lower()
+    assert bogus in str(exc.value), f"python error should echo the path: {exc.value!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) panel_rank_aggregate hand-computed (3 reviewers)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_rank_aggregate_hand_computed_parity(tmp_path):
+    """3 reviewers with rankings ('A C B', 'B A C', 'A B C'), N=3:
+        borda scale p=0→2, p=1→1, p=2→0
+          A: r1=2 (p=0), r2=1 (p=1), r3=2 (p=0)   → Σ = 5
+          B: r1=0 (p=2), r2=2 (p=0), r3=1 (p=1)   → Σ = 3
+          C: r1=1 (p=1), r2=0 (p=2), r3=0 (p=2)   → Σ = 1
+        mean_rank (1-indexed average position):
+          A: (1+2+1)/3 = 1.3333
+          B: (3+1+2)/3 = 2.0000
+          C: (2+3+3)/3 = 2.6667
+      Sort: borda DESC → glm(5) > kimi(3) > opus(1). Both sides must
+      emit panel-rank-aggregate.json with this exact shape + ordering.
+    """
+    _which_bash()
+    x = tmp_path / "xrank"
+    x.mkdir()
+    (x / "r1.md").write_text("# R1\npreamble\nFINAL RANKING: A C B\n")
+    (x / "r2.md").write_text("# R2\npreamble\nFINAL RANKING: B A C\n")
+    (x / "r3.md").write_text("# R3\npreamble\nFINAL RANKING: A B C\n")
+    lm = tmp_path / "label_map.json"
+    lm.write_text(json.dumps({"A": "glm", "B": "kimi", "C": "opus"}))
+
+    # Bash
+    r_bash = _bash_panel_rank_aggregate(str(x), str(lm))
+    assert r_bash.returncode == 0, f"bash rc={r_bash.returncode}\nstderr={r_bash.stderr}"
+    bash_out = _read_json(x / "panel-rank-aggregate.json")
+    assert isinstance(bash_out, list) and len(bash_out) == 3
+    bash_by_label = {e["label"]: e for e in bash_out}
+    assert int(bash_by_label["A"]["borda"]) == 5
+    assert int(bash_by_label["B"]["borda"]) == 3
+    assert int(bash_by_label["C"]["borda"]) == 1
+    assert abs(float(bash_by_label["A"]["mean_rank"]) - 1.3333) < _FLOAT_TOL
+    assert abs(float(bash_by_label["B"]["mean_rank"]) - 2.0000) < _FLOAT_TOL
+    assert abs(float(bash_by_label["C"]["mean_rank"]) - 2.6667) < _FLOAT_TOL
+    bash_order = [e["family"] for e in bash_out]
+    assert bash_order == ["glm", "kimi", "opus"], f"bash order={bash_order}"
+
+    # Reset output and run python on the same input
+    (x / "panel-rank-aggregate.json").unlink()
+    py_out = pb.panel_rank_aggregate(str(x), str(lm))
+    assert isinstance(py_out, list) and len(py_out) == 3
+    py_by_label: dict = {e["label"]: e for e in py_out}
+    assert int(str(py_by_label["A"]["borda"])) == 5
+    assert int(str(py_by_label["B"]["borda"])) == 3
+    assert int(str(py_by_label["C"]["borda"])) == 1
+    assert abs(float(str(py_by_label["A"]["mean_rank"])) - 1.3333) < _FLOAT_TOL
+    assert abs(float(str(py_by_label["B"]["mean_rank"])) - 2.0000) < _FLOAT_TOL
+    assert abs(float(str(py_by_label["C"]["mean_rank"])) - 2.6667) < _FLOAT_TOL
+    py_order = [e["family"] for e in py_out]
+    assert py_order == ["glm", "kimi", "opus"], f"python order={py_order}"
+
+    # The output file written by python must round-trip identically.
+    py_out_file = _read_json(x / "panel-rank-aggregate.json")
+    assert py_out_file == py_out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) panel_rank_aggregate tie-break (borda+mean_rank tie → family ASC)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_rank_aggregate_tiebreak_parity(tmp_path):
+    """N=2, 2 reviewers with anti-symmetric ranking ('A B', 'B A') →
+    borda_tie=1 each, mean_rank=1.5 each. Tie broken by family
+    alphabetical (alpha < bravo)."""
+    _which_bash()
+    x = tmp_path / "xrank_tb"
+    x.mkdir()
+    (x / "r1.md").write_text("FINAL RANKING: A B\n")
+    (x / "r2.md").write_text("FINAL RANKING: B A\n")
+    lm = tmp_path / "label_map_tb.json"
+    lm.write_text(json.dumps({"A": "bravo", "B": "alpha"}))
+
+    r_bash = _bash_panel_rank_aggregate(str(x), str(lm))
+    assert r_bash.returncode == 0, f"bash rc={r_bash.returncode}\nstderr={r_bash.stderr}"
+    bash_out = _read_json(x / "panel-rank-aggregate.json")
+    bash_order = [e["family"] for e in bash_out]
+    assert bash_order == ["alpha", "bravo"], f"bash tie-break order={bash_order}"
+
+    (x / "panel-rank-aggregate.json").unlink()
+    py_out = pb.panel_rank_aggregate(str(x), str(lm))
+    py_order = [e["family"] for e in py_out]
+    assert py_order == ["alpha", "bravo"], f"python tie-break order={py_order}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) panel_permute_order determinism (same seed → same order)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_permute_order_determinism_parity(tmp_path):
+    """Same seed on the SAME implementation must yield identical order
+    (deterministic). Different seeds on the same implementation must
+    yield different orders (with high prob). 5 files: alpha/beta/gamma
+    /delta/epsilon."""
+    _which_bash()
+    p = tmp_path / "perm_reports"
+    p.mkdir()
+    for f in ("alpha", "beta", "gamma", "delta", "epsilon"):
+        (p / f"{f}.md").write_text("")
+
+    # Bash: same seed → same order
+    r1 = _bash_panel_permute_order(str(p), 1)
+    r2 = _bash_panel_permute_order(str(p), 1)
+    assert r1.returncode == 0 and r2.returncode == 0
+    assert r1.stdout == r2.stdout, (
+        f"bash panel_permute_order seed=1 not deterministic:\n{r1.stdout!r}\nvs\n{r2.stdout!r}"
+    )
+
+    # Bash: different seed → different order (with retry)
+    bash_seed = 2
+    rb = _bash_panel_permute_order(str(p), bash_seed)
+    assert rb.returncode == 0
+    tries = 0
+    while r1.stdout == rb.stdout and tries < 2:
+        tries += 1
+        bash_seed = 2 + tries
+        rb = _bash_panel_permute_order(str(p), bash_seed)
+        assert rb.returncode == 0
+    assert r1.stdout != rb.stdout, (
+        f"bash seed=1 vs seed={bash_seed} produced identical order "
+        f"(collision after {tries + 1} retries)"
+    )
+
+    # Python: same seed → same order
+    py1 = pb.panel_permute_order(str(p), 1)
+    py2 = pb.panel_permute_order(str(p), 1)
+    assert py1 == py2, f"python seed=1 not deterministic: {py1} vs {py2}"
+
+    # Python: different seed → different order (with retry)
+    py_seed = 2
+    pyb = pb.panel_permute_order(str(p), py_seed)
+    tries = 0
+    while py1 == pyb and tries < 2:
+        tries += 1
+        py_seed = 2 + tries
+        pyb = pb.panel_permute_order(str(p), py_seed)
+    assert py1 != pyb, f"python seed=1 vs seed={py_seed} produced identical order"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) panel_permute_order multiset preservation
+# ─────────────────────────────────────────────────────────────────────────────
+def test_panel_permute_order_multiset_parity(tmp_path):
+    """Both sides must emit a permutation of the source basenames —
+    count + multiset preserved. 7 files of varying lengths."""
+    _which_bash()
+    p = tmp_path / "perm_multi"
+    p.mkdir()
+    files = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf"]
+    for f in files:
+        (p / f"{f}.md").write_text("")
+    src_sorted = sorted(f"{f}.md" for f in files)
+
+    r_bash = _bash_panel_permute_order(str(p), 7)
+    assert r_bash.returncode == 0, f"bash rc={r_bash.returncode}\nstderr={r_bash.stderr}"
+    bash_lines = sorted(line for line in r_bash.stdout.splitlines() if line)
+    assert bash_lines == src_sorted, (
+        f"bash output not a permutation of source: got {bash_lines}"
+    )
+    assert len(bash_lines) == len(set(bash_lines)), "bash output has duplicates"
+
+    py_out = pb.panel_permute_order(str(p), 7)
+    assert sorted(py_out) == src_sorted, (
+        f"python output not a permutation of source: got {sorted(py_out)}"
+    )
+    assert len(py_out) == len(set(py_out)), "python output has duplicates"


### PR DESCRIPTION
Autonomous ports. lane_helpers uses PATH-shim fakes (no real claude spawn). Live-bash parity tests. Strangler-fig.