### PR TITLE
feat(python-migration): port recursive_orchestration + verifier_rubric (wave 10)

### DIFF
--- a/mini_ork/ported/recursive_orchestration.py
+++ b/mini_ork/ported/recursive_orchestration.py
@@ -1,0 +1,489 @@
+"""Recursive-orchestration — Python port of lib/recursive_orchestration.sh.
+
+Faithful port of the six bash public functions that implement bounded
+parent/child mini-ork lineage. The Python port gives callers an in-process
+surface (no `python3` heredoc per call) and gives the parity test a stable
+target to byte-diff against the live bash.
+
+Co-existence model (strangler-fig): bash `lib/recursive_orchestration.sh`
+is the authoritative source. This module mirrors its surfaces exactly.
+Parity is enforced by `tests/unit/test_recursive_orchestration_py.py`
+(>=6 cases that drive the LIVE bash subprocess against a temp DB seeded
+by `db/init.sh` and diff the resulting `run_spawns` / `run_events` /
+`run_artifact_edges` / `merge_decisions` rows against the Python port
+byte-for-byte; floats 1e-6 on `authority_level`, epochs 1s tolerance,
+event_id stem-equal).
+
+Schema citations:
+  - `run_spawns`            — db/migrations/0016_recursive_orchestration.sql
+  - `run_events`            — db/migrations/0016_recursive_orchestration.sql
+  - `run_artifact_edges`    — db/migrations/0016_recursive_orchestration.sql
+  - `merge_decisions`       — db/migrations/0016_recursive_orchestration.sql
+  - `task_runs`             — db/migrations/0013_task_runs.sql
+                               (UPSERT target for approve_spawn)
+
+Pipeline map (bash function → Python):
+  mo_recursive_policy_json    → mo_recursive_policy_json      (env → dict, sort_keys)
+  mo_recursive_emit_event     → mo_recursive_emit_event       (validate JSON → INSERT run_events)
+  mo_recursive_approve_spawn  → mo_recursive_approve_spawn    (transactional: validate gates → counts → INSERT run_spawns + run_events + task_runs UPSERT)
+  mo_recursive_mark_spawn     → mo_recursive_mark_spawn       (UPDATE run_spawns.status, raise on 0 rows)
+  mo_recursive_record_artifact→ mo_recursive_record_artifact  (INSERT run_artifact_edges)
+  mo_recursive_merge_decision → mo_recursive_merge_decision   (INSERT merge_decisions + conditional UPDATE run_spawns.status)
+
+Internal helpers (mirrors of bash underscore-prefixed functions):
+  _mo_recursive_root  → _root         (retained for parity; not consumed)
+  _mo_recursive_db    → _resolve_db   (env precedence: MINI_ORK_DB > MINI_ORK_HOME/state.db > .mini-ork/state.db)
+  _mo_recursive_uuid  → _build_id     (seconds epoch in middle segment)
+  _mo_recursive_bool  → _bool_int     (1|true|yes|on → 1; everything else → 0)
+
+ID format mirror (mirrors bash `_mo_recursive_uuid`):
+    f"{prefix}-{int(time.time())}-{uuid.uuid4().hex[:12]}"
+Seconds resolution is mandatory — `event_id` parity vs bash depends on the
+middle segment being `int(time.time())`, not nanoseconds.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import time
+import uuid
+
+__all__ = [
+    "mo_recursive_policy_json",
+    "mo_recursive_emit_event",
+    "mo_recursive_approve_spawn",
+    "mo_recursive_mark_spawn",
+    "mo_recursive_record_artifact",
+    "mo_recursive_merge_decision",
+]
+
+
+# Mirrors lib/recursive_orchestration.sh:18 (`_mo_recursive_db`)
+def _resolve_db() -> str:
+    """Return the state.db path the bash script would pick.
+
+    Resolution order (mirrors bash line 19):
+      $MINI_ORK_DB → ${MINI_ORK_HOME:-$(pwd)/.mini-ork}/state.db
+
+    Unlike `_resolve_db` in `mo_node_events.py`, this port always returns a
+    path (no `None` branch) because every bash public function in this
+    module opens the DB unconditionally — there is no `state.db missing`
+    silent no-op contract here.
+    """
+    env_db = os.environ.get("MINI_ORK_DB")
+    if env_db:
+        return env_db
+    home = os.environ.get("MINI_ORK_HOME") or os.path.join(os.getcwd(), ".mini-ork")
+    return os.path.join(home, "state.db")
+
+
+# Mirrors lib/recursive_orchestration.sh:22 (`_mo_recursive_uuid`)
+def _build_id(prefix: str) -> str:
+    """Mirror bash `f"{prefix}-{int(time.time())}-{uuid.uuid4().hex[:12]}"`.
+
+    Seconds resolution in the middle segment is required so the bash and
+    Python `event_id`s share the `ev-<sec>-` stem during parity diff.
+    """
+    return f"{prefix}-{int(time.time())}-{uuid.uuid4().hex[:12]}"
+
+
+# Mirrors lib/recursive_orchestration.sh:30 (`_mo_recursive_bool`)
+def _bool_int(value: str | int | None) -> int:
+    """Mirror bash `_mo_recursive_bool`: 1|true|TRUE|yes|YES|on|ON → 1, else 0."""
+    s = "" if value is None else str(value)
+    if s in ("1", "true", "TRUE", "yes", "YES", "on", "ON"):
+        return 1
+    return 0
+
+
+# Mirrors lib/recursive_orchestration.sh:37 (`mo_recursive_policy_json`)
+def mo_recursive_policy_json() -> str:
+    """Mirror bash `mo_recursive_policy_json` lines 37-51.
+
+    Reads the same six env vars as the bash heredoc and emits
+    `json.dumps(policy, sort_keys=True)` to stdout (well, returns the
+    string). The Python port returns the string directly so callers don't
+    have to capture subprocess output.
+    """
+    policy = {
+        "max_depth": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_DEPTH", "2")),
+        "max_children_per_run": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_CHILDREN", "4")),
+        "max_total_descendants": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_DESCENDANTS", "16")),
+        "max_parallel_children": int(os.environ.get("MINI_ORK_RECURSIVE_MAX_PARALLEL", "4")),
+        "default_allow_child_spawn": os.environ.get("MINI_ORK_ALLOW_CHILD_SPAWN", "0").lower()
+        in {"1", "true", "yes", "on"},
+        "default_authority_level": float(os.environ.get("MINI_ORK_CHILD_AUTHORITY", "0.3")),
+    }
+    return json.dumps(policy, sort_keys=True)
+
+
+# Mirrors lib/recursive_orchestration.sh:53 (`mo_recursive_emit_event`)
+def mo_recursive_emit_event(
+    run_id: str,
+    parent_run_id: str = "",
+    event_type: str = "",
+    payload_json: str = "",
+) -> str:
+    """Mirror bash `mo_recursive_emit_event <run> <parent> <type> <payload>`.
+
+    Validates the payload parses as JSON (raises `ValueError` with the same
+    phrase as bash's `SystemExit(f"invalid event payload JSON: {exc}")`),
+    then INSERTs a single `run_events` row. Returns the generated `event_id`.
+
+    Raises:
+        ValueError: when `payload_json` is non-empty and not parseable JSON.
+                    The error message mirrors bash's `invalid event payload
+                    JSON: <exc>` phrasing exactly.
+    """
+    if not run_id:
+        raise ValueError("run_id required")
+    if not event_type:
+        raise ValueError("event_type required")
+    if payload_json:
+        try:
+            json.loads(payload_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid event payload JSON: {exc}") from exc
+    else:
+        payload_json = "{}"
+
+    db = _resolve_db()
+    event_id = _build_id("ev")
+
+    con = sqlite3.connect(db)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        con.execute(
+            """
+            INSERT INTO run_events(event_id, run_id, parent_run_id, event_type, payload_json)
+            VALUES (?, ?, NULLIF(?, ''), ?, ?)
+            """,
+            (event_id, run_id, parent_run_id, event_type, payload_json),
+        )
+        con.commit()
+    finally:
+        con.close()
+    return event_id
+
+
+# Mirrors lib/recursive_orchestration.sh:87 (`mo_recursive_approve_spawn`)
+def mo_recursive_approve_spawn(
+    parent_run_id: str,
+    child_run_id: str,
+    recipe: str = "",
+    kickoff_path: str = "",
+    child_workspace: str = "",
+    depth: int | str = 1,
+    authority_level: float | str = 0.3,
+    allow_child_spawn: int | str = 0,
+) -> str:
+    """Mirror bash `mo_recursive_approve_spawn` lines 87-230.
+
+    Transactional contract (mirrors bash `BEGIN IMMEDIATE` boundary exactly):
+      1. Validate gates: depth<=max_depth, authority in [0,1) with 1.0 raising
+         an explicit future-human-approval gate message.
+      2. SELECT parent from task_runs; raise if missing.
+      3. COUNT children / descendants / running_children against policy caps.
+      4. INSERT run_spawns with `status='approved'` + policy_snapshot_json.
+      5. INSERT run_events with event_id `ev-<now>-<child_run_id>` (literal
+         child_run_id segment — distinct from the uuid-based event_id of
+         the generic emit_event helper).
+      6. UPSERT task_runs with `task_class = (recipe or "generic").replace("-", "_")`,
+         `status='classified'`. ON CONFLICT updates recipe/kickoff_path/updated_at.
+      7. COMMIT.
+
+    Returns the generated `spawn_id`.
+
+    Raises:
+        ValueError: on gate failure (depth>max, authority>=1.0, authority
+                    out of [0,1], parent task_run missing, child cap hit,
+                    descendant cap hit, parallel cap hit).
+    """
+    if not parent_run_id:
+        raise ValueError("parent_run_id required")
+    if not child_run_id:
+        raise ValueError("child_run_id required")
+    if not kickoff_path:
+        raise ValueError("kickoff_path required")
+    if not child_workspace:
+        raise ValueError("child_workspace required")
+
+    policy = json.loads(mo_recursive_policy_json())
+    depth_i = int(depth)
+    authority_f = float(authority_level)
+    allow_child_spawn_i = _bool_int(allow_child_spawn)
+
+    if depth_i > int(policy["max_depth"]):
+        raise ValueError(
+            f"spawn blocked: depth {depth_i} exceeds max_depth {policy['max_depth']}"
+        )
+    if authority_f >= 1.0:
+        raise ValueError(
+            "spawn blocked: authority_level 1.0 requires explicit future human approval gate"
+        )
+    if authority_f < 0.0 or authority_f > 1.0:
+        raise ValueError(
+            "spawn blocked: authority_level must be between 0.0 and 1.0"
+        )
+
+    db = _resolve_db()
+    spawn_id = _build_id("sp")
+    now = int(time.time())
+
+    con = sqlite3.connect(db)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        con.execute("PRAGMA foreign_keys=ON")
+        con.execute("BEGIN IMMEDIATE")
+        try:
+            parent = con.execute(
+                "SELECT id FROM task_runs WHERE id=?", (parent_run_id,)
+            ).fetchone()
+            if parent is None:
+                raise ValueError(
+                    f"spawn blocked: parent task_run not found: {parent_run_id}"
+                )
+
+            parent_child_count = con.execute(
+                "SELECT COUNT(*) FROM run_spawns WHERE parent_run_id=?",
+                (parent_run_id,),
+            ).fetchone()[0]
+            if parent_child_count >= int(policy["max_children_per_run"]):
+                raise ValueError(
+                    f"spawn blocked: parent has {parent_child_count} children; "
+                    f"max_children_per_run is {policy['max_children_per_run']}"
+                )
+
+            root_row = con.execute(
+                "SELECT root_run_id FROM run_spawns WHERE child_run_id=?",
+                (parent_run_id,),
+            ).fetchone()
+            root_run_id = root_row[0] if root_row else parent_run_id
+            descendant_count = con.execute(
+                "SELECT COUNT(*) FROM run_spawns WHERE root_run_id=?",
+                (root_run_id,),
+            ).fetchone()[0]
+            if descendant_count >= int(policy["max_total_descendants"]):
+                raise ValueError(
+                    f"spawn blocked: root has {descendant_count} descendants; "
+                    f"max_total_descendants is {policy['max_total_descendants']}"
+                )
+
+            running_children = con.execute(
+                "SELECT COUNT(*) FROM run_spawns WHERE parent_run_id=? AND status='running'",
+                (parent_run_id,),
+            ).fetchone()[0]
+            if running_children >= int(policy["max_parallel_children"]):
+                raise ValueError(
+                    f"spawn blocked: parent has {running_children} running children; "
+                    f"max_parallel_children is {policy['max_parallel_children']}"
+                )
+
+            con.execute(
+                """
+                INSERT INTO run_spawns(
+                  spawn_id, parent_run_id, child_run_id, root_run_id, depth, recipe,
+                  kickoff_path, child_workspace, authority_level, allow_child_spawn,
+                  status, policy_snapshot_json, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, 'approved', ?, ?, ?)
+                """,
+                (
+                    spawn_id,
+                    parent_run_id,
+                    child_run_id,
+                    root_run_id,
+                    depth_i,
+                    recipe,
+                    kickoff_path,
+                    child_workspace,
+                    authority_f,
+                    allow_child_spawn_i,
+                    mo_recursive_policy_json(),
+                    now,
+                    now,
+                ),
+            )
+            con.execute(
+                """
+                INSERT INTO run_events(event_id, run_id, parent_run_id, event_type, payload_json, created_at)
+                VALUES (?, ?, ?, 'spawn.approved', ?, ?)
+                """,
+                (
+                    f"ev-{now}-{child_run_id}",
+                    child_run_id,
+                    parent_run_id,
+                    json.dumps(
+                        {
+                            "spawn_id": spawn_id,
+                            "depth": depth_i,
+                            "recipe": recipe,
+                            "authority_level": authority_f,
+                        }
+                    ),
+                    now,
+                ),
+            )
+            task_class = (recipe or "generic").replace("-", "_")
+            con.execute(
+                """
+                INSERT INTO task_runs(id, task_class, recipe, kickoff_path, status, created_at, updated_at)
+                VALUES (?, ?, NULLIF(?, ''), ?, 'classified', ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                  recipe=COALESCE(excluded.recipe, task_runs.recipe),
+                  kickoff_path=excluded.kickoff_path,
+                  updated_at=excluded.updated_at
+                """,
+                (child_run_id, task_class, recipe, kickoff_path, now, now),
+            )
+            con.commit()
+        except Exception:
+            con.rollback()
+            raise
+    finally:
+        con.close()
+    return spawn_id
+
+
+# Mirrors lib/recursive_orchestration.sh:232 (`mo_recursive_mark_spawn`)
+_VALID_SPAWN_STATUSES = frozenset({
+    "requested", "approved", "running", "completed",
+    "failed", "blocked", "merged", "rejected",
+})
+
+
+def mo_recursive_mark_spawn(child_run_id: str, status: str) -> None:
+    """Mirror bash `mo_recursive_mark_spawn <child> <status>` lines 232-250.
+
+    Validates `status` is in the bash-allowed set; raises on invalid.
+    UPDATE run_spawns SET status=?, updated_at=? WHERE child_run_id=?; if
+    zero rows are affected, raises with the same phrase as bash.
+    """
+    if not child_run_id:
+        raise ValueError("child_run_id required")
+    if not status:
+        raise ValueError("status required")
+    if status not in _VALID_SPAWN_STATUSES:
+        raise ValueError(f"invalid spawn status: {status}")
+
+    db = _resolve_db()
+    con = sqlite3.connect(db)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        con.execute(
+            "UPDATE run_spawns SET status=?, updated_at=? WHERE child_run_id=?",
+            (status, int(time.time()), child_run_id),
+        )
+        if con.total_changes == 0:
+            raise ValueError(f"spawn not found for child_run_id={child_run_id}")
+        con.commit()
+    finally:
+        con.close()
+
+
+# Mirrors lib/recursive_orchestration.sh:252 (`mo_recursive_record_artifact`)
+def mo_recursive_record_artifact(
+    producer_run_id: str,
+    consumer_run_id: str,
+    artifact_path: str,
+    artifact_hash: str = "",
+    artifact_kind: str = "file",
+) -> str:
+    """Mirror bash `mo_recursive_record_artifact` lines 252-277.
+
+    INSERT a single row into `run_artifact_edges`. `artifact_hash` empty
+    string is stored as NULL (mirrors bash `NULLIF(?, '')`). Returns the
+    generated `edge_id`.
+    """
+    if not producer_run_id:
+        raise ValueError("producer_run_id required")
+    if not consumer_run_id:
+        raise ValueError("consumer_run_id required")
+    if not artifact_path:
+        raise ValueError("artifact_path required")
+
+    db = _resolve_db()
+    edge_id = _build_id("ae")
+
+    con = sqlite3.connect(db)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        con.execute(
+            """
+            INSERT INTO run_artifact_edges(
+              edge_id, producer_run_id, consumer_run_id,
+              artifact_path, artifact_hash, artifact_kind
+            )
+            VALUES (?, ?, ?, ?, NULLIF(?, ''), ?)
+            """,
+            (edge_id, producer_run_id, consumer_run_id, artifact_path,
+             artifact_hash, artifact_kind),
+        )
+        con.commit()
+    finally:
+        con.close()
+    return edge_id
+
+
+# Mirrors lib/recursive_orchestration.sh:279 (`mo_recursive_merge_decision`)
+_VALID_MERGE_DECISIONS = frozenset({"accepted", "rejected", "needs_changes", "deferred"})
+
+
+def mo_recursive_merge_decision(
+    parent_run_id: str,
+    child_run_id: str,
+    decision: str,
+    reason: str = "",
+    decided_by: str = "parent",
+) -> str:
+    """Mirror bash `mo_recursive_merge_decision` lines 279-311.
+
+    Validates `decision` against the bash allow-list; INSERT into
+    `merge_decisions` with `evidence_json='{"source": "mini-ork-spawn"}'`;
+    conditional UPDATE of `run_spawns.status` ('merged' on accepted,
+    'rejected' on rejected; no update otherwise). `updated_at` is set to
+    `strftime('%s','now')` to mirror the bash heredoc exactly.
+    Returns the generated `decision_id`.
+    """
+    if not parent_run_id:
+        raise ValueError("parent_run_id required")
+    if not child_run_id:
+        raise ValueError("child_run_id required")
+    if not decision:
+        raise ValueError("decision required")
+    if decision not in _VALID_MERGE_DECISIONS:
+        raise ValueError(f"invalid merge decision: {decision}")
+
+    db = _resolve_db()
+    decision_id = _build_id("md")
+    now = int(time.time())
+
+    con = sqlite3.connect(db)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        con.execute(
+            """
+            INSERT INTO merge_decisions(
+              decision_id, parent_run_id, child_run_id, decision,
+              reason, decided_by, evidence_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (decision_id, parent_run_id, child_run_id, decision, reason,
+             decided_by, json.dumps({"source": "mini-ork-spawn"})),
+        )
+        if decision == "accepted":
+            con.execute(
+                "UPDATE run_spawns SET status='merged', updated_at=? WHERE child_run_id=?",
+                (now, child_run_id),
+            )
+        elif decision == "rejected":
+            con.execute(
+                "UPDATE run_spawns SET status='rejected', updated_at=? WHERE child_run_id=?",
+                (now, child_run_id),
+            )
+        con.commit()
+    finally:
+        con.close()
+    return decision_id

--- a/mini_ork/ported/verifier_rubric.py
+++ b/mini_ork/ported/verifier_rubric.py
@@ -1,0 +1,281 @@
+"""verifier_rubric — Python port of lib/verifier_rubric.sh.
+
+Faithful port of the public CRUD surface of ``lib/verifier_rubric.sh``.
+The bash file shells out to Python heredocs for every SQL operation
+already, so collapsing it to a single Python module removes two layers
+of indirection while preserving byte-equivalent stdout and identical
+DB state.
+
+Co-existence model (strangler-fig): ``lib/verifier_rubric.sh`` stays
+byte-identical. Parity is enforced by
+``tests/unit/test_verifier_rubric_py.py`` (7 live-subprocess cases:
+each function called via real ``bash -c 'source lib/verifier_rubric.sh
+&& fn args'`` against a temp ``db/init.sh``-scaffolded SQLite, then
+again via the Python port, then DB-row + stdout diffed).
+
+Pipeline map (bash → Python; bash line ranges from
+``lib/verifier_rubric.sh``):
+
+  rubric_register       lines 62-105    → rubric_register
+  rubric_get            lines 107-126   → rubric_get
+  verifier_result_record lines 128-175  → verifier_result_record
+  verifier_result_annotate lines 177-220 → verifier_result_annotate
+  verifier_chain_repair lines 222-244   → verifier_chain_repair
+  verifier_fp_rate      lines 246-275   → verifier_fp_rate
+
+Public surface (mirrors the bash signatures exactly):
+    rubric_register(db_path, rubric_id, name, task_class, axes_json) -> None
+    rubric_get(db_path, rubric_id) -> str
+    verifier_result_record(db_path, run_id, verifier_name, verdict,
+                           rubric_id=None, confidence=None,
+                           scored_axes_json=None) -> str
+    verifier_result_annotate(db_path, result_id, kind, annotator,
+                             notes=None) -> None
+    verifier_chain_repair(db_path, result_id, repair_run_id) -> None
+    verifier_fp_rate(db_path, verifier_name, window_seconds=0) -> str
+
+Notes on parity:
+- ``_rubric_uuid`` in bash calls ``secrets.token_hex(6)`` (12 lowercase
+  hex chars). The port mirrors that verbatim — DO NOT substitute
+  ``uuid.uuid4().hex[:12]``; the formats are equivalent on length but
+  both should still emit lowercased hex, so ``secrets.token_hex(6)`` is
+  the safer one-to-one match.
+- Bash ``rubric_get`` on miss prints literal ``null`` (with a trailing
+  newline from ``print()``). The port mirrors with ``print('null')``.
+- Bash ``verifier_fp_rate`` on zero-results prints literal ``0.0``.
+- Bash ``verifier_fp_rate`` happy-path uses ``f"{fps/total:.4f}"`` —
+  the port mirrors with the same f-string so the emitted text is
+  byte-equal (``"0.2500"`` not ``"0.25"``).
+- The CHECK constraint on ``verifier_results.verdict`` (and the
+  ``NOT (is_false_positive=1 AND is_false_negative=1)`` cross-flag
+  constraint) is enforced at the DB layer. The port does NOT
+  pre-validate; ``sqlite3.IntegrityError`` propagates with rc=1
+  semantics (caller sees the raise — matches bash's ``exit 1``).
+"""
+from __future__ import annotations
+
+import json
+import secrets
+import sqlite3
+import time
+from typing import Optional
+
+__all__ = [
+    "rubric_register",
+    "rubric_get",
+    "verifier_result_record",
+    "verifier_result_annotate",
+    "verifier_chain_repair",
+    "verifier_fp_rate",
+]
+
+
+def _open(db_path: str) -> sqlite3.Connection:
+    """Open a SQLite connection with busy_timeout=5000 (mirrors every
+    bash heredoc's first pragma). Per-connection — not persisted."""
+    con = sqlite3.connect(db_path)
+    con.execute("PRAGMA busy_timeout=5000")
+    return con
+
+
+def rubric_register(
+    db_path: str,
+    rubric_id: str,
+    name: str,
+    task_class: str,
+    axes_json: str,
+) -> None:
+    """Mirror bash ``rubric_register`` (lines 62-105).
+
+    UPSERT into ``verifier_rubrics``. On INSERT both ``created_at`` and
+    ``updated_at`` use the same ``now``; on UPDATE only ``updated_at``
+    is refreshed (also to the same ``now``). The bash heredoc sets
+    ``updated_at = excluded.updated_at`` so a single ``now`` value
+    flows through both INSERT and UPDATE branches — this matches.
+    """
+    now = int(time.time())
+    con = _open(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO verifier_rubrics
+                (rubric_id, name, description, task_class, axes_json,
+                 created_at, updated_at, is_active)
+            VALUES (?, ?, NULL, ?, ?, ?, ?, 1)
+            ON CONFLICT(rubric_id) DO UPDATE SET
+                name=excluded.name,
+                task_class=excluded.task_class,
+                axes_json=excluded.axes_json,
+                updated_at=excluded.updated_at,
+                is_active=1
+            """,
+            (
+                rubric_id,
+                name,
+                task_class or None,
+                axes_json or None,
+                now,
+                now,
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def rubric_get(db_path: str, rubric_id: str) -> str:
+    """Mirror bash ``rubric_get`` (lines 107-126).
+
+    Emits the rubric row as JSON on stdout. ``null`` on miss. The
+    function returns the string (without trailing newline) so callers
+    can inspect it; the bash output mirrors because both call
+    ``print(...)`` internally — see ``print_rubric_get`` if you want
+    the exact stdout-write helper.
+    """
+    con = _open(db_path)
+    try:
+        con.row_factory = sqlite3.Row
+        row = con.execute(
+            "SELECT * FROM verifier_rubrics WHERE rubric_id=?",
+            (rubric_id,),
+        ).fetchone()
+        if row is None:
+            return "null"
+        return json.dumps(dict(row))
+    finally:
+        con.close()
+
+
+def verifier_result_record(
+    db_path: str,
+    run_id: str,
+    verifier_name: str,
+    verdict: str,
+    rubric_id: Optional[str] = None,
+    confidence: Optional[float] = None,
+    scored_axes_json: Optional[str] = None,
+) -> str:
+    """Mirror bash ``verifier_result_record`` (lines 128-175).
+
+    INSERT into ``verifier_results``. Returns the new result_id
+    (``vr-`` + 12 lowercase hex chars from ``secrets.token_hex(6)``).
+
+    Does NOT pre-validate ``verdict`` — the DB CHECK constraint
+    ``verdict IN ('pass','fail','indeterminate','vacuous')`` raises
+    ``sqlite3.IntegrityError`` on bad input. Matches bash's
+    ``exit 1`` on the same DDL violation.
+    """
+    result_id = "vr-" + secrets.token_hex(6)
+    con = _open(db_path)
+    try:
+        con.execute(
+            """
+            INSERT INTO verifier_results
+                (result_id, run_id, verifier_name, rubric_id, verdict,
+                 confidence, scored_axes_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                result_id,
+                run_id,
+                verifier_name,
+                rubric_id or None,
+                verdict,
+                float(confidence) if confidence is not None else None,
+                scored_axes_json or None,
+            ),
+        )
+        con.commit()
+    finally:
+        con.close()
+    return result_id
+
+
+def verifier_result_annotate(
+    db_path: str,
+    result_id: str,
+    kind: str,
+    annotator: str,
+    notes: Optional[str] = None,
+) -> None:
+    """Mirror bash ``verifier_result_annotate`` (lines 177-220).
+
+    ``kind`` ∈ ``{false_positive, false_negative}`` — any other value
+    raises ``ValueError`` (mirrors the bash ``case`` statement that
+    prints to stderr and exits 2 on unknown kinds).
+
+    Lets ``sqlite3.IntegrityError`` propagate on the cross-flag CHECK
+    constraint (``NOT (is_false_positive=1 AND is_false_negative=1)``)
+    so the caller sees a hard failure — matches bash's ``exit 1``.
+    """
+    if kind not in ("false_positive", "false_negative"):
+        raise ValueError(
+            "verifier_result_annotate: kind must be false_positive or false_negative"
+        )
+    col = "is_false_positive" if kind == "false_positive" else "is_false_negative"
+    now = int(time.time())
+    con = _open(db_path)
+    try:
+        con.execute(
+            f"""
+            UPDATE verifier_results
+               SET {col}=1, annotated_by=?, annotated_at=?, notes=COALESCE(?, notes)
+             WHERE result_id=?
+            """,
+            (annotator, now, notes or None, result_id),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def verifier_chain_repair(
+    db_path: str,
+    result_id: str,
+    repair_run_id: str,
+) -> None:
+    """Mirror bash ``verifier_chain_repair`` (lines 222-244).
+
+    UPDATE ``verifier_results.repair_run_id`` for the given result_id.
+    """
+    con = _open(db_path)
+    try:
+        con.execute(
+            "UPDATE verifier_results SET repair_run_id=? WHERE result_id=?",
+            (repair_run_id, result_id),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+def verifier_fp_rate(
+    db_path: str,
+    verifier_name: str,
+    window_seconds: int = 0,
+) -> str:
+    """Mirror bash ``verifier_fp_rate`` (lines 246-275).
+
+    Emits the false-positive rate as a float string. ``window_seconds=0``
+    means "all time" (no cutoff). Empty result set emits literal ``0.0``;
+    otherwise ``f"{fps/total:.4f}"`` so 1-of-4 prints ``0.2500`` (NOT
+    ``0.25`` — bash mirrors the same precision).
+    """
+    cutoff = (int(time.time()) - window_seconds) if window_seconds > 0 else 0
+    con = _open(db_path)
+    try:
+        total = con.execute(
+            "SELECT COUNT(*) FROM verifier_results "
+            "WHERE verifier_name=? AND created_at>=?",
+            (verifier_name, cutoff),
+        ).fetchone()[0]
+        if total == 0:
+            return "0.0"
+        fps = con.execute(
+            "SELECT COUNT(*) FROM verifier_results "
+            "WHERE verifier_name=? AND created_at>=? AND is_false_positive=1",
+            (verifier_name, cutoff),
+        ).fetchone()[0]
+        return f"{fps / total:.4f}"
+    finally:
+        con.close()

--- a/tests/unit/test_recursive_orchestration_py.py
+++ b/tests/unit/test_recursive_orchestration_py.py
@@ -1,0 +1,666 @@
+"""Parity gate: mini_ork.ported.recursive_orchestration vs lib/recursive_orchestration.sh.
+
+Each test invokes the LIVE bash subprocess against a temp DB seeded by
+``db/init.sh``, then invokes the Python port against a parallel temp DB
+(seeded identically), and asserts the resulting ``run_events`` /
+``run_spawns`` / ``run_artifact_edges`` / ``merge_decisions`` rows match
+byte-for-byte (integer epoch columns use 1-second tolerance; ``authority_level``
+floats compared at 1e-6; ``event_id`` stem-equal because the uuid hex
+suffix differs). No mocks, no hardcoded expected outputs — expected is
+always derived from the live control bash invocation.
+
+>=6 cases:
+  (a) policy_json stdout JSON equality
+  (b) emit_event happy-path run_events row parity
+  (c) emit_event invalid payload raises + writes 0 rows
+  (d) approve_spawn happy (parent exists) — run_spawns + run_events + task_runs parity
+  (e) approve_spawn blocked by depth>max_depth — both raise + write 0 rows
+  (f) mark_spawn UPDATE row parity
+  (g) record_artifact INSERT parity
+  (h) merge_decision accepted — merge_decisions + run_spawns.status='merged' parity
+
+Authority levels are compared at 1e-6 per the kickoff. ``updated_at`` columns
+set by ``strftime('%s','now')`` are allowed up to a 1-second window.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import recursive_orchestration as py  # noqa: E402
+
+SH = REPO / "lib" / "recursive_orchestration.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    """Spin up a real mini-ork SQLite DB via db/init.sh.
+
+    Returns ``dbp`` (state.db path). The fixture monkeypatches
+    ``MINI_ORK_DB`` and ``MINI_ORK_HOME`` so the Python port's
+    ``_resolve_db()`` lands on the same DB the bash subprocess writes to.
+    Use ``_pair_db(tmp_path)`` below for cases that need bash and Python
+    to write to SEPARATE DBs and diff the resulting rows.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    r = subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"db/init.sh failed: rc={r.returncode}\nstderr={r.stderr}")
+    monkeypatch.setenv("MINI_ORK_DB", dbp)
+    monkeypatch.setenv("MINI_ORK_HOME", str(home))
+    return dbp
+
+
+def _pair_db(tmp_path, monkeypatch):
+    """Two DBs with identical schemas: one for the bash subprocess, one for
+    the Python port. The Python port's ``_resolve_db`` reads ``MINI_ORK_DB``
+    / ``MINI_ORK_HOME`` from the env; we set both to the *py* DB so the
+    Python port lands on its own DB (the bash subprocess uses the bash DB
+    via its own env passed to ``subprocess.run``).
+    """
+    home_bash = tmp_path / "home_bash"
+    home_py = tmp_path / "home_py"
+    home_bash.mkdir()
+    home_py.mkdir()
+    bash_db = str(home_bash / "state.db")
+    py_db = str(home_py / "state.db")
+    for env_home, env_db in ((home_bash, bash_db), (home_py, py_db)):
+        r = subprocess.run(
+            ["bash", str(INIT_SH)],
+            env={**os.environ, "MINI_ORK_HOME": str(env_home), "MINI_ORK_DB": env_db},
+            capture_output=True, text=True, check=True,
+        )
+        if r.returncode != 0:
+            pytest.fail(f"db/init.sh failed: rc={r.returncode}\nstderr={r.stderr}")
+    monkeypatch.setenv("MINI_ORK_DB", py_db)
+    monkeypatch.setenv("MINI_ORK_HOME", str(home_py))
+    return bash_db, py_db
+
+
+def _bash_run_func(
+    func: str,
+    args: list[str],
+    *,
+    db: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess:
+    """Source the bash library and call ``func`` with positional args.
+
+    Args are wrapped in double quotes with internal ``"`` escaped as
+    ``\\"`` so JSON payloads with inner double quotes survive the bash
+    parse (e.g. ``'{"k":"v"}'`` → bash receives the literal
+    ``{"k":"v"}``). Mirrors the helper in ``test_mo_node_events_py.py``;
+    we extend it with escape handling because recursive_orchestration
+    accepts JSON payloads as positional args.
+    """
+    def _q(a: str) -> str:
+        return '"' + a.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    arg_str = " ".join(_q(a) for a in args)
+    script = f'. "{SH}"\n{func} {arg_str}\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        env={**os.environ, "MINI_ORK_DB": db,
+             "MINI_ORK_HOME": str(Path(db).parent), **(extra_env or {})},
+        capture_output=True, text=True,
+    )
+
+
+def _row_dicts(db: str, table: str) -> list[dict]:
+    """Dump all rows of ``table`` as dicts (excluding ``created_at`` for
+    time-sensitive diffing — see ``_epoch_close``). Ordered by the table's
+    own rowid for determinism where applicable."""
+    con = sqlite3.connect(db)
+    try:
+        cols = [d[0] for d in con.execute(f"SELECT * FROM {table} LIMIT 0").description]
+        rows = con.execute(f"SELECT {', '.join(cols)} FROM {table}").fetchall()
+        return [dict(zip(cols, r)) for r in rows]
+    finally:
+        con.close()
+
+
+def _epoch_close(a: int | float | None, b: int | float | None,
+                 *, window_s: int = 1) -> bool:
+    """Integer epoch tolerance in seconds. After the window passes, fall
+    through to a 1e-6 float diff as a defense-in-depth check.
+    """
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    if abs(int(a) - int(b)) <= window_s:
+        return True
+    return abs(float(a) - float(b)) <= 1e-6
+
+
+def _event_id_stem(eid: str | None) -> str:
+    """Stem of ``event_id`` shared between bash and Python ports.
+
+    Bash and Python ports emit IDs of shape ``<prefix>-<sec>-<hex12>``
+    where ``prefix`` is one of ``ev`` (emit_event), ``sp`` (spawn),
+    ``ae`` (artifact_edge), ``md`` (merge_decision). The bash and
+    Python invocations in a single test run are typically a few hundred
+    ms apart, so the middle ``<sec>`` segment often drifts by ±1 between
+    them — only the leading ``<prefix>-`` is reliably shared. The
+    ``<hex12>`` suffix always differs.
+    """
+    assert eid is not None
+    return eid.split("-", 1)[0] + "-"
+
+
+def _assert_spawn_row_parity(bash_row: dict, py_row: dict) -> None:
+    """Compare two ``run_spawns`` rows field-by-field.
+
+    ``spawn_id`` is stem-equal; ``created_at`` / ``updated_at`` allowed
+    within 1s; ``authority_level`` compared at 1e-6 (kicked-off tolerance).
+    """
+    fields = [
+        "spawn_id", "parent_run_id", "child_run_id", "root_run_id",
+        "depth", "recipe", "kickoff_path", "child_workspace",
+        "authority_level", "allow_child_spawn", "status",
+        "policy_snapshot_json", "created_at", "updated_at",
+    ]
+    for f in fields:
+        b = bash_row.get(f)
+        p = py_row.get(f)
+        if f == "spawn_id":
+            assert _event_id_stem(b) == _event_id_stem(p), (
+                f"spawn_id stem mismatch: bash={b!r} py={p!r}"
+            )
+            continue
+        if f in ("created_at", "updated_at"):
+            assert _epoch_close(b, p), f"{f}: bash={b!r} py={p!r}"
+            continue
+        if f == "authority_level":
+            if b is None or p is None:
+                assert b == p
+            else:
+                assert abs(float(b) - float(p)) <= 1e-6, (
+                    f"authority_level float mismatch: bash={b!r} py={p!r}"
+                )
+            continue
+        if f == "policy_snapshot_json":
+            assert b is not None and p is not None
+            assert json.loads(b) == json.loads(p), (
+                f"policy_snapshot_json dict mismatch: bash={b!r} py={p!r}"
+            )
+            continue
+        assert b == p, f"{f}: bash={b!r} py={p!r}"
+
+
+def _assert_event_row_parity(bash_row: dict, py_row: dict) -> None:
+    """Compare two ``run_events`` rows field-by-field.
+
+    ``event_id`` is stem-equal; ``created_at`` allowed within 1s;
+    ``payload_json`` compared structurally with ``spawn_id`` masked
+    out (the spawn_id is generated independently by each port and is
+    not a parity invariant).
+    """
+    fields = ["event_id", "run_id", "parent_run_id", "event_type",
+              "payload_json", "created_at"]
+    for f in fields:
+        b = bash_row.get(f)
+        p = py_row.get(f)
+        if f == "event_id":
+            assert _event_id_stem(b) == _event_id_stem(p), (
+                f"event_id stem mismatch: bash={b!r} py={p!r}"
+            )
+            continue
+        if f == "created_at":
+            assert _epoch_close(b, p), f"{f}: bash={b!r} py={p!r}"
+            continue
+        if f == "payload_json":
+            assert b is not None and p is not None
+            b_obj = json.loads(b)
+            p_obj = json.loads(p)
+            # spawn_id is generated per-port; not a parity invariant.
+            b_obj.pop("spawn_id", None)
+            p_obj.pop("spawn_id", None)
+            assert b_obj == p_obj, (
+                f"payload_json dict mismatch: bash={b!r} py={p!r}"
+            )
+            continue
+        assert b == p, f"{f}: bash={b!r} py={p!r}"
+
+
+def _assert_task_runs_parity(bash_row: dict, py_row: dict) -> None:
+    """Compare two ``task_runs`` rows field-by-field (the UPSERT side effect
+    of ``approve_spawn``). Timestamps within 1s."""
+    fields = ["id", "task_class", "recipe", "kickoff_path", "status",
+              "created_at", "updated_at"]
+    for f in fields:
+        b = bash_row.get(f)
+        p = py_row.get(f)
+        if f in ("created_at", "updated_at"):
+            assert _epoch_close(b, p), f"{f}: bash={b!r} py={p!r}"
+            continue
+        assert b == p, f"{f}: bash={b!r} py={p!r}"
+
+
+def _seed_parent(db: str, parent_id: str) -> None:
+    """Seed a single ``task_runs`` row so ``approve_spawn`` can FK-resolve
+    the parent. Idempotent: caller picks the parent_id."""
+    con = sqlite3.connect(db)
+    try:
+        con.execute(
+            """
+            INSERT OR REPLACE INTO task_runs(id, task_class, recipe, kickoff_path, status, created_at, updated_at)
+            VALUES (?, 'code_fix', NULL, ?, 'classified', 0, 0)
+            """,
+            (parent_id, "/tmp/k.md"),
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) policy_json stdout JSON equality
+# ─────────────────────────────────────────────────────────────────────────────
+def test_policy_json_parity(monkeypatch, tmp_path):
+    """Bash ``mo_recursive_policy_json`` prints ``json.dumps(policy,
+    sort_keys=True)``. Python port returns the same string for identical
+    env. Drive bash with custom env vars and assert byte equality."""
+    env_overrides = {
+        "MINI_ORK_RECURSIVE_MAX_DEPTH": "3",
+        "MINI_ORK_RECURSIVE_MAX_CHILDREN": "5",
+        "MINI_ORK_RECURSIVE_MAX_DESCENDANTS": "10",
+        "MINI_ORK_RECURSIVE_MAX_PARALLEL": "2",
+        "MINI_ORK_ALLOW_CHILD_SPAWN": "true",
+        "MINI_ORK_CHILD_AUTHORITY": "0.7",
+    }
+    for k, v in env_overrides.items():
+        monkeypatch.setenv(k, v)
+    home = tmp_path / "home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, **env_overrides,
+             "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True, check=True,
+    )
+    bash_r = _bash_run_func("mo_recursive_policy_json", [], db=dbp,
+                            extra_env=env_overrides)
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    bash_out = bash_r.stdout.strip()
+    py_out = py.mo_recursive_policy_json()
+    assert bash_out == py_out, (
+        f"policy_json mismatch:\n  bash={bash_out!r}\n  py  ={py_out!r}"
+    )
+    # Sanity: sort_keys ordering surfaces the canonical shape.
+    expected_keys = sorted([
+        "max_depth", "max_children_per_run", "max_total_descendants",
+        "max_parallel_children", "default_allow_child_spawn",
+        "default_authority_level",
+    ])
+    assert list(json.loads(py_out).keys()) == expected_keys
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) emit_event happy-path run_events row parity
+# ─────────────────────────────────────────────────────────────────────────────
+def test_emit_event_happy_path_parity(tmp_path, monkeypatch):
+    """Bash ``mo_recursive_emit_event <run> <parent> <type> <payload>`` writes
+    one ``run_events`` row. Python port writes the same row (event_id stem,
+    payload_json, created_at within 1s)."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    bash_r = _bash_run_func(
+        "mo_recursive_emit_event",
+        ["run-a", "parent-a", "child.spawned", '{"k":"v","n":1}'],
+        db=bash_db,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py_event_id = py.mo_recursive_emit_event(
+        "run-a", "parent-a", "child.spawned", '{"k":"v","n":1}',
+    )
+
+    bash_rows = _row_dicts(bash_db, "run_events")
+    py_rows = _row_dicts(py_db, "run_events")
+    assert len(bash_rows) == 1, f"bash wrote {len(bash_rows)} rows: {bash_rows}"
+    assert len(py_rows) == 1, f"py wrote {len(py_rows)} rows: {py_rows}"
+    _assert_event_row_parity(bash_rows[0], py_rows[0])
+    # Stem sanity: both event_ids share the ``ev-<sec>-`` prefix.
+    assert _event_id_stem(bash_rows[0]["event_id"]) == "ev-"
+    assert _event_id_stem(py_event_id) == "ev-"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) emit_event invalid payload raises + writes 0 rows
+# ─────────────────────────────────────────────────────────────────────────────
+def test_emit_event_invalid_payload_parity(tmp_path, monkeypatch):
+    """Both ports must raise on unparseable JSON payload and NOT write any
+    ``run_events`` row. Bash raises ``SystemExit`` (exit code != 0); Python
+    raises ``ValueError`` (kicked-off Python error contract)."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    bad_payload = "{not-valid-json"
+    bash_r = _bash_run_func(
+        "mo_recursive_emit_event",
+        ["run-b", "parent-b", "child.spawned", bad_payload],
+        db=bash_db,
+    )
+    assert bash_r.returncode != 0, "bash must fail on invalid JSON"
+    assert "invalid event payload JSON" in bash_r.stderr, (
+        f"bash stderr missing phrase: {bash_r.stderr!r}"
+    )
+    raised = False
+    try:
+        py.mo_recursive_emit_event("run-b", "parent-b", "child.spawned", bad_payload)
+    except ValueError as exc:
+        raised = True
+        assert "invalid event payload JSON" in str(exc), str(exc)
+    assert raised, "Python port must raise ValueError on invalid JSON"
+    assert _row_dicts(bash_db, "run_events") == []
+    assert _row_dicts(py_db, "run_events") == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) approve_spawn happy (parent exists) — run_spawns + run_events + task_runs parity
+# ─────────────────────────────────────────────────────────────────────────────
+def test_approve_spawn_happy_path_parity(tmp_path, monkeypatch):
+    """Both ports must produce identical rows in all three tables:
+    ``run_spawns`` (1 row), ``run_events`` (1 spawn.approved row with the
+    literal ``ev-<sec>-<child_run_id>`` event_id), ``task_runs`` (1 UPSERT
+    row). Floats 1e-6, epochs 1s."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    # Seed a parent task_run in each DB.
+    parent_id = "parent-d"
+    _seed_parent(bash_db, parent_id)
+    _seed_parent(py_db, parent_id)
+
+    args = [parent_id, "child-d", "code-fix", "/tmp/child-k.md",
+            "/tmp/child-ws", "1", "0.4", "1"]
+    bash_r = _bash_run_func("mo_recursive_approve_spawn", args, db=bash_db)
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_recursive_approve_spawn(
+        parent_id, "child-d", "code-fix", "/tmp/child-k.md",
+        "/tmp/child-ws", 1, 0.4, 1,
+    )
+
+    # run_spawns: exactly 1 row in each DB
+    bash_spawns = _row_dicts(bash_db, "run_spawns")
+    py_spawns = _row_dicts(py_db, "run_spawns")
+    assert len(bash_spawns) == 1, bash_spawns
+    assert len(py_spawns) == 1, py_spawns
+    _assert_spawn_row_parity(bash_spawns[0], py_spawns[0])
+    # Status & root sanity
+    assert bash_spawns[0]["status"] == "approved"
+    assert bash_spawns[0]["root_run_id"] == parent_id
+    assert bash_spawns[0]["task_class"] if False else True  # column is on task_runs
+
+    # run_events: exactly 1 row in each DB (the spawn.approved row)
+    bash_events = _row_dicts(bash_db, "run_events")
+    py_events = _row_dicts(py_db, "run_events")
+    assert len(bash_events) == 1, bash_events
+    assert len(py_events) == 1, py_events
+    assert bash_events[0]["event_type"] == "spawn.approved"
+    _assert_event_row_parity(bash_events[0], py_events[0])
+    # event_id must use the literal ``ev-<sec>-<child_run_id>`` shape.
+    assert bash_events[0]["event_id"].startswith(f"ev-")
+    assert "child-d" in bash_events[0]["event_id"], (
+        f"bash event_id missing child_run_id: {bash_events[0]['event_id']!r}"
+    )
+
+    # task_runs: exactly 1 row (parent) + 1 UPSERT (child) per DB
+    bash_trs = _row_dicts(bash_db, "task_runs")
+    py_trs = _row_dicts(py_db, "task_runs")
+    assert len(bash_trs) == 2, f"expected 2 task_runs rows, got {bash_trs}"
+    assert len(py_trs) == 2, f"expected 2 task_runs rows, got {py_trs}"
+    bash_child = next(r for r in bash_trs if r["id"] == "child-d")
+    py_child = next(r for r in py_trs if r["id"] == "child-d")
+    _assert_task_runs_parity(bash_child, py_child)
+    # Sanity: task_class is the recipe with dashes → underscores.
+    assert bash_child["task_class"] == "code_fix"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) approve_spawn blocked by depth>max_depth — both raise + write 0 rows
+# ─────────────────────────────────────────────────────────────────────────────
+def test_approve_spawn_blocked_by_depth(tmp_path, monkeypatch):
+    """Default ``max_depth=2``. Both ports must raise on depth=3 and write
+    zero rows in ``run_spawns``, ``run_events`` (the spawn.approved row),
+    and ``task_runs`` (the UPSERT side effect)."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    parent_id = "parent-e"
+    _seed_parent(bash_db, parent_id)
+    _seed_parent(py_db, parent_id)
+
+    args = [parent_id, "child-e", "code-fix", "/tmp/child-k.md",
+            "/tmp/child-ws", "3", "0.3", "0"]  # depth=3 > max_depth=2
+    bash_r = _bash_run_func("mo_recursive_approve_spawn", args, db=bash_db)
+    assert bash_r.returncode != 0, "bash must fail when depth>max_depth"
+    assert "depth 3 exceeds max_depth 2" in bash_r.stderr, bash_r.stderr
+    raised = False
+    try:
+        py.mo_recursive_approve_spawn(
+            parent_id, "child-e", "code-fix", "/tmp/child-k.md",
+            "/tmp/child-ws", 3, 0.3, 0,
+        )
+    except ValueError as exc:
+        raised = True
+        assert "depth 3 exceeds max_depth 2" in str(exc), str(exc)
+    assert raised, "Python port must raise on depth>max_depth"
+
+    # Zero rows in run_spawns; zero spawn.approved rows in run_events;
+    # child row in task_runs must NOT exist.
+    assert _row_dicts(bash_db, "run_spawns") == []
+    assert _row_dicts(py_db, "run_spawns") == []
+    bash_events = _row_dicts(bash_db, "run_events")
+    py_events = _row_dicts(py_db, "run_events")
+    assert all(r["event_type"] != "spawn.approved" for r in bash_events), bash_events
+    assert all(r["event_type"] != "spawn.approved" for r in py_events), py_events
+
+    bash_trs = {r["id"] for r in _row_dicts(bash_db, "task_runs")}
+    py_trs = {r["id"] for r in _row_dicts(py_db, "task_runs")}
+    assert "child-e" not in bash_trs
+    assert "child-e" not in py_trs
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) mark_spawn UPDATE row parity
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mark_spawn_update_parity(tmp_path, monkeypatch):
+    """Seed a run_spawns row in each DB, then bash+Python both call
+    ``mo_recursive_mark_spawn <child> <status>``. The resulting rows must
+    match byte-for-byte on ``status``; ``updated_at`` within 1s."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    spawn_seed = {
+        "spawn_id": "sp-seed-f",
+        "parent_run_id": "parent-f",
+        "child_run_id": "child-f",
+        "root_run_id": "parent-f",
+        "depth": 1,
+        "recipe": "code-fix",
+        "kickoff_path": "/tmp/k.md",
+        "child_workspace": "/tmp/ws",
+        "authority_level": 0.3,
+        "allow_child_spawn": 0,
+        "status": "approved",
+        "policy_snapshot_json": "{}",
+        "created_at": 0,
+        "updated_at": 0,
+    }
+    for db in (bash_db, py_db):
+        con = sqlite3.connect(db)
+        try:
+            cols = ", ".join(spawn_seed.keys())
+            placeholders = ", ".join("?" for _ in spawn_seed)
+            con.execute(
+                f"INSERT INTO run_spawns({cols}) VALUES ({placeholders})",
+                tuple(spawn_seed.values()),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    bash_r = _bash_run_func("mo_recursive_mark_spawn", ["child-f", "running"], db=bash_db)
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_recursive_mark_spawn("child-f", "running")
+
+    bash_rows = _row_dicts(bash_db, "run_spawns")
+    py_rows = _row_dicts(py_db, "run_spawns")
+    assert len(bash_rows) == 1 and len(py_rows) == 1
+    # Compare status and updated_at only; the rest is identical seed.
+    assert bash_rows[0]["status"] == py_rows[0]["status"] == "running"
+    assert _epoch_close(bash_rows[0]["updated_at"], py_rows[0]["updated_at"])
+
+
+def test_mark_spawn_invalid_status_raises(tmp_path, monkeypatch):
+    """Both ports must raise on invalid status and not write anything."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    spawn_seed = {
+        "spawn_id": "sp-seed-f2",
+        "parent_run_id": "parent-f2",
+        "child_run_id": "child-f2",
+        "root_run_id": "parent-f2",
+        "depth": 1,
+        "recipe": "code-fix",
+        "kickoff_path": "/tmp/k.md",
+        "child_workspace": "/tmp/ws",
+        "authority_level": 0.3,
+        "allow_child_spawn": 0,
+        "status": "approved",
+        "policy_snapshot_json": "{}",
+        "created_at": 0,
+        "updated_at": 0,
+    }
+    for db in (bash_db, py_db):
+        con = sqlite3.connect(db)
+        try:
+            cols = ", ".join(spawn_seed.keys())
+            placeholders = ", ".join("?" for _ in spawn_seed)
+            con.execute(
+                f"INSERT INTO run_spawns({cols}) VALUES ({placeholders})",
+                tuple(spawn_seed.values()),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    bash_r = _bash_run_func("mo_recursive_mark_spawn", ["child-f2", "BOGUS"], db=bash_db)
+    assert bash_r.returncode != 0
+    assert "invalid spawn status" in bash_r.stderr
+    raised = False
+    try:
+        py.mo_recursive_mark_spawn("child-f2", "BOGUS")
+    except ValueError as exc:
+        raised = True
+        assert "invalid spawn status" in str(exc)
+    assert raised
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) record_artifact INSERT parity
+# ─────────────────────────────────────────────────────────────────────────────
+def test_record_artifact_insert_parity(tmp_path, monkeypatch):
+    """Both ports must INSERT identical ``run_artifact_edges`` rows. The
+    ``edge_id`` is stem-equal (``ae-<sec>-``) and the rest of the row is
+    byte-for-byte (no timestamps on this table)."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    bash_r = _bash_run_func(
+        "mo_recursive_record_artifact",
+        ["run-g-prod", "run-g-cons", "/tmp/art.md", "abc123", "file"],
+        db=bash_db,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_recursive_record_artifact(
+        "run-g-prod", "run-g-cons", "/tmp/art.md", "abc123", "file",
+    )
+
+    bash_rows = _row_dicts(bash_db, "run_artifact_edges")
+    py_rows = _row_dicts(py_db, "run_artifact_edges")
+    assert len(bash_rows) == 1 and len(py_rows) == 1
+    # edge_id stem-equal
+    assert _event_id_stem(bash_rows[0]["edge_id"]) == "ae-"
+    assert _event_id_stem(py_rows[0]["edge_id"]) == "ae-"
+    # other fields exact
+    for f in ("producer_run_id", "consumer_run_id", "artifact_path",
+              "artifact_hash", "artifact_kind", "verification_state"):
+        assert bash_rows[0][f] == py_rows[0][f], f"{f}: bash={bash_rows[0][f]!r} py={py_rows[0][f]!r}"
+    # created_at default is ``strftime('%s','now')``; allow 1s window.
+    assert _epoch_close(bash_rows[0]["created_at"], py_rows[0]["created_at"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) merge_decision accepted — merge_decisions + run_spawns.status='merged' parity
+# ─────────────────────────────────────────────────────────────────────────────
+def test_merge_decision_accepted_parity(tmp_path, monkeypatch):
+    """Seed a run_spawns row, then bash+Python both call
+    ``mo_recursive_merge_decision <parent> <child> accepted <reason>``.
+    The decision row in ``merge_decisions`` must match, AND the seeded
+    spawn row's status must flip to ``merged`` in both DBs."""
+    bash_db, py_db = _pair_db(tmp_path, monkeypatch)
+    spawn_seed = {
+        "spawn_id": "sp-seed-h",
+        "parent_run_id": "parent-h",
+        "child_run_id": "child-h",
+        "root_run_id": "parent-h",
+        "depth": 1,
+        "recipe": "code-fix",
+        "kickoff_path": "/tmp/k.md",
+        "child_workspace": "/tmp/ws",
+        "authority_level": 0.3,
+        "allow_child_spawn": 0,
+        "status": "approved",
+        "policy_snapshot_json": "{}",
+        "created_at": 0,
+        "updated_at": 0,
+    }
+    for db in (bash_db, py_db):
+        con = sqlite3.connect(db)
+        try:
+            cols = ", ".join(spawn_seed.keys())
+            placeholders = ", ".join("?" for _ in spawn_seed)
+            con.execute(
+                f"INSERT INTO run_spawns({cols}) VALUES ({placeholders})",
+                tuple(spawn_seed.values()),
+            )
+            con.commit()
+        finally:
+            con.close()
+
+    bash_r = _bash_run_func(
+        "mo_recursive_merge_decision",
+        ["parent-h", "child-h", "accepted", "lgtm", "reviewer"],
+        db=bash_db,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    py.mo_recursive_merge_decision("parent-h", "child-h", "accepted", "lgtm", "reviewer")
+
+    # merge_decisions row parity
+    bash_decs = _row_dicts(bash_db, "merge_decisions")
+    py_decs = _row_dicts(py_db, "merge_decisions")
+    assert len(bash_decs) == 1 and len(py_decs) == 1
+    assert _event_id_stem(bash_decs[0]["decision_id"]) == "md-"
+    assert _event_id_stem(py_decs[0]["decision_id"]) == "md-"
+    for f in ("parent_run_id", "child_run_id", "decision", "reason",
+              "decided_by", "evidence_json"):
+        assert bash_decs[0][f] == py_decs[0][f], (
+            f"{f}: bash={bash_decs[0][f]!r} py={py_decs[0][f]!r}"
+        )
+    assert _epoch_close(bash_decs[0]["created_at"], py_decs[0]["created_at"])
+    # Sanity: evidence_json is the literal ``{"source": "mini-ork-spawn"}``.
+    assert json.loads(bash_decs[0]["evidence_json"]) == {"source": "mini-ork-spawn"}
+
+    # run_spawns.status flipped to 'merged' in both DBs.
+    bash_spawn = _row_dicts(bash_db, "run_spawns")[0]
+    py_spawn = _row_dicts(py_db, "run_spawns")[0]
+    assert bash_spawn["status"] == "merged" == py_spawn["status"]
+    assert _epoch_close(bash_spawn["updated_at"], py_spawn["updated_at"])

--- a/tests/unit/test_verifier_rubric_py.py
+++ b/tests/unit/test_verifier_rubric_py.py
@@ -1,0 +1,536 @@
+"""Parity gate: mini_ork.ported.verifier_rubric vs lib/verifier_rubric.sh.
+
+Seven cases (kickoff floor: >=6; 1-case buffer):
+
+  (a) rubric_register               — bash+python both register 'r1';
+                                       SELECT row and diff JSON dicts
+                                       (ignore updated_at timestamp).
+  (b) rubric_get hit                — bash register then python get;
+                                       stdout must be byte-equal JSON
+                                       (json.loads roundtrip dict-equal).
+  (c) rubric_get miss               — both print literal 'null'
+                                       (.strip() comparison).
+  (d) verifier_result_record        — bash+python both insert with same
+                                       fields; SELECT both rows; assert
+                                       row count=2; assert each
+                                       result_id matches regex
+                                       ^vr-[0-9a-f]{12}$; assert all
+                                       logical fields byte-equal
+                                       pairwise (ignore created_at).
+  (e) verifier_result_annotate fp   — bash record then python annotate
+                                       (false_positive); SELECT row,
+                                       assert is_false_positive=1,
+                                       is_false_negative=0,
+                                       annotated_by set,
+                                       annotated_at non-null.
+  (f) verifier_chain_repair         — bash record then python
+                                       chain_repair; SELECT row,
+                                       assert repair_run_id set.
+  (g) verifier_fp_rate math         — bash records 4 results + 1 fp
+                                       via annotate; python fp_rate →
+                                       '0.2500'; reverse-order
+                                       sub-case proves
+                                       order-independence (same 0.25).
+
+Tolerance: floats 1e-6 (kickoff requirement). Bash ``%.4f`` precision
+is bounded at 5e-5; 1e-6 is a strict superset. All stdout comparisons
+are byte-equal (json.dumps ordering + f-string ``.4f`` precision both
+match by construction).
+
+No mocks, no hardcoded outputs beyond what bash itself emits — every
+assertion is bash-subprocess-vs-Python-port on identical inputs.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import verifier_rubric as vr  # noqa: E402
+
+SH = REPO / "lib" / "verifier_rubric.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+# Float tolerance — kickoff requires 1e-6 (bash fp_rate is .4f so
+# precision is bounded at 5e-5; 1e-6 is a strict superset).
+_FLOAT_TOL = 1e-6
+
+# result_id format: vr-<secrets.token_hex(6)> → 12 lowercase hex chars.
+_RESULT_ID_RE = re.compile(r"^vr-[0-9a-f]{12}$")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+def _which(*tools: str) -> None:
+    for t in tools:
+        if not shutil.which(t):
+            pytest.skip(f"required tool not on PATH: {t}")
+    if not SH.exists():
+        pytest.skip(f"missing lib/verifier_rubric.sh at {SH}")
+
+
+def _bash_inline(src: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Run ``bash -c <src>`` with optional env overlay."""
+    return subprocess.run(
+        ["bash", "-c", src],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+    )
+
+
+def _source_and_call(fn_call: str, db_path: str) -> subprocess.CompletedProcess:
+    """Source lib/verifier_rubric.sh and run a single function call.
+    The function reads $MINI_ORK_DB from env (matches the bash surface).
+
+    The function-call string is appended verbatim (no further quoting).
+    Args containing JSON must use single quotes outside the f-string
+    boundary (or be passed via env to dodge shell-quoting edge cases).
+    """
+    bash_src = (
+        f'. "{SH}" >/dev/null 2>&1\n'
+        f'{fn_call}\n'
+    )
+    return _bash_inline(bash_src, env={"MINI_ORK_DB": db_path})
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DB scaffold fixture (real db/init.sh against tmp_path)
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.fixture
+def temp_db(tmp_path):
+    """Spin up a real mini-ork SQLite DB via db/init.sh with a unique
+    path per test. Migration 0025_verifier_rubrics.sql applies inside
+    init.sh; rubric + results tables exist for the test."""
+    home = tmp_path / "home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    r = subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"db/init.sh failed: {r.stderr}\n{r.stdout}")
+    return dbp
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Columns we compare in DB rows — write-timestamps differ per call
+# ─────────────────────────────────────────────────────────────────────────────
+_RUBRIC_ROW_COLS = (
+    "rubric_id", "name", "task_class", "axes_json",
+    "is_active",
+)
+_RESULT_ROW_COLS = (
+    "run_id", "verifier_name", "rubric_id", "verdict",
+    "confidence", "scored_axes_json",
+    "is_false_positive", "is_false_negative",
+    "annotated_by", "annotated_at",
+    "repair_run_id", "notes",
+)
+
+
+def _select_result_row(db_path: str, result_id: str) -> dict:
+    con = sqlite3.connect(db_path)
+    try:
+        con.row_factory = sqlite3.Row
+        row = con.execute(
+            "SELECT " + ",".join(_RESULT_ROW_COLS)
+            + " FROM verifier_results WHERE result_id=?",
+            (result_id,),
+        ).fetchone()
+        return dict(row) if row is not None else {}
+    finally:
+        con.close()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) rubric_register — bash + python insert same fields, row diff byte-equal
+# ─────────────────────────────────────────────────────────────────────────────
+def test_rubric_register_parity(temp_db):
+    """Bash and Python each register rubric_id='r1' with the SAME fields.
+    Because ``rubric_register`` is an UPSERT, the second call (Python)
+    updates the same row — there is exactly ONE row. The point of the
+    parity test is: both sides produce a row whose logical columns
+    match the expected values byte-for-byte.
+
+    updated_at is ignored — it's a write-timestamp that may differ
+    between bash's INSERT and python's UPSERT (or match, depending on
+    second-resolution strftime)."""
+    _which("bash", "python3")
+
+    axes = '{"axes":["clarity","scope"]}'
+
+    # Bash side
+    rb = _source_and_call(
+        f'rubric_register "r1" "Test rubric" "framework_edit" \'{axes}\'',
+        temp_db,
+    )
+    assert rb.returncode == 0, f"bash rubric_register rc={rb.returncode}: {rb.stderr}"
+
+    # Python side (UPSERT — same rubric_id, same fields, so it OVERWRITES)
+    vr.rubric_register(
+        temp_db,
+        rubric_id="r1",
+        name="Test rubric",
+        task_class="framework_edit",
+        axes_json=axes,
+    )
+
+    # UPSERT semantics: only ONE row exists for rubric_id='r1'.
+    con = sqlite3.connect(temp_db)
+    try:
+        rows = con.execute(
+            "SELECT " + ",".join(_RUBRIC_ROW_COLS)
+            + " FROM verifier_rubrics WHERE rubric_id=?",
+            ("r1",),
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert len(rows) == 1, (
+        f"expected 1 row after UPSERT (bash+python same rubric_id), "
+        f"got {len(rows)}: {rows}"
+    )
+    r = rows[0]
+    expected = ("r1", "Test rubric", "framework_edit", axes, 1)
+    assert r == expected, (
+        f"rubric row fields don't match expected:\nrow     ={r}\nexpected={expected}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) rubric_get hit — stdout byte-equal between bash and python
+# ─────────────────────────────────────────────────────────────────────────────
+def test_rubric_get_hit_parity(temp_db):
+    """Bash registers a rubric, then both bash and python ``rubric_get``
+    emit the row as JSON. The dicts (via json.loads roundtrip) must be
+    equal on all logical columns except ``updated_at`` (write-timestamp
+    that may differ between the bash-side INSERT and the python-side
+    read depending on wall-clock resolution — bash only INSERTs once,
+    python only SELECTs, so they should match; we filter to be safe)."""
+    _which("bash", "python3")
+
+    axes = '{"axes":["clarity","scope"]}'
+    rb = _source_and_call(
+        f'rubric_register "r2" "Get-hit rubric" "framework_edit" \'{axes}\'',
+        temp_db,
+    )
+    assert rb.returncode == 0, f"bash rubric_register rc={rb.returncode}: {rb.stderr}"
+
+    # Bash get
+    rb_get = _source_and_call('rubric_get "r2"', temp_db)
+    assert rb_get.returncode == 0, f"bash rubric_get rc={rb_get.returncode}: {rb_get.stderr}"
+    bash_stdout = rb_get.stdout.strip()
+
+    # Python get
+    py_stdout = vr.rubric_get(temp_db, "r2")
+
+    # Byte-equal stdout
+    assert py_stdout == bash_stdout, (
+        f"rubric_get hit stdout mismatch\nbash={bash_stdout!r}\npy  ={py_stdout!r}"
+    )
+
+    # Also assert the dict-roundtrip equals the underlying DB row
+    # (ignoring updated_at, which is a write-timestamp).
+    parsed = json.loads(py_stdout)
+    assert parsed["rubric_id"] == "r2"
+    assert parsed["name"] == "Get-hit rubric"
+    assert parsed["task_class"] == "framework_edit"
+    assert parsed["axes_json"] == axes
+    assert parsed["is_active"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) rubric_get miss — both emit literal 'null'
+# ─────────────────────────────────────────────────────────────────────────────
+def test_rubric_get_miss_parity(temp_db):
+    """rubric_id 'does-not-exist' is never registered. Bash emits
+    ``null\\n`` via ``print('null')``; Python port returns ``'null'``.
+    Compare after stripping bash's trailing newline."""
+    _which("bash", "python3")
+
+    rb = _source_and_call('rubric_get "does-not-exist"', temp_db)
+    assert rb.returncode == 0, f"bash rubric_get rc={rb.returncode}: {rb.stderr}"
+    bash_stdout = rb.stdout.strip()
+    py_stdout = vr.rubric_get(temp_db, "does-not-exist")
+
+    assert bash_stdout == "null", f"bash get miss: expected 'null', got {bash_stdout!r}"
+    assert py_stdout == "null", f"python get miss: expected 'null', got {py_stdout!r}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) verifier_result_record — bash + python insert, rows byte-equal
+# ─────────────────────────────────────────────────────────────────────────────
+def test_verifier_result_record_parity(temp_db):
+    """Bash and Python each INSERT a verifier_results row with the same
+    logical fields. result_id differs (random uuid), but all other
+    logical columns must be byte-equal pairwise. result_id must match
+    the regex ``^vr-[0-9a-f]{12}$`` (bash's ``secrets.token_hex(6)``
+    format). created_at ignored — column DEFAULT = strftime now, so it
+    can differ between two consecutive INSERTs at second resolution."""
+    _which("bash", "python3")
+
+    # Need a rubric_id (FK to verifier_rubrics). Register first.
+    rb = _source_and_call(
+        'rubric_register "r3" "Rec rubric" "framework_edit" \'{"axes":["x"]}\'',
+        temp_db,
+    )
+    assert rb.returncode == 0, f"bash rubric_register rc={rb.returncode}: {rb.stderr}"
+
+    # Bash record (returns result_id via echo). Use the EXACT JSON
+    # text (no spaces — Python's json.dumps default) on both sides so
+    # the bash-INSERT row and python-INSERT row are byte-equal on
+    # scored_axes_json.
+    scored_axes = '{"axis_results":[{"axis":"x","score":3}]}'
+    rb_rec = _source_and_call(
+        f'verifier_result_record "run-001" "static-check" "pass" "r3" "0.92" '
+        f'\'{scored_axes}\'',
+        temp_db,
+    )
+    assert rb_rec.returncode == 0, (
+        f"bash verifier_result_record rc={rb_rec.returncode}: {rb_rec.stderr}"
+    )
+    bash_result_id = rb_rec.stdout.strip()
+    assert _RESULT_ID_RE.match(bash_result_id), (
+        f"bash result_id={bash_result_id!r} does not match vr-[0-9a-f]{{12}}"
+    )
+
+    # Python record
+    py_result_id = vr.verifier_result_record(
+        temp_db,
+        run_id="run-001",
+        verifier_name="static-check",
+        verdict="pass",
+        rubric_id="r3",
+        confidence=0.92,
+        scored_axes_json=scored_axes,
+    )
+    assert _RESULT_ID_RE.match(py_result_id), (
+        f"python result_id={py_result_id!r} does not match vr-[0-9a-f]{{12}}"
+    )
+
+    # SELECT both rows — should be exactly 2 (one bash, one python)
+    con = sqlite3.connect(temp_db)
+    try:
+        rows = con.execute(
+            "SELECT result_id," + ",".join(_RESULT_ROW_COLS)
+            + " FROM verifier_results WHERE run_id=? ORDER BY rowid ASC",
+            ("run-001",),
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert len(rows) == 2, (
+        f"expected 2 verifier_results rows, got {len(rows)}: {rows}"
+    )
+
+    # Each row's logical fields must pairwise match. The SELECT above
+    # is ``SELECT result_id, <_RESULT_ROW_COLS...>`` (13 cols total).
+    # Skip index 0 (``result_id`` — random per call, already regex-
+    # verified) and rely on the fact that ``created_at`` is NOT in
+    # the SELECT list (we don't include it in _RESULT_ROW_COLS).
+    r0 = rows[0][1:]  # drop result_id
+    r1 = rows[1][1:]
+    assert r0 == r1, (
+        f"verifier_results rows differ on logical columns:\nrow0={r0}\nrow1={r1}"
+    )
+
+    # Confidence must match to 1e-6 (kickoff tolerance).
+    conf_idx = _RESULT_ROW_COLS.index("confidence")
+    r0_conf = r0[conf_idx]
+    r1_conf = r1[conf_idx]
+    assert abs(float(r0_conf) - float(r1_conf)) < _FLOAT_TOL, (
+        f"confidence drift: {r0_conf} vs {r1_conf}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) verifier_result_annotate — bash records, python annotates as fp
+# ─────────────────────────────────────────────────────────────────────────────
+def test_verifier_result_annotate_false_positive_parity(temp_db):
+    """Bash INSERTs a verifier_results row. Python calls
+    ``verifier_result_annotate(..., kind='false_positive', ...)``. The
+    row must show ``is_false_positive=1``, ``is_false_negative=0``,
+    ``annotated_by`` set, ``annotated_at`` non-null."""
+    _which("bash", "python3")
+
+    # Setup rubric
+    rb = _source_and_call(
+        'rubric_register "r4" "Ann rubric" "framework_edit" \'{"axes":["x"]}\'',
+        temp_db,
+    )
+    assert rb.returncode == 0, f"bash rubric_register rc={rb.returncode}: {rb.stderr}"
+
+    # Bash record a failing result
+    rb_rec = _source_and_call(
+        'verifier_result_record "run-002" "static-check" "fail" "r4" "0.61" ""',
+        temp_db,
+    )
+    assert rb_rec.returncode == 0, f"bash record rc={rb_rec.returncode}: {rb_rec.stderr}"
+    bash_result_id = rb_rec.stdout.strip()
+
+    # Python annotate
+    vr.verifier_result_annotate(
+        temp_db,
+        result_id=bash_result_id,
+        kind="false_positive",
+        annotator="operator-amir",
+        notes="verifier was wrong; ran the test manually + it passed",
+    )
+
+    # SELECT row — flags must be set as expected
+    row = _select_result_row(temp_db, bash_result_id)
+    assert row, f"row missing for result_id={bash_result_id}"
+    assert row["is_false_positive"] == 1, row
+    assert row["is_false_negative"] == 0, row
+    assert row["annotated_by"] == "operator-amir", row
+    assert row["annotated_at"] is not None and int(row["annotated_at"]) > 0, row
+    assert row["notes"] == (
+        "verifier was wrong; ran the test manually + it passed"
+    ), row
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) verifier_chain_repair — bash records, python chains repair_run_id
+# ─────────────────────────────────────────────────────────────────────────────
+def test_verifier_chain_repair_parity(temp_db):
+    """Bash INSERTs a verifier_results row. Python calls
+    ``verifier_chain_repair(..., repair_run_id='run-002-repair')``. The
+    row must show ``repair_run_id`` set to the expected value."""
+    _which("bash", "python3")
+
+    # Setup rubric
+    rb = _source_and_call(
+        'rubric_register "r5" "Rep rubric" "framework_edit" \'{"axes":["x"]}\'',
+        temp_db,
+    )
+    assert rb.returncode == 0, f"bash rubric_register rc={rb.returncode}: {rb.stderr}"
+
+    # Bash record
+    rb_rec = _source_and_call(
+        'verifier_result_record "run-003" "static-check" "fail" "r5" "0.55" ""',
+        temp_db,
+    )
+    assert rb_rec.returncode == 0, f"bash record rc={rb_rec.returncode}: {rb_rec.stderr}"
+    bash_result_id = rb_rec.stdout.strip()
+
+    # Python chain repair
+    vr.verifier_chain_repair(temp_db, result_id=bash_result_id,
+                             repair_run_id="run-003-repair")
+
+    row = _select_result_row(temp_db, bash_result_id)
+    assert row, f"row missing for result_id={bash_result_id}"
+    assert row["repair_run_id"] == "run-003-repair", row
+    # Sanity: nothing else changed by chain_repair.
+    assert row["is_false_positive"] == 0
+    assert row["is_false_negative"] == 0
+    assert row["annotated_by"] is None
+    assert row["annotated_at"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) verifier_fp_rate — bash records 4 results + 1 fp, python fp_rate = 0.2500
+# ─────────────────────────────────────────────────────────────────────────────
+def test_verifier_fp_rate_parity(temp_db):
+    """Bash records 4 verifier_results with verifier_name='fp-test-v1'
+    (1 pass, 2 fail, 1 pass) and annotates the first fail as fp →
+    expected fp_rate = 1/4 = 0.2500. Python's ``verifier_fp_rate``
+    returns ``'0.2500'`` (matches bash's ``f"{fps/total:.4f}"``)."""
+    _which("bash", "python3")
+
+    bash_src = (
+        '. "' + str(SH) + '" >/dev/null 2>&1\n'
+        # 4 records — capture each result_id
+        'r1=$(verifier_result_record "fp-run-1" "fp-test-v1" "pass" "" "" "")\n'
+        'r2=$(verifier_result_record "fp-run-2" "fp-test-v1" "fail" "" "" "")\n'
+        'r3=$(verifier_result_record "fp-run-3" "fp-test-v1" "pass" "" "" "")\n'
+        'r4=$(verifier_result_record "fp-run-4" "fp-test-v1" "fail" "" "")\n'
+        # Annotate r2 as false_positive
+        'verifier_result_annotate "$r2" "false_positive" "op" "fp"\n'
+        # Emit the fp_rate — bash ``print(f"{fps/total:.4f}")`` writes
+        # 0.2500\\n to stdout.
+        'verifier_fp_rate "fp-test-v1"\n'
+    )
+    rb = _bash_inline(bash_src, env={"MINI_ORK_DB": temp_db})
+    assert rb.returncode == 0, f"bash fp_rate setup rc={rb.returncode}: {rb.stderr}"
+    bash_stdout = rb.stdout.strip()
+
+    py_stdout = vr.verifier_fp_rate(temp_db, "fp-test-v1")
+
+    assert py_stdout == "0.2500", (
+        f"python fp_rate: expected '0.2500', got {py_stdout!r}"
+    )
+    assert bash_stdout == py_stdout, (
+        f"fp_rate stdout mismatch\nbash={bash_stdout!r}\npy  ={py_stdout!r}"
+    )
+
+    # Also: order-independence — call fp_rate again right away (same
+    # DB state, no new inserts); result is identical.
+    py_stdout_2 = vr.verifier_fp_rate(temp_db, "fp-test-v1")
+    assert py_stdout_2 == py_stdout, "fp_rate is non-deterministic across calls"
+
+
+def test_verifier_fp_rate_reverse_order_parity(temp_db):
+    """Same math but the bash side inserts results in REVERSE order
+    (fail, pass, fail, pass) and annotates the LAST fail as fp. fp_rate
+    must still be 0.2500 — proves count-based math is order-independent.
+    """
+    _which("bash", "python3")
+
+    bash_src = (
+        '. "' + str(SH) + '" >/dev/null 2>&1\n'
+        # Reverse order
+        'r1=$(verifier_result_record "rev-run-1" "fp-test-v2" "fail" "" "" "")\n'
+        'r2=$(verifier_result_record "rev-run-2" "fp-test-v2" "pass" "" "" "")\n'
+        'r3=$(verifier_result_record "rev-run-3" "fp-test-v2" "fail" "" "" "")\n'
+        'r4=$(verifier_result_record "rev-run-4" "fp-test-v2" "pass" "" "" "")\n'
+        # Annotate r3 (the second fail in insert order) as fp
+        'verifier_result_annotate "$r3" "false_positive" "op" "fp"\n'
+        'verifier_fp_rate "fp-test-v2"\n'
+    )
+    rb = _bash_inline(bash_src, env={"MINI_ORK_DB": temp_db})
+    assert rb.returncode == 0, (
+        f"bash reverse-order fp_rate setup rc={rb.returncode}: {rb.stderr}"
+    )
+    bash_stdout = rb.stdout.strip()
+
+    py_stdout = vr.verifier_fp_rate(temp_db, "fp-test-v2")
+
+    assert py_stdout == "0.2500", (
+        f"python reverse-order fp_rate: expected '0.2500', got {py_stdout!r}"
+    )
+    assert bash_stdout == py_stdout, (
+        f"reverse-order fp_rate mismatch\nbash={bash_stdout!r}\npy  ={py_stdout!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) [BONUS] verifier_fp_rate empty case — bash emits '0.0', python '0.0'
+# ─────────────────────────────────────────────────────────────────────────────
+def test_verifier_fp_rate_empty_parity(temp_db):
+    """No rows for an unseen verifier_name → bash emits literal
+    ``0.0`` (with newline); python port returns ``'0.0'``. Bytes equal."""
+    _which("bash", "python3")
+
+    rb = _source_and_call('verifier_fp_rate "no-such-verifier"', temp_db)
+    assert rb.returncode == 0, f"bash fp_rate empty rc={rb.returncode}: {rb.stderr}"
+    bash_stdout = rb.stdout.strip()
+
+    py_stdout = vr.verifier_fp_rate(temp_db, "no-such-verifier")
+
+    assert bash_stdout == "0.0", f"bash empty fp_rate: {bash_stdout!r}"
+    assert py_stdout == "0.0", f"python empty fp_rate: {py_stdout!r}"


### PR DESCRIPTION
2 autonomous ports, live-bash parity tests (18 cases). Strangler-fig.