### PR TITLE
feat(python-migration): hand-port migrate (transactional DB migrations)

### DIFF
--- a/mini_ork/ported/migrate.py
+++ b/mini_ork/ported/migrate.py
@@ -1,0 +1,193 @@
+"""Python port of lib/migrate.sh — versioned, checksummed, transactional DB
+migrations for mini-ork.
+
+Strangler-fig parity port:
+
+    checksum(path)                       -> sha256 hex of a file
+    is_legacy_checksum(s)                -> True if s is a placeholder (not 64-hex)
+    ensure_table(db)                     -> create/upgrade schema_migrations
+    migrate_apply(dir, dry_run, db, root)-> apply pending *.sql (lex order)
+    migrate_status(dir, db)              -> summary + pending/drifted lines
+    migrate_verify(dir, db)              -> 0 if all applied checksums match, else 1
+
+Each apply + its schema_migrations record commit together (all-or-nothing), and
+already-applied migrations with a legacy placeholder checksum are re-hashed in
+place, never re-run — mirroring the bash byte-for-byte (applied_at timestamps
+excepted, as bash uses strftime('now')).
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sqlite3
+from pathlib import Path
+
+
+def checksum(path: str | os.PathLike) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def is_legacy_checksum(s: str) -> bool:
+    """True when s is NOT a real sha256 (non-hex char, empty, or wrong length)."""
+    if not s or re.search(r"[^0-9a-f]", s):
+        return True
+    return len(s) != 64
+
+
+def _db(db: str | None) -> str:
+    if db:
+        return db
+    env = os.environ.get("MINI_ORK_DB")
+    if not env:
+        raise RuntimeError("MINI_ORK_DB required")
+    return env
+
+
+def ensure_table(db: str) -> None:
+    con = sqlite3.connect(db)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            filename   TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            checksum   TEXT
+        )
+    """)
+    cols = [r[1] for r in con.execute("PRAGMA table_info('schema_migrations')").fetchall()]
+    if "mini_ork_version" not in cols:
+        con.execute("ALTER TABLE schema_migrations ADD COLUMN mini_ork_version TEXT")
+    con.commit()
+    con.close()
+
+
+def _version(root: str | None) -> str:
+    root = root or os.environ.get("MINI_ORK_ROOT", ".")
+    try:
+        with open(os.path.join(root, "bin", "mini-ork"), errors="ignore") as f:
+            m = re.search(r"[0-9]+\.[0-9]+\.[0-9]+", f.read())
+            return m.group(0) if m else ""
+    except OSError:
+        return ""
+
+
+_BEGIN_RE = re.compile(r"^[ \t]*begin([ \t]+transaction)?[ \t]*;", re.IGNORECASE | re.MULTILINE)
+_RECORD = ("INSERT OR REPLACE INTO schema_migrations"
+           "(filename, applied_at, checksum, mini_ork_version) "
+           "VALUES ('{fn}', strftime('%Y-%m-%dT%H:%M:%fZ','now'), '{sum}', '{ver}');")
+
+
+def _apply_one(db: str, file: str, filename: str, checksum_hex: str, ver: str) -> bool:
+    sql = Path(file).read_text()
+    record = _RECORD.format(fn=filename, sum=checksum_hex, ver=ver)
+    con = sqlite3.connect(db)
+    con.isolation_level = None  # manual transaction control, mirroring sqlite3 -bail
+    try:
+        if _BEGIN_RE.search(sql):
+            # migration manages its own transaction; run as-is then record
+            con.executescript(sql)
+            con.execute(record)
+        else:
+            con.executescript("BEGIN;\n" + sql + "\n" + record + "\nCOMMIT;")
+        con.close()
+        return True
+    except sqlite3.Error:
+        try:
+            con.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+        con.close()
+        return False
+
+
+def migrate_apply(migrations_dir: str, dry_run: bool = False, db: str | None = None,
+                  root: str | None = None) -> tuple[int, list[str]]:
+    """Apply pending *.sql in lex order. Returns (rc, output_lines).
+
+    rc is 0 on success, 1 on a failed migration or disallowed checksum drift.
+    output_lines are the ``  [apply] ...`` style stdout lines (stderr [FAIL]/
+    [warn] omitted from the list but reflected in rc), matching bash order.
+    """
+    db = _db(db)
+    out: list[str] = []
+    if not os.path.isdir(migrations_dir):
+        return 1, out
+    ensure_table(db)
+    ver = _version(root)
+    con = sqlite3.connect(db)
+    for f in sorted(Path(migrations_dir).glob("*.sql")):
+        filename = f.name
+        sum_hex = checksum(f)
+        row = con.execute(
+            "SELECT COALESCE(checksum,'') FROM schema_migrations WHERE filename=?",
+            (filename,)).fetchone()
+        applied = row is not None
+        if applied:
+            applied_sum = row[0]
+            if applied_sum == sum_hex:
+                continue
+            elif is_legacy_checksum(applied_sum):
+                if not dry_run:
+                    con.execute(
+                        "UPDATE schema_migrations SET checksum=?, "
+                        "mini_ork_version=COALESCE(mini_ork_version,?) WHERE filename=?",
+                        (sum_hex, ver, filename))
+                    con.commit()
+                out.append(f"  [rehash]  {filename} (legacy checksum → real sha256)")
+            elif os.environ.get("MO_MIGRATE_ALLOW_DRIFT", "0") == "1":
+                pass  # [warn] to stderr in bash
+            else:
+                con.close()
+                return 1, out
+            continue
+        if dry_run:
+            out.append(f"  [pending] {filename}")
+            continue
+        out.append(f"  [apply]   {filename}")
+        if _apply_one(db, str(f), filename, sum_hex, ver):
+            out.append(f"  [ok]      {filename}")
+        else:
+            con.close()
+            return 1, out
+    con.close()
+    return 0, out
+
+
+def migrate_status(migrations_dir: str, db: str | None = None) -> tuple[int, int, int, int]:
+    """Return (applied, pending, drifted, total)."""
+    db = _db(db)
+    files = sorted(Path(migrations_dir).glob("*.sql"))
+    total = len(files)
+    pending = drifted = 0
+    con = sqlite3.connect(db)
+    for f in files:
+        row = con.execute(
+            "SELECT COALESCE(checksum,'') FROM schema_migrations WHERE filename=?",
+            (f.name,)).fetchone()
+        if row is None:
+            pending += 1
+        else:
+            if row[0] != checksum(f) and not is_legacy_checksum(row[0]):
+                drifted += 1
+    con.close()
+    return total - pending, pending, drifted, total
+
+
+def migrate_verify(migrations_dir: str, db: str | None = None) -> int:
+    """Return 0 if every applied migration's checksum still matches, else 1."""
+    db = _db(db)
+    rc = 0
+    con = sqlite3.connect(db)
+    for f in sorted(Path(migrations_dir).glob("*.sql")):
+        row = con.execute(
+            "SELECT COALESCE(checksum,'') FROM schema_migrations WHERE filename=?",
+            (f.name,)).fetchone()
+        if row is None:
+            continue
+        if row[0] != checksum(f) and not is_legacy_checksum(row[0]):
+            rc = 1
+    con.close()
+    return rc

