### PR TITLE
port(py): mini-ork-conductor meta-orchestrator

### DIFF
--- a/mini_ork/ported/mini_ork_conductor.py
+++ b/mini_ork/ported/mini_ork_conductor.py
@@ -1,0 +1,186 @@
+"""Python port of bin/mini-ork-conductor — meta-orchestrator.
+
+Strangler-fig parity port. Per tick: pick the next ready epic (via ported
+epic_graph), decide topology + lane hints + prompt/plasticity gates from the
+learning tables (Mass win-rate + InfraMind budget-bias + GRPO lane advantage),
+log to conductor_decisions, then dispatch via the scheduler. The decision block
+is transcribed verbatim from the bash's embedded python.
+
+    decide_for_epic(db, epic_id, spent, cap, plasticity) -> dict
+    main(argv=None, *, db=None, root=None) -> int
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+
+from . import epic_graph
+
+
+def _today_cost(db):
+    c = sqlite3.connect(db)
+    r = c.execute("SELECT COALESCE(SUM(cost_usd),0) FROM task_runs "
+                  "WHERE created_at >= strftime('%s','now','-24 hours')").fetchone()
+    c.close()
+    return float(r[0] or 0)
+
+
+def decide_for_epic(db, epic_id, spent, cap, plast_budget) -> dict:
+    budget_pct = (spent / cap) if cap > 0 else 0.0
+    con = sqlite3.connect(db); con.execute("PRAGMA busy_timeout=5000"); con.row_factory = sqlite3.Row
+    epic = con.execute("SELECT id, title, kickoff_path FROM epics WHERE id=?", (epic_id,)).fetchone()
+    if not epic:
+        con.close(); return {"error": "epic_not_found", "epic_id": epic_id}
+
+    task_class = "framework_edit"
+    try:
+        tc = con.execute("SELECT task_class FROM task_runs WHERE kickoff_path=? "
+                         "ORDER BY created_at DESC LIMIT 1", (epic["kickoff_path"] or "",)).fetchone()
+        if tc and tc["task_class"]:
+            task_class = tc["task_class"]
+    except sqlite3.OperationalError:
+        pass
+
+    topology, topology_rationale = None, ""
+    try:
+        if budget_pct > 0.70:
+            rows = con.execute("""
+                SELECT t.topology_id, t.workflow_name, t.win_rate, t.sample_size, t.avg_cost_usd,
+                       COALESCE(wm.status,'unknown') AS wf_status
+                  FROM topology_win_rates t LEFT JOIN workflow_memory wm ON wm.yaml_hash = t.topology_id
+                 WHERE t.task_class=? AND t.sample_size >= 3
+                   AND (wm.status IS NULL OR wm.status IN ('promoted','shadow'))
+                 ORDER BY t.avg_cost_usd ASC, t.win_rate DESC LIMIT 1""", (task_class,)).fetchone()
+            topology_rationale = f"budget pressure {budget_pct:.0%} > 70%; biasing toward lowest avg_cost (InfraMind 2606.11440)."
+        else:
+            rows = con.execute("""
+                SELECT t.topology_id, t.workflow_name, t.win_rate, t.sample_size, t.avg_cost_usd,
+                       COALESCE(wm.status,'unknown') AS wf_status
+                  FROM topology_win_rates t LEFT JOIN workflow_memory wm ON wm.yaml_hash = t.topology_id
+                 WHERE t.task_class=? AND t.sample_size >= 3
+                   AND (wm.status IS NULL OR wm.status IN ('promoted','shadow'))
+                 ORDER BY t.win_rate DESC, t.sample_size DESC LIMIT 1""", (task_class,)).fetchone()
+            topology_rationale = "highest win_rate with sample_size >= 3, stability-anchored (Mass 2502.02533 + workflow_memory.status filter)."
+        if rows:
+            topology = {"topology_id": rows["topology_id"],
+                        "workflow_name": rows["workflow_name"] or task_class.replace("_", "-"),
+                        "win_rate": rows["win_rate"], "sample_size": rows["sample_size"]}
+    except sqlite3.OperationalError:
+        pass
+
+    lane_hints = {}
+    try:
+        for node_type in ("planner", "researcher", "reviewer", "implementer", "verifier"):
+            r = con.execute("""
+                SELECT agent_version_id, relative_advantage FROM agent_performance_memory
+                 WHERE task_class=? AND runs_count >= 3 AND (role=? OR model=?)
+                 ORDER BY relative_advantage DESC, runs_count DESC LIMIT 1""",
+                            (task_class, node_type, node_type)).fetchone()
+            if r and r["relative_advantage"] > 0:
+                lane_hints[node_type] = r["agent_version_id"]
+    except sqlite3.OperationalError:
+        pass
+
+    op = con.execute("SELECT COUNT(*) AS n FROM role_evolver_log WHERE status='open' "
+                     "AND (target_recipe=? OR target_recipe='*')",
+                     ((topology or {}).get("workflow_name") or "*",)).fetchone()
+    open_proposals_n = op["n"] if op else 0
+    mut_today = con.execute("SELECT COUNT(*) AS n FROM role_evolver_log "
+                            "WHERE applied_at >= strftime('%s','now','-24 hours')").fetchone()["n"]
+    plasticity_remaining = max(0, plast_budget - mut_today)
+
+    predicted = (topology or {}).get("win_rate", 0.5) or 0.5
+    lane_adv_sum = 0.0
+    try:
+        if lane_hints:
+            placeholders = ",".join(["?"] * len(lane_hints))
+            for r in con.execute(f"""SELECT agent_version_id, relative_advantage
+                    FROM agent_performance_memory WHERE task_class=? AND agent_version_id IN ({placeholders})""",
+                                 (task_class, *lane_hints.values())).fetchall():
+                if r["relative_advantage"] > 0:
+                    lane_adv_sum += r["relative_advantage"]
+    except sqlite3.OperationalError:
+        pass
+    predicted = min(1.0, predicted * (1.0 + lane_adv_sum * 0.3))
+    con.close()
+    return {"epic_id": epic_id, "task_class": task_class, "topology": topology,
+            "lane_hints": lane_hints, "open_role_proposals": open_proposals_n,
+            "plasticity_remaining": plasticity_remaining, "predicted_score": round(predicted, 4),
+            "budget_pct_used": round(budget_pct, 4), "topology_rationale": topology_rationale}
+
+
+def log_decision(db, dec):
+    con = sqlite3.connect(db); con.execute("PRAGMA busy_timeout=5000")
+    con.execute("""INSERT INTO conductor_decisions
+        (decided_at, epic_id, task_class, chosen_topology, chosen_recipe, chosen_lane_hints,
+         predicted_score, budget_pct_used, rationale, outcome)
+        VALUES (?,?,?,?,?,?,?,?,?,'pending')""",
+        (int(time.time()), dec.get("epic_id"), dec.get("task_class"),
+         (dec.get("topology") or {}).get("topology_id"),
+         (dec.get("topology") or {}).get("workflow_name"),
+         json.dumps(dec.get("lane_hints") or {}),
+         float(dec.get("predicted_score") or 0.0), float(dec.get("budget_pct_used") or 0.0),
+         dec.get("topology_rationale", "")[:600]))
+    con.commit(); con.close()
+
+
+def main(argv: list[str] | None = None, *, db: str | None = None, root: str | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    root = root or os.environ.get("MINI_ORK_ROOT") or os.getcwd()
+    home = os.environ.get("MINI_ORK_HOME") or os.path.join(root, ".mini-ork")
+    db = db or os.environ.get("MINI_ORK_DB") or os.path.join(home, "state.db")
+    cap = float(os.environ.get("MO_DAILY_BUDGET_USD", "50.0"))
+    plast = int(os.environ.get("MO_PLASTICITY_BUDGET", "5"))
+    once = max_iters = idle = dry_run = explain = 0
+    idle = 60
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--once": once = 1; i += 1
+        elif a == "--max-iters": max_iters = int(argv[i + 1]); i += 2
+        elif a == "--idle-secs": idle = int(argv[i + 1]); i += 2
+        elif a == "--dry-run": dry_run = 1; i += 1
+        elif a == "--explain": explain = 1; i += 1
+        elif a in ("--help", "-h"):
+            sys.stdout.write("mini-ork conductor — meta-orchestrator.\n"); return 0
+        else:
+            sys.stderr.write(f"conductor: unknown flag {a}\n"); return 2
+
+    it = 0
+    while True:
+        spent = _today_cost(db)
+        ready = epic_graph.ready_now(db) if hasattr(epic_graph, "ready_now") else []
+        nxt = (ready or [None])[0]
+        if not nxt:
+            # bash: _tick returns 2 on empty queue; sourced-lib errexit aborts the
+            # whole script with 2 before the --once/idle checks can run.
+            sys.stdout.write("conductor: queue empty\n"); return 2
+        dec = decide_for_epic(db, nxt, spent, cap, plast)
+        if explain or dry_run:
+            sys.stdout.write(f"conductor: decision for {nxt}:\n")
+            sys.stdout.write("  " + json.dumps(dec, indent=4).replace("\n", "\n  ") + "\n")
+        else:
+            recipe = (dec.get("topology") or {}).get("workflow_name", "") or ""
+            sys.stdout.write(f"conductor: chose recipe={recipe} for {nxt} spent=${spent}\n")
+        log_decision(db, dec)
+        if not dry_run:
+            recipe = (dec.get("topology") or {}).get("workflow_name", "") or ""
+            env = {**os.environ}
+            if recipe:
+                env["MO_SCHED_RECIPE"] = recipe
+                env["MO_CONDUCTOR_LANE_HINTS"] = json.dumps(dec.get("lane_hints", {}))
+            subprocess.run([os.path.join(root, "bin", "mini-ork-scheduler"),
+                            "--once", "--max-iters", "1"], env=env)
+        it += 1
+        if once:
+            return 0
+        if max_iters > 0 and it >= max_iters:
+            sys.stdout.write(f"conductor: max-iters {max_iters} reached\n"); return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mini_ork/ported/mini_ork_traceotter.py
+++ b/mini_ork/ported/mini_ork_traceotter.py
@@ -1,0 +1,112 @@
+"""Python port of bin/mini-ork-traceotter — distill this repo's own run
+trajectories with TraceOtter and surface grounded values.
+
+Strangler-fig parity port of the thin integration wrapper. Resolves the
+TraceOtter venv, runs the distill pipeline (subprocess into TraceOtter's own
+env — it is a separate package), then renders analytics / skills / dataset. The
+render functions read the produced OUT dir and are transcribed verbatim from the
+bash so they're testable against a fixture without a live distill.
+
+    main(argv=None) -> int   # 0 ok / 1 distill-fail / 2 not-configured
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+
+
+def _bar():
+    return "─" * 60
+
+
+def render_analytics(out: str, runs: str) -> str:
+    eps = [json.loads(l) for l in open(f"{out}/episodes.jsonl")]
+    rep = json.load(open(f"{out}/report.json"))
+    n = len(eps)
+    cost = sum(e["outcome"].get("costUsd", 0) for e in eps)
+    tc = sum(e["outcome"].get("toolCalls", 0) for e in eps)
+    te = sum(e["outcome"].get("toolErrors", 0) for e in eps)
+    st = Counter(e["outcome"]["status"] for e in eps)
+    tp = Counter(str(e["outcome"]["testsPassed"]) for e in eps)
+    imit = sum(1 for e in eps if e["labels"].get("shouldImitate"))
+    ps = [e["labels"]["processScore"] for e in eps]
+    avg = (sum(ps) / len(ps)) if ps else 0
+    bar = _bar()
+    lines = [
+        bar,
+        f" mini-ork ⟶ TraceOtter   ({n} run trajectories distilled)",
+        bar,
+        f" real cost         ${cost:,.2f}   (mean ${cost/n if n else 0:.3f}/run)",
+        f" tool reliability  {100*(1-te/tc) if tc else 0:.1f}%  ({tc:,} calls, {te:,} errors)",
+        f" outcome           completed {st.get('completed',0)} · partial {st.get('partial',0)} · failed {st.get('failed',0)}",
+        f" tests (parsed)    passed {tp.get('True',0)} · failed {tp.get('False',0)} · none {tp.get('None',0)}",
+        f" process_score     mean {avg:.3f}  (grounded: tool-reliability + grounding + no-fail)",
+        bar,
+        f" distilled skills  {rep['skills']}",
+        f" SFT-ready         {rep['llamafactory']['examples']} examples  (→ train a local lane)",
+        f" clean-imitate     {imit}  (would-imitate: clean completions worth training on)",
+        bar,
+        " next:  mini-ork traceotter skills   |   mini-ork traceotter dataset",
+        f" data:  {out}/  (episodes, skills, quality report, llamafactory/)",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_skills(out: str) -> str:
+    s = json.load(open(f"{out}/skills.json"))
+    lines = [f"# {len(s)} distilled skills (recurring procedures mined from your runs)", ""]
+    for x in sorted(s, key=lambda k: -(k.get("support") or len(k.get("sourceEpisodeIds", []))))[:20]:
+        n = x.get("support") or len(x.get("sourceEpisodeIds", []))
+        proc = " → ".join(x.get("procedure", [])[:2])
+        lines.append(f"[{n:>4} eps] {x.get('skillId','?')}: {proc[:110]}")
+    return "\n".join(lines) + "\n"
+
+
+def render_dataset(out: str) -> str:
+    lf = json.load(open(f"{out}/report.json"))["llamafactory"]
+    return (f"SFT examples: {lf['examples']}\n"
+            f"dataset:      {lf['dataset']}\n"
+            f"train:        {lf['train_command']}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    to = os.environ.get("TRACEOTTER_HOME", "/Volumes/docker-ssd/ps/TraceOtter")
+    py = os.path.join(to, ".venv", "bin", "python")
+    home = os.environ.get("MINI_ORK_HOME") or os.path.join(os.getcwd(), ".mini-ork")
+    runs = os.path.join(home, "runs")
+    out = os.path.join(home, "traceotter")
+    mode = argv[0] if argv else "analytics"
+
+    if not (os.path.isfile(py) and os.access(py, os.X_OK)):
+        sys.stderr.write(f"[traceotter] not found at {to} (.venv). Set TRACEOTTER_HOME.\n"); return 2
+    if not os.path.isdir(runs):
+        sys.stderr.write(f"[traceotter] no runs at {runs} — run some mini-ork tasks first.\n"); return 2
+
+    src_args = ["--mini-ork", runs]
+    if mode == "--all":
+        src_args = ["--claude", os.path.expanduser("~/.claude/projects"), "--mini-ork", runs]
+        codex = os.path.expanduser("~/.codex/sessions")
+        if os.path.isdir(codex):
+            src_args += ["--codex", codex]
+        mode = "analytics"
+
+    sys.stderr.write(f"[traceotter] distilling {runs} → {out} ...\n")
+    if subprocess.run([py, "-m", "traceotter.cli", "--json", "pipeline", *src_args, "--out", out],
+                      stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0:
+        sys.stderr.write("[traceotter] distill failed\n"); return 1
+
+    if mode == "skills":
+        sys.stdout.write(render_skills(out))
+    elif mode == "dataset":
+        sys.stdout.write(render_dataset(out))
+    else:
+        sys.stdout.write(render_analytics(out, runs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_mini_ork_conductor_py.py
+++ b/tests/unit/test_mini_ork_conductor_py.py
@@ -1,0 +1,77 @@
+"""Parity gate: mini_ork.ported.mini_ork_conductor vs bin/mini-ork-conductor.
+
+Seed a ready epic + a topology_win_rate, run --once --dry-run through the LIVE
+bash conductor and the port on separate DBs, and compare the logged
+conductor_decisions row (decided_at excluded). Plus a unit check of the
+predicted-score / budget-bias branches.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mini_ork_conductor as cond  # noqa: E402
+
+BIN = REPO / "bin" / "mini-ork-conductor"
+
+
+def _sql(db, stmt):
+    return subprocess.run(["sqlite3", db, stmt], capture_output=True, text=True).stdout.strip()
+
+
+def _seed(tmp_path, name):
+    home = tmp_path / name / ".mini-ork"; home.mkdir(parents=True)
+    db = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": db},
+                   capture_output=True, text=True, check=True)
+    _sql(db, "INSERT INTO epics (id,title,status,kickoff_path) VALUES ('e1','E1','not started','k.md');")
+    _sql(db, "INSERT INTO task_runs (id,task_class,workflow_version,kickoff_path,status,created_at,updated_at) "
+             "VALUES ('r1','code_fix','latest','k.md','classified',strftime('%s','now'),strftime('%s','now'));")
+    _sql(db, "INSERT INTO topology_win_rates (topology_id,workflow_name,task_class,wins,losses,ties,"
+             "win_rate,sample_size,avg_cost_usd) VALUES ('topo-1','code-fix','code_fix',8,2,0,0.8,5,1.0);")
+    return str(home), db
+
+
+_DEC_COLS = ("epic_id,task_class,chosen_topology,chosen_recipe,chosen_lane_hints,"
+             "predicted_score,budget_pct_used,rationale,outcome")
+
+
+def test_decision_logged_parity(tmp_path):
+    hb, db_b = _seed(tmp_path, "b")
+    _, db_p = _seed(tmp_path, "p")
+    subprocess.run(["bash", str(BIN), "--once", "--dry-run"], capture_output=True, text=True,
+                   env={**os.environ, "MINI_ORK_ROOT": str(REPO), "MINI_ORK_HOME": hb, "MINI_ORK_DB": db_b})
+    cond.main(["--once", "--dry-run"], db=db_p, root=str(REPO))
+    q = f"SELECT {_DEC_COLS} FROM conductor_decisions"
+    rb, rp = _sql(db_b, q), _sql(db_p, q)
+    assert rb == rp and rb  # identical decision persisted
+    # sanity: chose topo-1 / code-fix, predicted 0.8 (no lane advantage available)
+    assert "topo-1" in rp and "code-fix" in rp and "0.8" in rp
+
+
+def test_decide_predicted_and_budget_bias(tmp_path):
+    _, db = _seed(tmp_path, "u")
+    # add a cheaper topology; under >70% budget the cheap one wins
+    _sql(db, "INSERT INTO topology_win_rates (topology_id,workflow_name,task_class,wins,losses,ties,"
+             "win_rate,sample_size,avg_cost_usd) VALUES ('topo-cheap','cheapo','code_fix',5,5,0,0.5,4,0.10);")
+    hi = cond.decide_for_epic(db, "e1", spent=0.0, cap=50.0, plast_budget=5)
+    assert hi["topology"]["topology_id"] == "topo-1"        # best win_rate when budget ok
+    assert hi["predicted_score"] == 0.8
+    lo = cond.decide_for_epic(db, "e1", spent=40.0, cap=50.0, plast_budget=5)  # 80% > 70%
+    assert lo["topology"]["topology_id"] == "topo-cheap"    # cheapest under pressure
+    assert "budget pressure" in lo["topology_rationale"]
+
+
+def test_empty_queue(tmp_path):
+    hb, db_b = _seed(tmp_path, "e")
+    _sql(db_b, "UPDATE epics SET status='done' WHERE id='e1';")   # nothing ready
+    rb = subprocess.run(["bash", str(BIN), "--once"], capture_output=True, text=True,
+                        env={**os.environ, "MINI_ORK_ROOT": str(REPO), "MINI_ORK_HOME": hb,
+                             "MINI_ORK_DB": db_b}).returncode
+    rp = cond.main(["--once"], db=db_b, root=str(REPO))
+    assert rb == rp == 2   # empty queue → _tick returns 2, sourced-lib errexit aborts

--- a/tests/unit/test_mini_ork_traceotter_py.py
+++ b/tests/unit/test_mini_ork_traceotter_py.py
@@ -1,0 +1,88 @@
+"""Parity gate: mini_ork.ported.mini_ork_traceotter vs bin/mini-ork-traceotter.
+
+The distill step needs the TraceOtter venv + real runs, so full render parity is
+an integration concern; here we compare the deterministic preflight exit codes
+vs live bash, and unit-check the render functions (transcribed verbatim) against
+a fixture OUT dir.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mini_ork_traceotter as tot  # noqa: E402
+
+BIN = REPO / "bin" / "mini-ork-traceotter"
+_REAL_PY = Path("/Volumes/docker-ssd/ps/TraceOtter/.venv/bin/python")
+
+
+def _bash(env_extra, mode=None):
+    env = {**os.environ, **env_extra}
+    args = ["bash", str(BIN)] + ([mode] if mode else [])
+    return subprocess.run(args, capture_output=True, text=True, env=env).returncode
+
+
+def test_missing_traceotter_venv_parity(tmp_path):
+    env = {"TRACEOTTER_HOME": str(tmp_path / "nope"), "MINI_ORK_HOME": str(tmp_path / ".mini-ork")}
+    rb = _bash(env)
+    old = dict(os.environ); os.environ.update(env)
+    try:
+        rp = tot.main([])
+    finally:
+        os.environ.clear(); os.environ.update(old)
+    assert rb == rp == 2
+
+
+def test_missing_runs_parity(tmp_path):
+    if not (_REAL_PY.is_file() and os.access(_REAL_PY, os.X_OK)):
+        import pytest
+        pytest.skip("TraceOtter venv not present")
+    home = tmp_path / ".mini-ork"; home.mkdir()   # no runs/ subdir
+    env = {"MINI_ORK_HOME": str(home)}             # default TRACEOTTER_HOME (real)
+    rb = _bash(env)
+    old = dict(os.environ); os.environ.update(env)
+    try:
+        rp = tot.main([])
+    finally:
+        os.environ.clear(); os.environ.update(old)
+    assert rb == rp == 2
+
+
+def _fixture_out(tmp_path):
+    out = tmp_path / "traceotter"; out.mkdir()
+    eps = [
+        {"outcome": {"status": "completed", "costUsd": 1.5, "toolCalls": 10, "toolErrors": 1,
+                     "testsPassed": True}, "labels": {"processScore": 0.6, "shouldImitate": True}},
+        {"outcome": {"status": "partial", "costUsd": 0.5, "toolCalls": 4, "toolErrors": 0,
+                     "testsPassed": None}, "labels": {"processScore": 0.4, "shouldImitate": False}},
+    ]
+    (out / "episodes.jsonl").write_text("\n".join(json.dumps(e) for e in eps))
+    (out / "report.json").write_text(json.dumps({"skills": 7,
+        "llamafactory": {"examples": "42", "dataset": "/d/ds.json", "train_command": "llamafactory-cli train x"}}))
+    (out / "skills.json").write_text(json.dumps([
+        {"skillId": "sk1", "support": 9, "procedure": ["do a", "then b"]},
+        {"skillId": "sk2", "sourceEpisodeIds": ["e1"], "procedure": ["x"]}]))
+    return str(out)
+
+
+def test_render_analytics_grounded(tmp_path):
+    out = _fixture_out(tmp_path)
+    s = tot.render_analytics(out, "runs")
+    assert "$2.00" in s                       # real cost sum, formatted
+    assert "92.9%" in s                       # tool reliability: 14 calls, 1 err → 100*(1-1/14)
+    assert "completed 1 · partial 1 · failed 0" in s
+    assert "distilled skills  7" in s and "42 examples" in s
+    assert "clean-imitate     1" in s         # one shouldImitate
+
+
+def test_render_skills_and_dataset(tmp_path):
+    out = _fixture_out(tmp_path)
+    sk = tot.render_skills(out)
+    assert "2 distilled skills" in sk and "sk1" in sk and "do a → then b" in sk
+    ds = tot.render_dataset(out)
+    assert "SFT examples: 42" in ds and "llamafactory-cli train x" in ds


### PR DESCRIPTION
Ports `bin/mini-ork-conductor` → `mini_ork/ported/mini_ork_conductor.py`. 6-table decision engine (topology+lane+plasticity+predicted-score) transcribed verbatim; conductor_decisions logging; tick/dispatch loop. Parity test: logged-decision row vs live bash, budget-bias branch, empty-queue exit. 3/3 pass.