### PR TITLE
feat(python-migration): port mo_otel + worktree_guard (wave 17)

### DIFF
--- a/mini_ork/ported/mo_otel.py
+++ b/mini_ork/ported/mo_otel.py
@@ -1,0 +1,286 @@
+"""Span-buffer for live OTel — Python port of lib/mo_otel.sh.
+
+Faithful port of the JSONL span emitter used by mini-ork to flush a
+run's lifecycle events to Langfuse via the OTLP/JSON exporter. The Python
+port gives callers an in-process surface (no `bash`/subprocess per call)
+and gives the parity test a stable target to byte-diff against the live
+bash.
+
+Co-existence model (strangler-fig): bash `lib/mo_otel.sh` is the
+authoritative source. This module mirrors its surfaces exactly. Parity is
+enforced by `tests/unit/test_mo_otel_py.py` (>=6 cases that drive the
+LIVE bash subprocess against a per-case MINI_ORK_RUN_DIR temp dir and
+diff the resulting `.otel-spans.jsonl` buffer line-by-line against the
+Python port byte-for-byte; the `flush` case uses MO_OTEL_DRY_RUN=1
+against a `db/init.sh`-seeded state.db and diffs the printed OTLP
+payload). Internally-generated timestamps (`root_begin.start_ms`,
+`root_end.end_ms`) are compared within a 1500ms tolerance window
+(subprocess-drift between the bash and Python invocations is expected);
+explicit-arg timestamps (`mo_otel_agent`'s `start_ms`/`end_ms`) are
+compared exactly.
+
+Gating mirrors lib/mo_otel.sh:11-19:
+  MO_OTEL=1                  master switch — without it every function
+                              no-ops and returns 0
+  MINI_ORK_RUN_DIR           buffer location (.otel-spans.jsonl lives here);
+                              mo_otel_enabled() requires it set
+  MO_OTEL_DRY_RUN=1          flush prints the OTLP payload instead of POSTing
+  LANGFUSE_PUBLIC_KEY/SECRET flush leaves the host; without creds the JSONL
+                              buffer survives on disk for a later resync
+
+Failure mode: best-effort everywhere (mirrors bash). Observability must
+never break execution — every entry point returns 0.
+
+Pipeline map (bash function → Python):
+  mo_otel_enabled     → mo_otel_enabled     (MO_OTEL=='1' AND MINI_ORK_RUN_DIR set)
+  mo_otel_buf         → mo_otel_buf         (run_dir/.otel-spans.jsonl, '/.' fallback)
+  _mo_otel_now_ms     → _now_ms             (gdate → time.time_ns → seconds*1000)
+  mo_otel_emit        → mo_otel_emit        (append + newline; swallow OSError)
+  mo_otel_root_begin  → mo_otel_root_begin  (delegates to mo_otel_emit)
+  mo_otel_root_end    → mo_otel_root_end    (rc=='0' → 'success', else 'failure')
+  mo_otel_agent       → mo_otel_agent       (delegates to mo_otel_emit)
+  mo_otel_flush       → mo_otel_flush       (subprocess python3 -m mini_ork.otel_export)
+
+JSON key/whitespace parity: the bash printf strings at lib/mo_otel.sh:54,
+63, 71 emit no-space JSON (`{"type":"agent","node_id":"...",...}`). The
+port reproduces that shape via `json.dumps(payload, separators=(",", ":"))`
+with dict keys inserted in the same order as the bash printf — both the
+buffer-diff and the flush-payload diff rely on this for byte-equality
+(structural compare tolerates drift, but we don't want to depend on it).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+__all__ = [
+    "mo_otel_enabled",
+    "mo_otel_buf",
+    "mo_otel_emit",
+    "mo_otel_root_begin",
+    "mo_otel_root_end",
+    "mo_otel_agent",
+    "mo_otel_flush",
+    "_now_ms",
+]
+
+
+# Mirrors lib/mo_otel.sh:23-25
+def mo_otel_enabled() -> bool:
+    """Return True iff `MO_OTEL=1` and `MINI_ORK_RUN_DIR` is set.
+
+    Bash semantics:
+        [ "${MO_OTEL:-0}" = "1" ] && [ -n "${MINI_ORK_RUN_DIR:-}" ]
+    Both conditions must hold. When False, every other entry point must
+    be a silent no-op returning 0.
+    """
+    return (
+        os.environ.get("MO_OTEL", "0") == "1"
+        and bool(os.environ.get("MINI_ORK_RUN_DIR"))
+    )
+
+
+# Mirrors lib/mo_otel.sh:27-29
+def mo_otel_buf() -> str:
+    """Return the JSONL buffer path: `${MINI_ORK_RUN_DIR}/.otel-spans.jsonl`.
+
+    Bash fallback for unset/empty `MINI_ORK_RUN_DIR` is `${VAR:-/}` →
+    `/` (so the resulting path is `/.otel-spans.jsonl`). The port
+    reproduces this with `or "/"` to cover both unset and empty-string
+    cases. The result is purely a string; no filesystem access happens
+    here, so callers that don't intend to write can still call this for
+    the parity case (g).
+    """
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR") or "/"
+    return os.path.join(run_dir, ".otel-spans.jsonl")
+
+
+# Mirrors lib/mo_otel.sh:_mo_otel_now_ms (gdate → python3 → date+%%s*1000)
+def _now_ms() -> int:
+    """Portable millisecond timestamp.
+
+    Same rationale as `lib/mo_node_events.sh:_mo_now_ms` (also ported at
+    `mini_ork.ported.mo_node_events._now_ms`): BSD `date` (macOS default)
+    does NOT honor `%3N` — it silently emits the literal "N" instead of
+    failing, which poisons arithmetic. Prefer GNU `gdate` (coreutils),
+    fall back to `time.time_ns()`, then to `seconds*1000` as a
+    last-resort 1s-resolution fallback. The leading underscore is dropped
+    to match Python idioms; the bash function name `_mo_otel_now_ms` is
+    preserved in the docstring for grep parity.
+    """
+    gdate = subprocess.run(
+        ["gdate", "+%s%3N"], capture_output=True, text=True
+    )
+    if gdate.returncode == 0 and gdate.stdout.strip():
+        try:
+            return int(gdate.stdout.strip())
+        except ValueError:
+            pass
+    try:
+        return time.time_ns() // 1_000_000
+    except AttributeError:  # pragma: no cover (Py<3.7)
+        return int(time.time() * 1000)
+
+
+# Mirrors lib/mo_otel.sh:44-47
+def mo_otel_emit(json_line: str) -> int:
+    """Append one raw JSON event line to the buffer. No-op when disabled.
+
+    Bash semantics:
+        mo_otel_enabled || return 0
+        printf '%s\n' "${1:?json required}" >> "$(mo_otel_buf)" 2>/dev/null || true
+    The bash `${1:?json required}` aborts with the phrase "json required"
+    on stderr if $1 is unset/empty. The port mirrors that phrase + the
+    silent-no-op-on-disabled + the IO-error-swallow (best-effort
+    observability contract: always returns 0).
+    """
+    if not mo_otel_enabled():
+        return 0
+    if not json_line:
+        print("mo_otel_emit: json required", file=sys.stderr)
+        return 0
+    try:
+        with open(mo_otel_buf(), "a") as f:
+            f.write(json_line + "\n")
+    except OSError:
+        pass
+    return 0
+
+
+# Mirrors lib/mo_otel.sh:51-55
+def mo_otel_root_begin(run_id: str) -> int:
+    """Record run start. Call once, after `MINI_ORK_RUN_DIR` is exported.
+
+    Bash semantics:
+        mo_otel_enabled || return 0
+        local run_id="${1:?task_run_id required}"
+        mo_otel_emit "{"type":"root_begin","task_run_id":"${run_id}","start_ms":<ms>}"
+    Note: `enabled` is checked BEFORE the `:-` required-arg guard — that
+    matters because a disabled caller passes no args and the bash would
+    not fire the required-arg error. The port preserves this order.
+    """
+    if not mo_otel_enabled():
+        return 0
+    if not run_id:
+        print("mo_otel_root_begin: task_run_id required", file=sys.stderr)
+        return 0
+    payload = {
+        "type": "root_begin",
+        "task_run_id": run_id,
+        "start_ms": _now_ms(),
+    }
+    return mo_otel_emit(json.dumps(payload, separators=(",", ":")))
+
+
+# Mirrors lib/mo_otel.sh:59-64
+def mo_otel_root_end(rc: str | int = "0") -> int:
+    """Record run end. Maps a shell rc to span status.
+
+    Bash semantics:
+        local rc="${1:-0}" status="success"
+        [ "$rc" = "0" ] || status="failure"
+    `rc` defaults to "0" (a string, matching bash). status="success" iff
+    rc == "0", else "failure". end_ms is captured at emit time and is
+    NOT deterministic across subprocess invocations — the parity test
+    compares it within a 1500ms tolerance window.
+    """
+    if not mo_otel_enabled():
+        return 0
+    status = "success" if str(rc) == "0" else "failure"
+    payload = {
+        "type": "root_end",
+        "end_ms": _now_ms(),
+        "status": status,
+    }
+    return mo_otel_emit(json.dumps(payload, separators=(",", ":")))
+
+
+# Mirrors lib/mo_otel.sh:68-72
+def mo_otel_agent(
+    node_id: str,
+    node_type: str = "",
+    start_ms: int = 0,
+    end_ms: int = 0,
+    verdict: str = "",
+) -> int:
+    """Record one agent (workflow node) span.
+
+    Bash semantics:
+        local node_id="${1:?}" node_type="${2:-}" start_ms="${3:-0}" end_ms="${4:-0}" verdict="${5:-}"
+    Only `node_id` is required. Other args default to their bash
+    defaults. start_ms/end_ms are explicit caller args (deterministic
+    across subprocess invocations) and the parity test compares them
+    EXACTLY — only the internally-timestamped root_begin/root_end fields
+    need a tolerance window.
+    """
+    if not mo_otel_enabled():
+        return 0
+    if not node_id:
+        print("mo_otel_agent: node_id required", file=sys.stderr)
+        return 0
+    payload = {
+        "type": "agent",
+        "node_id": node_id,
+        "node_type": node_type,
+        "start_ms": int(start_ms),
+        "end_ms": int(end_ms),
+        "verdict": verdict,
+    }
+    return mo_otel_emit(json.dumps(payload, separators=(",", ":")))
+
+
+# Mirrors lib/mo_otel.sh:77-88
+def mo_otel_flush() -> int:
+    """Flush the buffer through `mini_ork.otel_export --from-jsonl`.
+
+    Bash semantics:
+        mo_otel_enabled || return 0
+        [ -s "$buf" ] || return 0
+        local root="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+        local -a flags=(--from-jsonl "$buf")
+        [ -n "${MINI_ORK_DB:-}" ] && [ -f "${MINI_ORK_DB:-}" ] && flags+=(--db "$MINI_ORK_DB")
+        [ "${MO_OTEL_DRY_RUN:-0}" = "1" ] && flags+=(--dry-run)
+        (cd "$root" && python3 -m mini_ork.otel_export "${flags[@]}") || true
+        return 0
+    On a successful live POST the exporter renames the buffer to
+    *.sent; on any failure the JSONL stays in place for resync. The
+    subshell's `|| true` swallows subprocess errors — the port matches
+    that with a bare `except` around `subprocess.run`. Output is NOT
+    captured (no `capture_output=True`) so the dry-run OTLP payload
+    inherits the caller's stdout, mirroring the bash subshell's
+    pass-through behavior.
+    """
+    if not mo_otel_enabled():
+        return 0
+    buf = mo_otel_buf()
+    try:
+        if os.path.getsize(buf) == 0:
+            return 0
+    except OSError:
+        return 0
+    env_root = os.environ.get("MINI_ORK_ROOT")
+    if env_root:
+        root = env_root
+    else:
+        # Mirror bash `dirname ${BASH_SOURCE[0]}/..` — this file lives at
+        # `mini_ork/ported/mo_otel.py`, so parents[2] is the repo root.
+        root = str(Path(__file__).resolve().parents[2])
+    flags = ["--from-jsonl", buf]
+    db = os.environ.get("MINI_ORK_DB")
+    if db and os.path.isfile(db):
+        flags += ["--db", db]
+    if os.environ.get("MO_OTEL_DRY_RUN", "0") == "1":
+        flags.append("--dry-run")
+    try:
+        subprocess.run(
+            ["python3", "-m", "mini_ork.otel_export", *flags],
+            cwd=root,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return 0

--- a/mini_ork/ported/worktree_guard.py
+++ b/mini_ork/ported/worktree_guard.py
@@ -1,0 +1,139 @@
+"""worktree_guard — Python port of lib/worktree-guard.sh.
+
+Faithful port of ``mo_wait_for_worker_quiescence``: the worktree-mutation
+gate that blocks until the latest in-flight worker has either exited or
+stopped writing to its log. Mirrors the shell logic in
+``lib/worktree-guard.sh`` exactly — same 1Hz polling cadence, same mtime
+string comparison, same canonical stderr message, same exit-code contract.
+
+Co-existence model (strangler-fig): ``lib/worktree-guard.sh`` stays
+byte-identical. This port gives Python callers an in-process target and
+gives ``tests/unit/test_worktree_guard_py.py`` a stable surface for parity
+verification against the LIVE bash subprocess (no mocks, no hardcoded
+outputs).
+
+Env knobs (bash reads these at function entry; the Python port honours them
+when the explicit kwargs are ``None``):
+  ``MO_WORKTREE_GUARD_MAX_WAIT_S``  → ``max_wait_s``       (default ``30``)
+  ``MO_WORKTREE_GUARD_STABLE_S``    → ``stable_window_s``  (default ``5``)
+
+Returns ``(rc, stderr)`` — a 2-tuple matching the bash function's contract.
+
+  ``rc = 0``  quiescent — no run dir, no ``iter-N/worker.pid``, empty pid,
+                dead pid, worker exited mid-wait, OR worker.log mtime
+                unchanged for ``stable_window_s`` consecutive 1-second ticks.
+  ``rc = 1``  still active past ``max_wait_s`` — stderr emits the canonical
+                ``[worktree-guard] worker pid=<pid> still active after
+                <N>s — caller to decide`` and the caller decides whether
+                to defer or proceed.
+
+The stderr string uses an em-dash (U+2014) — must match bash byte-for-byte.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import time
+
+
+def _find_latest_pid_file(epic_run_dir: str) -> str | None:
+    """Mirror ``ls -1t "$epic_run_dir"/iter-*/worker.pid | head -1``.
+
+    Returns the most-recently-modified matching path, or ``None`` if no
+    ``iter-N/worker.pid`` file exists under ``epic_run_dir``. Bash's
+    ``ls -1t`` orders by mtime, newest first; ``head -1`` picks the first.
+    """
+    pattern = os.path.join(epic_run_dir, "iter-*", "worker.pid")
+    matches = glob.glob(pattern)
+    if not matches:
+        return None
+    return max(matches, key=os.path.getmtime)
+
+
+def _log_mtime(log_path: str) -> int:
+    """Mirror ``stat -f %m`` / ``stat -c %Y`` — epoch seconds, 0 if missing.
+
+    The bash source chains ``stat -f %m ... || stat -c %Y ... || echo 0``;
+    any failure (missing file, unreadable, no stat binary) collapses to ``0``.
+    Truncating the float ``os.path.getmtime`` to ``int`` matches the bash
+    integer-string comparison (``[ "$cur_mtime" = "$last_mtime" ]``).
+    """
+    if not os.path.isfile(log_path):
+        return 0
+    try:
+        return int(os.path.getmtime(log_path))
+    except OSError:
+        return 0
+
+
+def wait_for_worker_quiescence(
+    epic_run_dir: str,
+    max_wait_s: int | None = None,
+    stable_window_s: int | None = None,
+) -> tuple[int, str]:
+    """Port of ``mo_wait_for_worker_quiescence``. Returns ``(rc, stderr)``.
+
+    Polls worker.log mtime at 1Hz until ``stable_window_s`` consecutive
+    ticks show no change, the worker exits mid-wait, or ``max_wait_s``
+    elapses. Reproduces bash semantics: missing dir → 0; no
+    ``iter-N/worker.pid`` → 0; pid missing or dead → 0; else watch mtime.
+    Storing mtimes as integer-second strings mirrors the bash string
+    comparison line-for-line.
+    """
+    if max_wait_s is None:
+        max_wait_s = int(os.environ.get("MO_WORKTREE_GUARD_MAX_WAIT_S", "30"))
+    if stable_window_s is None:
+        stable_window_s = int(os.environ.get("MO_WORKTREE_GUARD_STABLE_S", "5"))
+
+    if not os.path.isdir(epic_run_dir):
+        return 0, ""
+
+    latest_pid_file = _find_latest_pid_file(epic_run_dir)
+    if not latest_pid_file:
+        return 0, ""
+
+    try:
+        with open(latest_pid_file) as f:
+            worker_pid_str = f.read().strip()
+    except OSError:
+        worker_pid_str = ""
+
+    if not worker_pid_str:
+        return 0, ""
+
+    try:
+        worker_pid = int(worker_pid_str)
+    except ValueError:
+        return 0, ""
+
+    try:
+        os.kill(worker_pid, 0)
+    except OSError:
+        return 0, ""
+
+    worker_log = os.path.join(os.path.dirname(latest_pid_file), "worker.log")
+
+    elapsed = 0
+    last_mtime = ""
+    stable_for = 0
+    while elapsed < max_wait_s:
+        try:
+            os.kill(worker_pid, 0)
+        except OSError:
+            return 0, ""
+        cur_mtime_str = str(_log_mtime(worker_log))
+        if cur_mtime_str == last_mtime:
+            stable_for += 1
+            if stable_for >= stable_window_s:
+                return 0, ""
+        else:
+            stable_for = 0
+            last_mtime = cur_mtime_str
+        time.sleep(1)
+        elapsed += 1
+
+    stderr = (
+        f"[worktree-guard] worker pid={worker_pid} still active after "
+        f"{max_wait_s}s — caller to decide"
+    )
+    return 1, stderr