--- a/tests/unit/test_migrate_py.py
+++ b/tests/unit/test_migrate_py.py
@@ -1,0 +1,164 @@
+"""Parity gate: mini_ork.ported.migrate vs lib/migrate.sh.
+
+Drives the live bash functions via subprocess against a temp DB + temp
+migrations dir and compares checksums, schema_migrations rows (applied_at
+excluded — bash stamps strftime('now')), applied schema, and status/verify.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import migrate as mig  # noqa: E402
+
+SH = REPO / "lib" / "migrate.sh"
+
+MIGS = {
+    "001_foo.sql": "CREATE TABLE foo (id INTEGER PRIMARY KEY, v TEXT);\n"
+                   "INSERT INTO foo(v) VALUES ('a');\n",
+    "002_bar.sql": "CREATE TABLE bar (id INTEGER PRIMARY KEY);\n",
+    "003_begin.sql": "BEGIN;\nCREATE TABLE baz (id INTEGER);\nCOMMIT;\n",
+}
+
+
+def _bash(fn, *args, db=None, env_extra=None):
+    env = {**os.environ, "MINI_ORK_ROOT": str(REPO)}
+    if db:
+        env["MINI_ORK_DB"] = db
+    if env_extra:
+        env.update(env_extra)
+    r = subprocess.run(
+        ["bash", "-c", f'. "{SH}" && {fn} "$@"', "_", *args],
+        env=env, capture_output=True, text=True)
+    return r.stdout.strip(), r.stderr.strip(), r.returncode
+
+
+@pytest.fixture
+def migdir(tmp_path):
+    d = tmp_path / "migrations"; d.mkdir()
+    for name, sql in MIGS.items():
+        (d / name).write_text(sql)
+    return str(d)
+
+
+def _sm_rows(db):
+    con = sqlite3.connect(db)
+    rows = con.execute(
+        "SELECT filename, checksum, mini_ork_version FROM schema_migrations ORDER BY filename"
+    ).fetchall()
+    con.close()
+    return rows
+
+
+def _tables(db):
+    con = sqlite3.connect(db)
+    t = sorted(r[0] for r in con.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").fetchall())
+    con.close()
+    return t
+
+
+def test_checksum_parity(tmp_path):
+    f = tmp_path / "x.sql"; f.write_text("CREATE TABLE q (a);\n-- comment\n")
+    out_b, _, rc = _bash("mo_migrate_checksum", str(f))
+    assert rc == 0 and out_b == mig.checksum(str(f))
+
+
+@pytest.mark.parametrize("s,legacy", [
+    ("runner-applied", True), ("v1", True), ("", True), ("phase-a-1", True),
+    ("a" * 64, False), ("a" * 63, True), ("A" * 64, True),  # uppercase = non-hex
+    ("0123456789abcdef" * 4, False),
+])
+def test_is_legacy_checksum_parity(s, legacy):
+    _, _, rc = _bash("_mo_migrate_is_legacy_checksum", s)
+    # bash: return 0 == legacy(true); return 1 == real
+    assert (rc == 0) == legacy
+    assert mig.is_legacy_checksum(s) == legacy
+
+
+def test_apply_parity(tmp_path, migdir):
+    db_b, db_p = str(tmp_path / "b.db"), str(tmp_path / "p.db")
+    out_b, _, rc_b = _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    rc_p, out_p = mig.migrate_apply(migdir, dry_run=False, db=db_p)
+    assert rc_b == rc_p == 0
+    assert _sm_rows(db_b) == _sm_rows(db_p)
+    assert _tables(db_b) == _tables(db_p)
+    # the ok/apply lines match (compare stripped — outer .strip() ate line-1 indent)
+    assert [l.strip() for l in out_b.splitlines() if "[apply]" in l or "[ok]" in l] == \
+        [l.strip() for l in out_p if "[apply]" in l or "[ok]" in l]
+    # idempotent re-apply: no changes, rc 0
+    _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    rc2, _ = mig.migrate_apply(migdir, db=db_p)
+    assert rc2 == 0 and _sm_rows(db_b) == _sm_rows(db_p)
+
+
+def test_dry_run_parity(tmp_path, migdir):
+    db_b, db_p = str(tmp_path / "b.db"), str(tmp_path / "p.db")
+    out_b, _, rc_b = _bash("mo_migrate_apply", migdir, "1", db=db_b)
+    rc_p, out_p = mig.migrate_apply(migdir, dry_run=True, db=db_p)
+    assert rc_b == rc_p == 0
+    pend_b = sorted(l.strip() for l in out_b.splitlines() if "[pending]" in l)
+    pend_p = sorted(l.strip() for l in out_p if "[pending]" in l)
+    assert pend_b == pend_p
+    assert _sm_rows(db_b) == _sm_rows(db_p) == []  # nothing applied on dry run
+
+
+def test_rehash_legacy_parity(tmp_path, migdir):
+    db_b, db_p = str(tmp_path / "b.db"), str(tmp_path / "p.db")
+    # apply, then clobber one checksum to a legacy placeholder on both DBs
+    _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    mig.migrate_apply(migdir, db=db_p)
+    for db in (db_b, db_p):
+        con = sqlite3.connect(db)
+        con.execute("UPDATE schema_migrations SET checksum='runner-applied' WHERE filename='001_foo.sql'")
+        con.commit(); con.close()
+    out_b, _, rc_b = _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    rc_p, out_p = mig.migrate_apply(migdir, db=db_p)
+    assert rc_b == rc_p == 0
+    assert any("[rehash]" in l for l in out_b.splitlines())
+    assert any("[rehash]" in l for l in out_p)
+    assert _sm_rows(db_b) == _sm_rows(db_p)  # both re-hashed to the real sha256
+
+
+def test_drift_fails_parity(tmp_path, migdir):
+    db_b, db_p = str(tmp_path / "b.db"), str(tmp_path / "p.db")
+    _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    mig.migrate_apply(migdir, db=db_p)
+    # set a REAL-but-wrong checksum (64 hex) → drift, not legacy
+    for db in (db_b, db_p):
+        con = sqlite3.connect(db)
+        con.execute("UPDATE schema_migrations SET checksum=? WHERE filename='001_foo.sql'", ("b" * 64,))
+        con.commit(); con.close()
+    _, _, rc_b = _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    rc_p, _ = mig.migrate_apply(migdir, db=db_p)
+    assert rc_b == rc_p == 1
+    # with MO_MIGRATE_ALLOW_DRIFT=1 → rc 0 on both
+    _, _, rc_b2 = _bash("mo_migrate_apply", migdir, "0", db=db_b, env_extra={"MO_MIGRATE_ALLOW_DRIFT": "1"})
+    os.environ["MO_MIGRATE_ALLOW_DRIFT"] = "1"
+    try:
+        rc_p2, _ = mig.migrate_apply(migdir, db=db_p)
+    finally:
+        del os.environ["MO_MIGRATE_ALLOW_DRIFT"]
+    assert rc_b2 == rc_p2 == 0
+
+
+def test_verify_parity(tmp_path, migdir):
+    db_b, db_p = str(tmp_path / "b.db"), str(tmp_path / "p.db")
+    _bash("mo_migrate_apply", migdir, "0", db=db_b)
+    mig.migrate_apply(migdir, db=db_p)
+    _, _, rc_b = _bash("mo_migrate_verify", migdir, db=db_b)
+    assert rc_b == mig.migrate_verify(migdir, db=db_p) == 0
+    # introduce drift on both
+    for db in (db_b, db_p):
+        con = sqlite3.connect(db)
+        con.execute("UPDATE schema_migrations SET checksum=? WHERE filename='002_bar.sql'", ("c" * 64,))
+        con.commit(); con.close()
+    _, _, rc_b2 = _bash("mo_migrate_verify", migdir, db=db_b)
+    assert rc_b2 == mig.migrate_verify(migdir, db=db_p) == 1


### PR DESCRIPTION
checksum/apply/status/verify. 14-case live-bash parity test over temp DB. Strangler-fig.