### PR TITLE
fix(scheduler): dep cascade via epic_graph.on_done

### DIFF
--- a/mini_ork/ported/mini_ork_scheduler.py
+++ b/mini_ork/ported/mini_ork_scheduler.py
@@ -127,7 +127,7 @@ def dispatch_epic(db, epic_id, root, home, recipe, dry_run) -> int:
                     pass
     if verdict in ("pass", "success"):
         c.execute("UPDATE epics SET status='done' WHERE id=?", (epic_id,)); c.commit(); c.close()
-        epic_graph.epic_graph_on_done(epic_id, db=db) if hasattr(epic_graph, "epic_graph_on_done") else None
+        epic_graph.on_done(epic_id, db=db)   # cascade dep resolution (bash: epic_graph_on_done)
     else:
         c.execute("UPDATE epics SET status='escalated' WHERE id=?", (epic_id,)); c.commit(); c.close()
     return rc


### PR DESCRIPTION
The hasattr guard used the bash name and no-op'd the cascade on real dispatch.