### PR TITLE
fix(proof-integrity): outcome-gate process_reward (Goodhart fix)

### DIFF
--- a/lib/process_reward.sh
+++ b/lib/process_reward.sh
@@ -97,7 +97,7 @@ def _len_json(s):
 #   ACTIVITY_CAP   = 0.15   # MO_PRM_ACTIVITY_CAP=1 (default): clamp W_TOOL+W_FILE
 #                           # MO_PRM_ACTIVITY_CAP=0 (legacy): no clamp, activity can dominate
 W_STATUS, W_TOOL, W_FILE, W_VERDICT, W_DURATION, W_COST, ACTIVITY_CAP = \
-    0.40, 0.20, 0.10, 0.15, 0.10, 0.05, 0.15
+    0.50, 0.10, 0.05, 0.30, 0.05, 0.00, 0.15
 try:
     _activity_cap_enabled = int(os.environ.get("MO_PRM_ACTIVITY_CAP", "1")) != 0
 except ValueError:
@@ -105,28 +105,23 @@ except ValueError:
 
 score = 0.0
 status_success = (r["status"] or "") == "success"
+# Goodhart fix: activity, timeliness, and verdict credit apply ONLY on success.
+# A busy/timely FAILURE earns nothing (was ~0.25 from activity+duration) — this
+# sharpens the success/failure separation the GRPO advantage learns from.
 if status_success:
     score += W_STATUS