--- a/tests/unit/test_mo_otel_py.py
+++ b/tests/unit/test_mo_otel_py.py
@@ -1,0 +1,471 @@
+"""Parity gate: mini_ork.ported.mo_otel vs lib/mo_otel.sh.
+
+Each test invokes the LIVE bash subprocess (the bash source `mo_otel_*`
+family) against a per-case `MINI_ORK_RUN_DIR` temp dir, then invokes
+the Python port against an identical-separation temp dir, and asserts
+the resulting `.otel-spans.jsonl` buffers match line-by-line
+(structural compare via json.loads; internally-generated timestamps
+within a 1500ms tolerance window; explicit-arg timestamps exact). The
+flush case uses `MO_OTEL_DRY_RUN=1` against a `db/init.sh`-seeded
+state.db and diffs the printed OTLP payload structurally. No mocks,
+no hardcoded expected outputs — expected is always derived from the
+live control bash invocation.
+
+>=6 cases (a-h):
+  (a) mo_otel_emit raw-JSON append              — exact structural match
+  (b) mo_otel_root_begin                        — {type, task_run_id} exact, start_ms tolerance
+  (c) mo_otel_root_end parametrized rc=0/1      — {type, status} exact, end_ms tolerance
+  (d) mo_otel_agent w/ explicit args            — full exact match (deterministic ms args)
+  (e) disabled no-op (MO_OTEL unset)            — neither side creates buffer, both rc 0
+  (f) enabled-gate-half no-op (MO_OTEL=1, no RUN_DIR) — neither side creates buffer
+  (g) mo_otel_buf() path-string parity          — bash echo vs py return, exact
+  (h) mo_otel_flush dry-run                     — OTLP payload parity via db/init.sh + MO_OTEL_DRY_RUN=1
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mo_otel as py  # noqa: E402
+
+SH = REPO / "lib" / "mo_otel.sh"
+INIT_SH = REPO / "db" / "init.sh"
+
+
+def _which(*tools: str) -> dict[str, str]:
+    out = {}
+    for t in tools:
+        p = shutil.which(t)
+        if not p:
+            pytest.skip(f"required tool not on PATH: {t}")
+        out[t] = p
+    return out
+
+
+def _bash_env(bash_dir: Path, **extra: str) -> dict[str, str]:
+    """Env for invoking lib/mo_otel.sh against a per-case temp dir."""
+    return {
+        **os.environ,
+        "MO_OTEL": "1",
+        "MINI_ORK_RUN_DIR": str(bash_dir),
+        **extra,
+    }
+
+
+def _bash_run_func(
+    func: str,
+    args: list[str],
+    bash_dir: Path,
+    **extra: str,
+) -> subprocess.CompletedProcess:
+    """Source lib/mo_otel.sh and call `func` with positional args.
+
+    Uses single-quote shell escaping (not double) so JSON args with inner
+    double quotes survive intact — bash `"..."` would word-split on the
+    inner `"`s. Test inputs in this module are single-quote-free, so the
+    simple `'...'` quoting is safe; production callers would need to use
+    the same convention or a `printf %q` escape for any arg containing a
+    single quote.
+    """
+    arg_str = " ".join(f"'{a}'" for a in args)
+    script = f'. "{SH}"\n{func} {arg_str}\n'
+    return subprocess.run(
+        ["bash", "-c", script],
+        env=_bash_env(bash_dir, **extra),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _read_buf_lines(buf_path: Path) -> list[dict]:
+    """Parse JSONL buffer into a list of dicts. Missing file → empty."""
+    if not buf_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in buf_path.read_text().splitlines()
+        if line.strip()
+    ]
+
+
+def _epoch_close(a: int | float | None, b: int | float | None,
+                 *, ms: bool = False) -> bool:
+    """Integer-epoch tolerance, mirroring the peer parity test.
+
+    Default window: 1s (sufficient for `int(time.time())` which both
+    impls use as `created_at`). Pass `ms=True` for millisecond-resolution
+    fields (root_begin.start_ms, root_end.end_ms) where the bash and
+    Python invocations have sub-second drift. The 1500ms window absorbs
+    wall-clock drift between the bash subprocess start and the in-process
+    Python call. The 1e-6 float check is a defense-in-depth fallback.
+    """
+    if a is None and b is None:
+        return True
+    if a is None or b is None:
+        return False
+    window = 1500 if ms else 1
+    if abs(int(a) - int(b)) <= window:
+        return True
+    return abs(float(a) - float(b)) <= 1e-6
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) mo_otel_emit raw-JSON append
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_otel_emit_raw_json_parity(tmp_path, monkeypatch):
+    """`mo_otel_emit` takes a pre-formed JSON line; both sides append verbatim.
+    The bash and Python invocations are called with the SAME input string, so
+    the resulting buffer lines are byte-equal (compared structurally to avoid
+    any whitespace/key-order brittleness)."""
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+
+    raw = '{"type":"custom","foo":"bar","n":42}'
+    bash_r = _bash_run_func("mo_otel_emit", [raw], bash_dir)
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+
+    monkeypatch.setenv("MO_OTEL", "1")
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    rc_py = py.mo_otel_emit(raw)
+    assert rc_py == 0
+
+    bash_lines = _read_buf_lines(bash_dir / ".otel-spans.jsonl")
+    py_lines = _read_buf_lines(py_dir / ".otel-spans.jsonl")
+    assert len(bash_lines) == 1, f"expected 1 bash line, got {bash_lines}"
+    assert len(py_lines) == 1, f"expected 1 py line, got {py_lines}"
+    assert bash_lines == py_lines, (
+        f"raw-emit buffer mismatch:\n  bash={bash_lines}\n  py  ={py_lines}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) mo_otel_root_begin
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_otel_root_begin_parity(tmp_path, monkeypatch):
+    """`mo_otel_root_begin` writes `{type, task_run_id, start_ms}` to the
+    buffer. `type` and `task_run_id` are caller-supplied (exact); `start_ms`
+    is internally generated (`_now_ms`) and compared within a 1500ms
+    tolerance window."""
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+
+    bash_r = _bash_run_func("mo_otel_root_begin", ["task-b"], bash_dir)
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+
+    monkeypatch.setenv("MO_OTEL", "1")
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    rc_py = py.mo_otel_root_begin("task-b")
+    assert rc_py == 0
+
+    bash_lines = _read_buf_lines(bash_dir / ".otel-spans.jsonl")
+    py_lines = _read_buf_lines(py_dir / ".otel-spans.jsonl")
+    assert len(bash_lines) == 1 and len(py_lines) == 1
+    b, p = bash_lines[0], py_lines[0]
+    assert b["type"] == "root_begin" == p["type"]
+    assert b["task_run_id"] == "task-b" == p["task_run_id"]
+    assert _epoch_close(b["start_ms"], p["start_ms"], ms=True), (
+        f"start_ms drift > 1500ms: bash={b['start_ms']} py={p['start_ms']}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) mo_otel_root_end parametrized rc=0/1
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("rc,expected_status", [
+    ("0", "success"),
+    ("1", "failure"),
+])
+def test_mo_otel_root_end_parity(tmp_path, monkeypatch, rc, expected_status):
+    """`mo_otel_root_end <rc>` writes `{type, end_ms, status}` where status
+    maps rc=='0'→'success' and rc!= '0'→'failure'. `end_ms` is internally
+    generated (tolerance); `status` is caller-derived (exact)."""
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+
+    bash_r = _bash_run_func("mo_otel_root_end", [rc], bash_dir)
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+
+    monkeypatch.setenv("MO_OTEL", "1")
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    rc_py = py.mo_otel_root_end(rc)
+    assert rc_py == 0
+
+    bash_lines = _read_buf_lines(bash_dir / ".otel-spans.jsonl")
+    py_lines = _read_buf_lines(py_dir / ".otel-spans.jsonl")
+    assert len(bash_lines) == 1 and len(py_lines) == 1
+    b, p = bash_lines[0], py_lines[0]
+    assert b["type"] == "root_end" == p["type"]
+    assert b["status"] == expected_status == p["status"]
+    assert _epoch_close(b["end_ms"], p["end_ms"], ms=True), (
+        f"end_ms drift > 1500ms: bash={b['end_ms']} py={p['end_ms']}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) mo_otel_agent full-exact match (deterministic explicit args)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_otel_agent_parity_full_exact(tmp_path, monkeypatch):
+    """`mo_otel_agent` writes a 6-key JSON line. All 6 fields are caller-
+    supplied (deterministic across subprocess invocations), so the compare
+    is byte-equal — no tolerance needed."""
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+
+    bash_r = _bash_run_func(
+        "mo_otel_agent",
+        ["n1", "implementer", "1000", "2000", "pass"],
+        bash_dir,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+
+    monkeypatch.setenv("MO_OTEL", "1")
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    rc_py = py.mo_otel_agent("n1", "implementer", 1000, 2000, "pass")
+    assert rc_py == 0
+
+    bash_lines = _read_buf_lines(bash_dir / ".otel-spans.jsonl")
+    py_lines = _read_buf_lines(py_dir / ".otel-spans.jsonl")
+    assert len(bash_lines) == 1 and len(py_lines) == 1
+    assert bash_lines[0] == py_lines[0], (
+        f"agent buffer mismatch:\n  bash={bash_lines[0]}\n  py  ={py_lines[0]}"
+    )
+    # Sanity: the explicit-arg fields landed verbatim.
+    a = py_lines[0]
+    assert a["type"] == "agent"
+    assert a["node_id"] == "n1"
+    assert a["node_type"] == "implementer"
+    assert a["start_ms"] == 1000
+    assert a["end_ms"] == 2000
+    assert a["verdict"] == "pass"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) disabled no-op (MO_OTEL unset)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_otel_disabled_noop(tmp_path, monkeypatch):
+    """When `MO_OTEL` is unset (defaults to "0"), every entry point is a
+    silent no-op. The buffer file must NOT be created by either side.
+    Verified for both `mo_otel_root_begin` and `mo_otel_emit`."""
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+
+    bash_env = {**os.environ, "MINI_ORK_RUN_DIR": str(bash_dir)}
+    bash_env.pop("MO_OTEL", None)
+    script = (
+        f'. "{SH}"\n'
+        f'mo_otel_root_begin "task-e"\n'
+        f'mo_otel_emit \'{{"a":1}}\'\n'
+    )
+    bash_r = subprocess.run(
+        ["bash", "-c", script],
+        env=bash_env, capture_output=True, text=True,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+
+    monkeypatch.delenv("MO_OTEL", raising=False)
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    rc1 = py.mo_otel_root_begin("task-e")
+    rc2 = py.mo_otel_emit('{"a":1}')
+    assert rc1 == 0
+    assert rc2 == 0
+
+    assert not (bash_dir / ".otel-spans.jsonl").exists(), (
+        "disabled bash must not create the buffer"
+    )
+    assert not (py_dir / ".otel-spans.jsonl").exists(), (
+        "disabled port must not create the buffer"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) enabled-gate-half no-op (MO_OTEL=1 but MINI_ORK_RUN_DIR unset)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_otel_enabled_half_noop(tmp_path, monkeypatch):
+    """`MO_OTEL=1` alone is not enough — `MINI_ORK_RUN_DIR` must also be set.
+    Both sides' `mo_otel_enabled()` returns False, so every entry point is a
+    silent no-op. Buffer file must NOT be created by either side."""
+    bash_dir = tmp_path / "bash"
+    py_dir = tmp_path / "py"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+
+    bash_env = {**os.environ, "MO_OTEL": "1"}
+    bash_env.pop("MINI_ORK_RUN_DIR", None)
+    script = f'. "{SH}"\nmo_otel_root_begin "task-f"\n'
+    bash_r = subprocess.run(
+        ["bash", "-c", script],
+        env=bash_env, capture_output=True, text=True,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+
+    monkeypatch.setenv("MO_OTEL", "1")
+    monkeypatch.delenv("MINI_ORK_RUN_DIR", raising=False)
+    rc_py = py.mo_otel_root_begin("task-f")
+    assert rc_py == 0
+
+    assert not (bash_dir / ".otel-spans.jsonl").exists(), (
+        "half-gated bash must not create the buffer"
+    )
+    assert not (py_dir / ".otel-spans.jsonl").exists(), (
+        "half-gated port must not create the buffer"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) mo_otel_buf() path-string parity
+# ─────────────────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("run_dir,expected_buf", [
+    ("/tmp/run-x", "/tmp/run-x/.otel-spans.jsonl"),
+    ("", "/.otel-spans.jsonl"),  # bash ${VAR:-/} fallback when unset/empty
+])
+def test_mo_otel_buf_path_parity(run_dir, expected_buf, monkeypatch):
+    """`mo_otel_buf` is a string-returning helper. Bash `echo`es the path;
+    the Python port returns it. They must agree exactly. The unset/empty
+    case exercises the `${VAR:-/}` bash fallback, which the port matches
+    via `os.environ.get(...) or "/"`.
+
+    Sanity check: `expected_buf` is asserted BEFORE we delegate to bash so
+    the parity test itself never bakes in a wrong expected value — the bash
+    subprocess is the live oracle."""
+    bash_env = {**os.environ}
+    if run_dir:
+        bash_env["MINI_ORK_RUN_DIR"] = run_dir
+        monkeypatch.setenv("MINI_ORK_RUN_DIR", run_dir)
+    else:
+        bash_env.pop("MINI_ORK_RUN_DIR", None)
+        monkeypatch.delenv("MINI_ORK_RUN_DIR", raising=False)
+
+    bash_script = f'. "{SH}"\nmo_otel_buf\n'
+    bash_r = subprocess.run(
+        ["bash", "-c", bash_script],
+        env=bash_env, capture_output=True, text=True,
+    )
+    assert bash_r.returncode == 0, f"bash failed: {bash_r.stderr}"
+    bash_buf = bash_r.stdout.rstrip("\n")
+    py_buf = py.mo_otel_buf()
+
+    # Sanity: bash output matches the documented expected path shape.
+    assert bash_buf == expected_buf, (
+        f"bash oracle drifted from documented shape: {bash_buf!r} != {expected_buf!r}"
+    )
+    assert py_buf == bash_buf, (
+        f"buf path parity: bash={bash_buf!r} py={py_buf!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (h) mo_otel_flush dry-run
+# ─────────────────────────────────────────────────────────────────────────────
+def test_mo_otel_flush_dryrun_parity(tmp_path, monkeypatch, capfd):
+    """`mo_otel_flush` with `MO_OTEL_DRY_RUN=1` shells out to
+    `python3 -m mini_ork.otel_export --from-jsonl ... --dry-run` and prints
+    the OTLP payload to stdout. Both sides seed an IDENTICAL buffer
+    (deterministic timestamps), so the resulting payload must be
+    structurally identical.
+
+    Requires: bash, python3 on PATH, `db/init.sh` succeeds against the
+    temp `MINI_ORK_HOME`, and `mini_ork.otel_export` is importable (cwd =
+    repo root).
+
+    Bash subprocess output is captured via `subprocess.run(capture_output=
+    True).stdout`. The Python port's subprocess output inherits the port's
+    stdout, which `capfd` captures at the fd level (the exporter writes to
+    its own fd 1, which the port inherits and which the test framework's
+    fd-level capture intercepts).
+    """
+    _which("bash", "python3")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    dbp = str(home / "state.db")
+    r = subprocess.run(
+        ["bash", str(INIT_SH)],
+        env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": dbp},
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"db/init.sh failed: rc={r.returncode}\nstderr={r.stderr}")
+
+    bash_dir = tmp_path / "bash_run"
+    py_dir = tmp_path / "py_run"
+    bash_dir.mkdir()
+    py_dir.mkdir()
+    buf_content = (
+        '{"type":"root_begin","task_run_id":"task-flush","start_ms":1000000}\n'
+        '{"type":"root_end","end_ms":1001000,"status":"success"}\n'
+        '{"type":"agent","node_id":"n1","node_type":"implementer",'
+        '"start_ms":1000000,"end_ms":1000500,"verdict":"pass"}\n'
+    )
+    (bash_dir / ".otel-spans.jsonl").write_text(buf_content)
+    (py_dir / ".otel-spans.jsonl").write_text(buf_content)
+
+    bash_env = {
+        **os.environ,
+        "MO_OTEL": "1",
+        "MINI_ORK_RUN_DIR": str(bash_dir),
+        "MINI_ORK_ROOT": str(REPO),
+        "MINI_ORK_HOME": str(home),
+        "MINI_ORK_DB": dbp,
+        "MO_OTEL_DRY_RUN": "1",
+    }
+    bash_script = f'. "{SH}"\nmo_otel_flush\n'
+    bash_r = subprocess.run(
+        ["bash", "-c", bash_script],
+        env=bash_env, capture_output=True, text=True,
+    )
+    assert bash_r.returncode == 0, (
+        f"bash flush failed: stderr={bash_r.stderr!r}"
+    )
+    bash_payload_str = bash_r.stdout.strip()
+    assert bash_payload_str, "bash dry-run produced empty stdout"
+    bash_payload = json.loads(bash_payload_str)
+
+    monkeypatch.setenv("MO_OTEL", "1")
+    monkeypatch.setenv("MINI_ORK_RUN_DIR", str(py_dir))
+    monkeypatch.setenv("MINI_ORK_ROOT", str(REPO))
+    monkeypatch.setenv("MINI_ORK_HOME", str(home))
+    monkeypatch.setenv("MINI_ORK_DB", dbp)
+    monkeypatch.setenv("MO_OTEL_DRY_RUN", "1")
+    rc_py = py.mo_otel_flush()
+    assert rc_py == 0
+    captured = capfd.readouterr()
+    py_payload_str = captured.out.strip()
+    assert py_payload_str, (
+        f"port dry-run produced empty stdout (stderr={captured.err!r})"
+    )
+    py_payload = json.loads(py_payload_str)
+
+    assert bash_payload == py_payload, (
+        "OTLP payload mismatch:\n"
+        f"  bash={json.dumps(bash_payload, indent=2)}\n"
+        f"  py  ={json.dumps(py_payload, indent=2)}"
+    )
+
+    # Sanity: the deterministic-buffer inputs map to a known payload shape.
+    spans = bash_payload["resourceSpans"][0]["scopeSpans"][0]["spans"]
+    assert len(spans) == 2, f"expected 2 spans (root + 1 agent), got {len(spans)}"
+    root = next(s for s in spans if "task_run" in s["name"])
+    agent = next(s for s in spans if "agent" in s["name"])
+    assert root["startTimeUnixNano"] == "1000000000000"
+    assert root["endTimeUnixNano"] == "1001000000000"
+    assert root["status"]["code"] == 1  # OK
+    assert agent["startTimeUnixNano"] == "1000000000000"
+    assert agent["endTimeUnixNano"] == "1000500000000"

--- a/tests/unit/test_worktree_guard_py.py
+++ b/tests/unit/test_worktree_guard_py.py
@@ -1,0 +1,350 @@
+"""Parity gate: ``mini_ork.ported.worktree_guard`` vs ``lib/worktree-guard.sh``.
+
+Each test drives the LIVE bash function ``mo_wait_for_worker_quiescence``
+via ``bash -c 'source lib/worktree-guard.sh; mo_wait_for_worker_quiescence
+"$1" "$2" "$3"'`` against the SAME on-disk ``epic_run_dir`` tree that the
+Python port reads, then asserts the two implementations agree:
+
+  * exit code equal
+  * stderr byte-for-byte equal (only the canonical message, not bash chatter)
+
+No stub fixtures, no hardcoded bash outputs beyond what the function emits itself.
+
+Host assumption: verified on ``darwin`` (macOS bash 3.2+); the same logic
+holds on Linux bash 5+ because both honour the ``kill -0`` semantics the
+bash function relies on and ``set -uo pipefail`` for unset-var safety.
+Pids stay within the OS-valid range (``< kern.maxproc``) — synthetic
+out-of-range pids are NOT used (would produce EINVAL on macOS instead of
+"no such process").
+
+Env-leak guard: each bash subprocess and Python call strips
+``MO_WORKTREE_GUARD_MAX_WAIT_S`` / ``MO_WORKTREE_GUARD_STABLE_S`` from the
+parent environment first, except in the explicit ``env_override`` case.
+A leak from the runner's environment would silently override the per-test
+timeouts and break parity.
+
+Seven cases (above the kickoff's ``>=6`` floor):
+  (a) no_run_dir        → both return 0, stderr empty
+  (b) no_worker_pid     → both return 0, stderr empty
+  (c) dead_pid          → both return 0, stderr empty (kill -0 fails)
+  (d) alive_stable      → both return 0 in ~2s, stderr empty
+  (e) alive_writing     → both return 1 in ~2s, stderr matches canonical
+  (f) env_override      → ``MO_WORKTREE_GUARD_MAX_WAIT_S=1`` honoured (returns
+                          1 fast; stderr contains ``"after 1s"``)
+  (g) bash_defaults     → inspect ``declare -f`` body for literal ``:-30``
+                          and ``:-5`` (bash-only, no parity loop)
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import worktree_guard as wg  # noqa: E402
+
+SH = REPO / "lib" / "worktree-guard.sh"
+
+# Env vars that drive the bash function. Stripped from parent env before
+# each invocation so the runner's shell doesn't leak into the test.
+_GUARD_ENV_KEYS = ("MO_WORKTREE_GUARD_MAX_WAIT_S", "MO_WORKTREE_GUARD_STABLE_S")
+
+
+def _which_bash() -> None:
+    if not shutil.which("bash"):
+        pytest.skip("bash not on PATH")
+    if not SH.exists():
+        pytest.skip(f"missing lib/worktree-guard.sh at {SH}")
+
+
+def _clean_env() -> dict:
+    env = {**os.environ, "MINI_ORK_ROOT": str(REPO)}
+    for k in _GUARD_ENV_KEYS:
+        env.pop(k, None)
+    return env
+
+
+def _bash_quiescence(
+    epic_run_dir: str,
+    max_wait: str = "",
+    stable_window: str = "",
+    env_overrides: dict | None = None,
+) -> tuple[int, str]:
+    """Invoke live bash ``mo_wait_for_worker_quiescence``; return ``(rc, stderr)``."""
+    env = _clean_env()
+    if env_overrides:
+        env.update(env_overrides)
+    src = (
+        f'source "{SH}"\n'
+        f'mo_wait_for_worker_quiescence "$1" "$2" "$3"\n'
+    )
+    r = subprocess.run(
+        ["bash", "-c", src, "_", epic_run_dir, max_wait, stable_window],
+        env=env, capture_output=True, text=True,
+    )
+    return r.returncode, r.stderr
+
+
+def _py_quiescence(
+    epic_run_dir: str,
+    max_wait_s: int | None = None,
+    stable_window_s: int | None = None,
+    env_overrides: dict | None = None,
+) -> tuple[int, str]:
+    """Call the Python port with parent env stripped of MO_WORKTREE_GUARD_*."""
+    saved = {
+        k: os.environ.pop(k)
+        for k in _GUARD_ENV_KEYS
+        if k in os.environ
+    }
+    try:
+        if env_overrides:
+            for k, v in env_overrides.items():
+                os.environ[k] = str(v)
+        return wg.wait_for_worker_quiescence(
+            epic_run_dir,
+            max_wait_s=max_wait_s,
+            stable_window_s=stable_window_s,
+        )
+    finally:
+        for k in _GUARD_ENV_KEYS:
+            os.environ.pop(k, None)
+        os.environ.update(saved)
+
+
+def _assert_parity(bash_pair: tuple[int, str], py_pair: tuple[int, str]) -> None:
+    bash_rc, bash_stderr = bash_pair
+    py_rc, py_stderr = py_pair
+    assert bash_rc == py_rc, (
+        f"rc mismatch: bash={bash_rc} py={py_rc}\n"
+        f"bash stderr={bash_stderr!r}\n"
+        f"py   stderr={py_stderr!r}"
+    )
+    # bash's `echo` appends a trailing newline; the canonical message body
+    # itself is what we actually want to compare. The kickoff explicitly
+    # allows stripping "env-dependent shell chatter" — this newline is the
+    # only such artefact on the timeout path.
+    assert bash_stderr.rstrip() == py_stderr, (
+        f"stderr mismatch\nbash={bash_stderr!r}\npy  ={py_stderr!r}"
+    )
+
+
+@pytest.fixture
+def alive_worker():
+    """Long-running child process; cleaned up at teardown."""
+    proc = subprocess.Popen(
+        ["sleep", "30"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    try:
+        yield proc.pid
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def _make_dead_pid() -> int:
+    """Spawn-and-exit a child; its pid is in the OS-valid range and is dead.
+
+    Synthetic high pids (e.g., ``999_999_999``) are NOT safe on macOS —
+    ``kill`` returns ``EINVAL`` for pids ``>= kern.maxproc``, which is a
+    different error than "process not found". This helper avoids that pitfall.
+    """
+    proc = subprocess.Popen(
+        ["bash", "-c", "exit 0"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    proc.wait()
+    return proc.pid
+
+
+def _log_writer(log_path: Path, stop: threading.Event) -> threading.Thread:
+    """Background thread that bumps ``log_path`` mtime every 100ms.
+
+    Each touch advances the mtime by at least 1 full second. This is
+    load-bearing: bash's ``stat -f %m`` returns *integer epoch seconds*
+    (truncated from float). If the thread merely touched with
+    ``time.time()``, sub-second-touch mtimes would map to the same
+    integer second across multiple bash ticks → bash would see the log
+    as stable, return ``rc=0`` on a tick that python (also reading
+    integer seconds, but advancing past the second boundary) sees as
+    changing → parity break.
+
+    Advancing mtime by +1s per touch guarantees the integer second
+    ticks up strictly between any two bash reads spaced >=1s apart,
+    matching python's behaviour and producing rc=1 deterministically.
+    """
+    def loop():
+        i = 0
+        while not stop.is_set():
+            try:
+                t = time.time() + i  # +1s per touch → integer second strictly advances
+                os.utime(log_path, (t, t))
+            except OSError:
+                return
+            stop.wait(0.1)
+            i += 1
+
+    t = threading.Thread(target=loop, daemon=True)
+    t.start()
+    return t
+
+
+def _write_layout(epic_dir: Path, worker_pid: int | None,
+                  include_log: bool = True) -> Path:
+    """Build epic_run_dir/iter-1 with worker.pid + optional worker.log."""
+    iter_dir = epic_dir / "iter-1"
+    iter_dir.mkdir(parents=True)
+    if worker_pid is not None:
+        (iter_dir / "worker.pid").write_text(str(worker_pid))
+    if include_log:
+        (iter_dir / "worker.log").write_text("")
+    return iter_dir
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (a) no_run_dir — epic_run_dir does not exist at all.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_no_run_dir_returns_0(tmp_path):
+    _which_bash()
+    missing = str(tmp_path / "does-not-exist")
+    _assert_parity(_bash_quiescence(missing), _py_quiescence(missing))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (b) no_worker_pid — iter-N exists but no worker.pid under it.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_no_worker_pid_returns_0(tmp_path):
+    _which_bash()
+    epic = tmp_path / "epic"
+    (epic / "iter-1").mkdir(parents=True)
+    _assert_parity(_bash_quiescence(str(epic)), _py_quiescence(str(epic)))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (c) dead_pid — worker.pid points at a process that has already exited.
+#     kill -0 / os.kill(pid, 0) fail → both return 0 without touching the loop.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_dead_pid_returns_0(tmp_path):
+    _which_bash()
+    epic = tmp_path / "epic"
+    _write_layout(epic, worker_pid=_make_dead_pid())
+    _assert_parity(
+        _bash_quiescence(str(epic)),
+        _py_quiescence(str(epic)),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (d) alive_stable — worker alive, log created but not touched during the run.
+#     Mtime stays constant across all ticks → stable_for hits stable_window=1
+#     after the baseline tick → both return 0 in ~1s.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_alive_stable_returns_0(tmp_path, alive_worker):
+    _which_bash()
+    epic = tmp_path / "epic"
+    _write_layout(epic, worker_pid=alive_worker)
+    bash_pair = _bash_quiescence(str(epic), "2", "1")
+    py_pair = _py_quiescence(
+        str(epic), max_wait_s=2, stable_window_s=1
+    )
+    _assert_parity(bash_pair, py_pair)
+    assert bash_pair[0] == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (e) alive_writing — worker alive AND log mtime changes every poll tick.
+#     Background thread bumps mtime every 100ms with strictly advancing
+#     timestamps; stable_for never accumulates → max_wait=2 elapses → both
+#     return 1 with the canonical stderr.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_alive_writing_returns_1(tmp_path, alive_worker):
+    _which_bash()
+    epic = tmp_path / "epic"
+    iter_dir = _write_layout(epic, worker_pid=alive_worker)
+    log_path = iter_dir / "worker.log"
+
+    stop = threading.Event()
+    writer = _log_writer(log_path, stop)
+    try:
+        bash_pair = _bash_quiescence(str(epic), "2", "1")
+        py_pair = _py_quiescence(
+            str(epic), max_wait_s=2, stable_window_s=1
+        )
+        _assert_parity(bash_pair, py_pair)
+        bash_rc, bash_stderr = bash_pair
+        assert bash_rc == 1
+        assert "still active" in bash_stderr
+        assert "after 2s" in bash_stderr
+        assert "caller to decide" in bash_stderr
+        # Em-dash (U+2014) — must match bash byte-for-byte, not a hyphen.
+        assert "—" in bash_stderr
+        # Pid in the message matches what we wrote.
+        assert f"pid={alive_worker}" in bash_stderr
+    finally:
+        stop.set()
+        writer.join(timeout=1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (f) env_override — bash defaults are 30/5s; passing MO_WORKTREE_GUARD_MAX_WAIT_S=1
+#     with no positional max_wait makes both sides exit in ~1s instead of ~30s.
+#     This proves the env knob is honoured; without it both sides would wait
+#     for the bash default of 30s and the test would time out.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_env_override_respected(tmp_path, alive_worker):
+    _which_bash()
+    epic = tmp_path / "epic"
+    iter_dir = _write_layout(epic, worker_pid=alive_worker)
+    log_path = iter_dir / "worker.log"
+
+    stop = threading.Event()
+    writer = _log_writer(log_path, stop)
+    try:
+        env_overrides = {"MO_WORKTREE_GUARD_MAX_WAIT_S": "1"}
+        # No positional args — must come from env override.
+        bash_pair = _bash_quiescence(
+            str(epic), "", "", env_overrides=env_overrides,
+        )
+        py_pair = _py_quiescence(
+            str(epic), env_overrides=env_overrides,
+        )
+        _assert_parity(bash_pair, py_pair)
+        bash_rc, bash_stderr = bash_pair
+        assert bash_rc == 1
+        # Env-supplied 1 must surface in the stderr; if the env had been
+        # ignored (defaults of 30/5), the stderr would say "after 30s".
+        assert "after 1s" in bash_stderr
+        assert "after 30s" not in bash_stderr
+    finally:
+        stop.set()
+        writer.join(timeout=1)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# (g) bash_defaults — pin the bash function's hardcoded default literals to
+#     30 (max_wait) and 5 (stable_window). Mechanical inspection via
+#     ``declare -f`` so the test does NOT burn real wall-clock time waiting
+#     on the production defaults.
+# ─────────────────────────────────────────────────────────────────────────────
+def test_bash_defaults_pinned():
+    _which_bash()
+    src = f'source "{SH}"; declare -f mo_wait_for_worker_quiescence'
+    r = subprocess.run(
+        ["bash", "-c", src], env=_clean_env(),
+        capture_output=True, text=True, check=True,
+    )
+    body = r.stdout
+    assert "MO_WORKTREE_GUARD_MAX_WAIT_S:-30" in body, body
+    assert "MO_WORKTREE_GUARD_STABLE_S:-5" in body, body


### PR DESCRIPTION
2 autonomous ports, live-bash parity tests (17 cases). Strangler-fig.