-tool_n = _len_json(r["tool_calls"])
-file_n = _len_json(r["files_written"]) + _len_json(r["files_read"])
-activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
-# Goodhart guard: cap combined activity contribution so noisy failed work
-# cannot outscore bare success. Legacy uncapped behavior is opt-in via
-# MO_PRM_ACTIVITY_CAP=0.
-if _activity_cap_enabled:
-    activity = min(activity, ACTIVITY_CAP)
-score += activity
-v = (r["reviewer_verdict"] or "").lower()
-# Verdict term GATED on status==success. A failed trace cannot be lifted
-# by an approving judge. Same-family decontamination has been removed
-# pending a real reviewer_model column.
-if status_success and v in {"approve", "approved", "pass", "success", "ok"}:
-    score += W_VERDICT
-dur = int(r["duration_ms"] or 0)
-if 1000 <= dur <= 600000:
-    score += W_DURATION
-if float(r["cost_usd"] or 0) > 0:
-    score += W_COST
+    tool_n = _len_json(r["tool_calls"])
+    file_n = _len_json(r["files_written"]) + _len_json(r["files_read"])
+    activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
+    if _activity_cap_enabled:
+        activity = min(activity, ACTIVITY_CAP)
+    score += activity
+    v = (r["reviewer_verdict"] or "").lower()
+    if v in {"approve", "approved", "pass", "success", "ok"}:
+        score += W_VERDICT
+    dur = int(r["duration_ms"] or 0)
+    if 1000 <= dur <= 600000:
+        score += W_DURATION
 
 score = round(min(1.0, max(0.0, score)), 4)
 con.execute("UPDATE execution_traces SET process_reward=? WHERE trace_id=?",
@@ -186,7 +181,7 @@ def _len_json(s):
 #   ACTIVITY_CAP   = 0.15   # MO_PRM_ACTIVITY_CAP=1 (default): clamp W_TOOL+W_FILE
 #                           # MO_PRM_ACTIVITY_CAP=0 (legacy): no clamp, activity can dominate
 W_STATUS, W_TOOL, W_FILE, W_VERDICT, W_DURATION, W_COST, ACTIVITY_CAP = \
-    0.40, 0.20, 0.10, 0.15, 0.10, 0.05, 0.15
+    0.50, 0.10, 0.05, 0.30, 0.05, 0.00, 0.15
 try:
     _activity_cap_enabled = int(os.environ.get("MO_PRM_ACTIVITY_CAP", "1")) != 0
 except ValueError:
@@ -196,29 +191,23 @@ scored = 0
 for r in rows:
     score = 0.0
     status_success = (r["status"] or "") == "success"
+    # Goodhart fix (mirror of prm_score_trace): activity/timeliness/verdict credit
+    # ONLY on success; a busy FAILURE scores 0. Keep identical to the single-trace
+    # copy or single vs bulk process_reward diverge.
     if status_success:
         score += W_STATUS
-    tool_n = _len_json(r["tool_calls"])
-    file_n = _len_json(r["files_written"]) + _len_json(r["files_read"])
-    activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
-    # Goodhart guard: cap combined activity contribution so noisy failed work
-    # cannot outscore bare success. Legacy uncapped behavior is opt-in via
-    # MO_PRM_ACTIVITY_CAP=0.
-    if _activity_cap_enabled:
-        activity = min(activity, ACTIVITY_CAP)
-    score += activity
-    v = (r["reviewer_verdict"] or "").lower()
-    # Verdict term GATED on status==success. Identical to prm_score_trace;
-    # do not drift these two copies or process_reward will diverge between
-    # single-trace and bulk paths. Same-family decontamination has been
-    # removed pending a real reviewer_model column.
-    if status_success and v in {"approve", "approved", "pass", "success", "ok"}:
-        score += W_VERDICT
-    dur = int(r["duration_ms"] or 0)
-    if 1000 <= dur <= 600000:
-        score += W_DURATION
-    if float(r["cost_usd"] or 0) > 0:
-        score += W_COST
+        tool_n = _len_json(r["tool_calls"])
+        file_n = _len_json(r["files_written"]) + _len_json(r["files_read"])
+        activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
+        if _activity_cap_enabled:
+            activity = min(activity, ACTIVITY_CAP)
+        score += activity
+        v = (r["reviewer_verdict"] or "").lower()
+        if v in {"approve", "approved", "pass", "success", "ok"}:
+            score += W_VERDICT
+        dur = int(r["duration_ms"] or 0)
+        if 1000 <= dur <= 600000:
+            score += W_DURATION
     score = round(min(1.0, max(0.0, score)), 4)
     con.execute("UPDATE execution_traces SET process_reward=? WHERE trace_id=?",
                 (score, r["trace_id"]))

--- a/mini_ork/learning/process_reward.py
+++ b/mini_ork/learning/process_reward.py
@@ -10,23 +10,26 @@ function and compares scores within ``1e-6``.
 Weight table (mirrors ``prm_score_trace`` and ``prm_backfill`` verbatim —
 do not edit one without the other):
 
+OUTCOME-GATED (proof-integrity Goodhart fix): every term below applies ONLY
+when ``status == "success"``. A FAILED trace scores 0 regardless of activity.
+
 ================  ======  ==================================================
-Signal            Weight  Trigger
+Signal            Weight  Trigger (all require status == success)
 ================  ======  ==================================================
-status            0.40    ``trace["status"] == "success"``
-tool_calls        0.20    ``len(json.loads(tool_calls)) > 0``     [capped]
-files_read/written 0.10   ``len(json.loads(...)) > 0``           [capped]
-reviewer_verdict  0.15    lower-cased verdict in {approve, approved,
-                           pass, success, ok} AND status == success
-duration_ms       0.10    ``1000 <= duration_ms <= 600000``
-cost_usd          0.05    ``cost_usd > 0``
+status            0.50    ``trace["status"] == "success"``
+reviewer_verdict  0.30    verdict in {approve, approved, pass, success, ok}
+tool_calls        0.10    ``len(json.loads(tool_calls)) > 0``     [capped]
+files_read/written 0.05   ``len(json.loads(...)) > 0``           [capped]
+duration_ms       0.05    ``1000 <= duration_ms <= 600000``
+cost_usd          0.00    RETIRED (rewarded cost>0 — near-constant, off-thesis)
 ================  ======  ==================================================
 
-Activity cap (Goodhart guard): combined ``tool_calls + files_read +
-files_written`` contribution is clamped at ``ACTIVITY_CAP=0.15`` by default
-so a noisy failed trace with high activity cannot outscore a bare-success
-trace. Set ``MO_PRM_ACTIVITY_CAP=0`` to reproduce the legacy uncapped
-weighting for A/B comparison.
+So outcome + independent review carry 0.80; activity/timeliness are a small
+success-only bonus (combined activity clamped at ``ACTIVITY_CAP=0.15``). A bare
+success = 0.50; a fully-approved active timely success = 1.00; any failure = 0.
+This sharpens the success/failure separation the GRPO group-relative advantage
+learns from (was: busy failures scored ~0.25). ``MO_PRM_ACTIVITY_CAP=0`` still
+disables the activity clamp for A/B comparison.
 
 Same-family decontamination is INTENTIONALLY ABSENT: the doer's lane is
 not a valid proxy for the reviewer's lane without a real ``reviewer_model``
@@ -52,12 +55,15 @@ from __future__ import annotations
 import json
 import os
 
-W_STATUS = 0.40
-W_TOOL = 0.20
-W_FILE = 0.10
-W_VERDICT = 0.15
-W_DURATION = 0.10
-W_COST = 0.05
+# Outcome-dominant weights (proof-integrity Goodhart fix). Outcome (status) +
+# independent review (verdict) carry 0.80; activity/timeliness are a small
+# SUCCESS-ONLY bonus. A FAILED node scores 0 regardless of how busy it was.
+W_STATUS = 0.50
+W_TOOL = 0.10
+W_FILE = 0.05
+W_VERDICT = 0.30
+W_DURATION = 0.05
+W_COST = 0.00      # retired: rewarded cost>0 (near-constant, off-thesis)
 ACTIVITY_CAP = 0.15
 
 _VERDICT_SET = {"approve", "approved", "pass", "success", "ok"}
@@ -100,26 +106,27 @@ def score_trace(trace: dict) -> float:
     """
     score = 0.0
     status_success = (trace.get("status") or "") == "success"
+    # Goodhart fix: activity, timeliness, and verdict credit apply ONLY when the
+    # node actually succeeded. A busy/timely FAILURE earns nothing — failures
+    # score 0, sharpening the success/failure separation the GRPO group-relative
+    # advantage learns from (was: failed-but-busy scored ~0.25 from activity).
     if status_success:
         score += W_STATUS
 
-    tool_n = _len_json(trace.get("tool_calls"))
-    file_n = _len_json(trace.get("files_written")) + _len_json(trace.get("files_read"))
-    activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
-    if _activity_cap_enabled():
-        activity = min(activity, ACTIVITY_CAP)
-    score += activity
+        tool_n = _len_json(trace.get("tool_calls"))
+        file_n = _len_json(trace.get("files_written")) + _len_json(trace.get("files_read"))
+        activity = (W_TOOL if tool_n > 0 else 0.0) + (W_FILE if file_n > 0 else 0.0)
+        if _activity_cap_enabled():
+            activity = min(activity, ACTIVITY_CAP)
+        score += activity
 
-    verdict_lower = (trace.get("reviewer_verdict") or "").lower()
-    if status_success and verdict_lower in _VERDICT_SET:
-        score += W_VERDICT
+        verdict_lower = (trace.get("reviewer_verdict") or "").lower()
+        if verdict_lower in _VERDICT_SET:
+            score += W_VERDICT
 
-    dur = int(trace.get("duration_ms") or 0)
-    if 1000 <= dur <= 600000:
-        score += W_DURATION
-
-    if float(trace.get("cost_usd") or 0) > 0:
-        score += W_COST
+        dur = int(trace.get("duration_ms") or 0)
+        if 1000 <= dur <= 600000:
+            score += W_DURATION
 
     return round(min(1.0, max(0.0, score)), 4)
 

--- a/tests/unit/test_process_reward_goodhart.py
+++ b/tests/unit/test_process_reward_goodhart.py
@@ -1,0 +1,55 @@
+"""Goodhart-guard for the outcome-gated process_reward (proof-integrity).
+
+Before: activity (tool_calls>0, files>0) + duration were added even to FAILED
+traces, so a busy/timely failure scored ~0.25 — muddying the success/failure
+signal the GRPO group-relative advantage learns from. After: all activity/
+timeliness/verdict credit is gated on status=='success'; failures score 0.
+
+These assertions FAIL if activity ever leaks reward back into a failed trace.
+"""
+from __future__ import annotations
+
+import json
+
+from mini_ork.learning.process_reward import score_trace
+
+
+def _t(status, *, tool=0, files=0, dur=30000, verdict="", cost=0.01):
+    return {
+        "status": status,
+        "tool_calls": json.dumps([{}] * tool),
+        "files_written": json.dumps([{}] * files),
+        "files_read": "[]",
+        "duration_ms": dur,
+        "reviewer_verdict": verdict,
+        "cost_usd": cost,
+    }
+
+
+def test_busy_failure_scores_zero():
+    # a FAILED trace that made 5 tool calls, wrote 3 files, ran a reasonable time,
+    # and even drew an (erroneous) approve — earns NOTHING. This is the fix.
+    assert score_trace(_t("failed", tool=5, files=3, dur=30000, verdict="approve")) == 0.0
+
+
+def test_bare_success_beats_busiest_failure():
+    bare_success = score_trace(_t("success", tool=0, files=0, dur=0))
+    busiest_failure = score_trace(_t("failed", tool=99, files=99, dur=30000, verdict="approve"))
+    assert bare_success == 0.50           # exactly W_STATUS — no activity/cost bonus
+    assert busiest_failure == 0.0
+    assert bare_success > busiest_failure  # the separation the old reward blurred
+
+
+def test_success_gradient_is_outcome_dominant():
+    bare = score_trace(_t("success", tool=0, files=0, dur=0))
+    active = score_trace(_t("success", tool=3, files=2, dur=30000))
+    approved = score_trace(_t("success", tool=3, files=2, dur=30000, verdict="approve"))
+    assert bare == 0.50
+    assert active == 0.70                  # + capped activity(0.15) + duration(0.05)
+    assert approved == 1.00                # + verdict(0.30)
+    assert bare < active < approved <= 1.0
+
+
+def test_cost_is_no_longer_rewarded():
+    # cost>0 must contribute nothing (retired term) — a bare success is exactly 0.50
+    assert score_trace(_t("success", tool=0, files=0, dur=0, cost=5.0)) == 0.50


### PR DESCRIPTION
Activity/timeliness/verdict credit now gated on status=='success' — a busy FAILURE scores 0 (was ~0.25). Outcome-dominant re-weight (status 0.50 + verdict 0.30). cost>0 retired. bash+python mirrored, parity 15/15, Goodhart-guard 4/4.