### PR TITLE
port(py): bin/mini-ork entrypoint dispatcher

### DIFF
--- a/mini_ork/ported/mini_ork_cli.py
+++ b/mini_ork/ported/mini_ork_cli.py
@@ -1,0 +1,483 @@
+"""Python port of bin/mini-ork — the entrypoint / universal-loop dispatcher.
+
+Strangler-fig parity port. Simple subcommands delegate to bin/mini-ork-<sub>
+(still bash until ported); the `run` recipe-runner walks classify → profile →
+plan → execute → rubric → verify → reflect with deadline soft-gates between
+stages. The two embedded-python blocks (recipe resolution + run-profile
+generation) are transcribed verbatim so their output byte-matches the bash.
+
+    main(argv=None, *, root=None) -> int
+
+Note: bash uses `exec` for the simple subcommands (process replacement); this
+port uses subprocess with inherited stdio and returns the child's exit code —
+observationally identical (same stdout/stderr, same exit code).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+_EXEC_SUBS = {"classify", "plan", "execute", "verify", "reflect", "improve", "eval",
+              "promote", "init", "update", "spawn", "scheduler", "epics", "bugs",
+              "inject", "review", "traceotter", "metrics", "rollback", "resume", "serve"}
+
+_HELP = """mini-ork — task operating system for agents (v0.1)
+
+Universal loop subcommands:
+  classify <kickoff.md>          Route kickoff to a task_class
+  plan <kickoff.md>              Generate plan (decomposition + verifier contract)
+  execute [<plan.json>]          Dispatch to workflow nodes (planner/researcher/
+                                   implementer/reviewer/verifier/reflector/
+                                   publisher/rollback)
+  verify <artifact-path>         Run verifiers + gates for the artifact contract
+  reflect [--since <timestamp>]  Extract gradients + patterns from recent runs
+  improve                        Propose workflow candidates via group_evolver
+  eval --candidate <id>          Run benchmark suite against a workflow candidate
+  promote --candidate <id>       Promotion gate decision (promote|quarantine)
+
+Recipe runner:
+  run <kickoff.md>               Classify kickoff, resolve recipe, then walk
+                                   classify → plan → execute → verify
+  run <recipe-name> <kickoff.md> Force a recipe, then walk the same lifecycle
+
+Lifecycle:
+  init                           Bootstrap project (creates .mini-ork/)
+  update                         Apply migrations + report config drift
+  doctor                         Check deps + env vars + lib presence
+  version
+
+Environment:
+  MINI_ORK_HOME   project home dir  (default: .mini-ork/)
+  MINI_ORK_DB     sqlite3 state db  (default: $MINI_ORK_HOME/state.db)
+  MINI_ORK_DRY_RUN  set to 1 for dry-run mode on all subcommands
+"""
+
+
+def _bin(root, name):
+    return os.path.join(root, "bin", f"mini-ork-{name}")
+
+
+def resolve_recipe(root: str, task_class: str) -> str:
+    """Verbatim transcription of the user-first recipe-resolution python."""
+    import yaml
+    recipes = os.path.join(root, "recipes")
+    if os.path.isdir(recipes):
+        for name in sorted(os.listdir(recipes)):
+            tc = os.path.join(recipes, name, "task_class.yaml")
+            if not os.path.isfile(tc):
+                continue
+            try:
+                with open(tc) as f:
+                    data = yaml.safe_load(f) or {}
+            except Exception:
+                continue
+            if (data.get("name") or "").strip() == task_class:
+                return name
+    fallback = task_class.replace("_", "-")
+    if os.path.isdir(os.path.join(recipes, fallback)):
+        return fallback
+    return ""
+
+
+def gen_profile(kickoff_path, root, recipe, task_class, profile_path, agents_path) -> dict:
+    """Verbatim transcription of the run-profile embedded python. Writes the
+    profile.json and returns the same dict (caller prints the key=value lines)."""
+    root = Path(root)
+    kickoff = Path(kickoff_path)
+    profile = Path(profile_path)
+    text = kickoff.read_text(encoding="utf-8", errors="replace")
+
+    def section_lines(names):
+        wanted = {n.lower() for n in names}
+        current = None
+        lines = []
+        for raw in text.splitlines():
+            m = re.match(r"^\s*#{2,6}\s+(.+?)\s*$", raw)
+            if m:
+                title = m.group(1).strip().lower()
+                current = title if any(w in title for w in wanted) else None
+                continue
+            if current:
+                lines.append(raw.rstrip())
+        return [line for line in lines if line.strip()]
+
+    def bullets(lines):
+        items = []
+        for line in lines:
+            stripped = re.sub(r"^\s*[-*]\s*", "", line).strip()
+            if stripped:
+                items.append(stripped)
+        return items
+
+    def first_heading():
+        for line in text.splitlines():
+            m = re.match(r"^\s*#\s+(.+?)\s*$", line)
+            if m:
+                return m.group(1).strip()
+        return kickoff.stem.replace("-", " ").replace("_", " ")
+
+    def load_yaml(path):
+        try:
+            import yaml
+            with open(path, encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+        except Exception:
+            return {}
+
+    def command_hints():
+        patterns = [
+            r"\bpnpm\s+(?:test|run\s+test|type-check)\b[^\n`]*",
+            r"\bnpm\s+(?:test|run\s+test)\b[^\n`]*",
+            r"\bpytest\b[^\n`]*",
+            r"\bcargo\s+test\b[^\n`]*",
+            r"\bgo\s+test\b[^\n`]*",
+            r"\bbash\s+tests/[^\n`]+",
+            r"\bmake\s+(?:test|check|verify|smoke|probe|coverage|lint|ci)[A-Za-z0-9_.:-]*(?:\s+&&\s+make\s+[A-Za-z0-9_.:-]+)*[^\n`]*",
+            r"\bbash\s+recipes/[^\s`]+\.sh\b[^\n`]*",
+            r"\bbash\s+verifiers/[^\s`]+\.sh\b[^\n`]*",
+            r"\b\./verifiers/[^\s`]+\.sh\b[^\n`]*",
+            r"\bbin/mini-ork(?:-[a-z]+)?\s+(?:verify|run|classify|plan)\b[^\n`]*",
+        ]
+        found = []
+        for pattern in patterns:
+            found.extend(m.group(0).strip().rstrip(".") for m in re.finditer(pattern, text, re.I))
+        return list(dict.fromkeys(found))
+
+    success = bullets(section_lines(["success", "definition of done", "done when", "acceptance"]))
+    scope_allow = bullets(section_lines(["scope allow", "in scope", "scope"]))
+    scope_deny = bullets(section_lines(["scope deny", "out of scope", "forbidden"]))
+    commands = command_hints()
+
+    def _bullet_only(lines):
+        out = []
+        for line in lines:
+            m = re.match(r"^\s*[-*]\s+(.+?)\s*$", line)
+            if m:
+                out.append(m.group(1).strip())
+        return out
+    _explicit_verify = _bullet_only(section_lines([
+        "verification command", "verification commands", "proof of success"]))
+    for _c in _explicit_verify:
+        _c = _c.strip()
+        if _c.startswith("`") and _c.endswith("`") and len(_c) >= 2:
+            _c = _c[1:-1].strip()
+        if _c and _c not in commands:
+            commands.append(_c)
+
+    task_yaml = load_yaml(root / "recipes" / recipe / "task_class.yaml")
+    artifact_yaml = load_yaml(root / "recipes" / recipe / "artifact_contract.yaml")
+    agents_yaml = load_yaml(agents_path)
+
+    outputs = artifact_yaml.get("outputs") or []
+    if isinstance(outputs, str):
+        outputs = [outputs]
+
+    lanes = {}
+    if isinstance(agents_yaml.get("lanes"), dict):
+        lanes = agents_yaml["lanes"]
+
+    questions = []
+    if not success:
+        questions.append("What exact success criteria should the verifier use?")
+    if not scope_allow:
+        questions.append("Which files or directories are explicitly in scope?")
+    if not commands:
+        questions.append("What command should prove this run succeeded?")
+    if task_class == "db_migration":
+        questions = [
+            "Which database engine and version should this migration target?",
+            "Is downtime allowed, and what is the maximum acceptable window?",
+            "What exact rollback or backup restore path should the planner assume?",
+        ]
+    elif task_class == "ui_audit" and len(questions) < 3:
+        questions.append("Which target user profile or viewport should the audit prioritize?")
+
+    questions = questions[:3]
+    confidence = 0.35
+    confidence += 0.15 if success else 0
+    confidence += 0.15 if scope_allow else 0
+    confidence += 0.15 if commands else 0
+    confidence += 0.10 if outputs else 0
+    confidence += 0.10 if lanes else 0
+    confidence = min(confidence, 0.95)
+
+    high_risk = task_class in {"db_migration", "bdd_first_delivery"}
+    status = "ready"
+    if questions:
+        status = "blocked_profile" if high_risk else "needs_answers"
+
+    data = {
+        "schema_version": "1.0",
+        "kickoff_path": str(kickoff.resolve()),
+        "target_repo": str(Path.cwd().resolve()),
+        "recipe": recipe,
+        "task_class": task_class,
+        "user_goal": first_heading(),
+        "success_criteria": success,
+        "scope_allow": scope_allow,
+        "scope_deny": scope_deny,
+        "risk_tolerance": "conservative" if high_risk else "standard",
+        "budget_cap_usd": task_yaml.get("budget_cap_usd"),
+        "provider_policy": {
+            "source": str(Path(agents_path).resolve()),
+            "lanes": lanes,
+            "env": {"MINI_ORK_PROVIDER_POLICY": str(Path(agents_path).resolve()) if lanes else ""},
+        },
+        "artifact_destination": outputs,
+        "verification_command": commands[:3],
+        "human_questions": questions,
+        "confidence": round(confidence, 2),
+        "profile_status": status,
+    }
+    profile.parent.mkdir(parents=True, exist_ok=True)
+    profile.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return data
+
+
+def _grep_kv(text: str, key: str) -> str:
+    for line in text.splitlines():
+        if line.startswith(key + "="):
+            return line.split("=", 1)[1]
+    return ""
+
+
+def _deadline(root, *args) -> subprocess.CompletedProcess:
+    """Shell into lib/deadline_budget.sh (not yet ported) for init/check."""
+    lib = os.path.join(root, "lib", "deadline_budget.sh")
+    fn = args[0]
+    return subprocess.run(["bash", "-c", f'source "{lib}" && {fn} "$@"', "_", *args[1:]],
+                          capture_output=True, text=True)
+
+
+def _run_lifecycle(argv, root) -> int:
+    t0 = int(time.time())
+    # ── flag pre-parse: pull --deadline out ──
+    deadline = ""
+    rest = []
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--deadline":
+            if i + 1 >= len(argv):
+                sys.stderr.write("--deadline requires <seconds>\n"); return 2
+            v = argv[i + 1]
+            if not v.isdigit():
+                sys.stderr.write(f"--deadline: seconds must be a positive integer (got '{v}')\n"); return 2
+            deadline = v; i += 2
+        elif a.startswith("--deadline="):
+            v = a.split("=", 1)[1]
+            if not v.isdigit():
+                sys.stderr.write(f"--deadline: seconds must be a positive integer (got '{v}')\n"); return 2
+            deadline = v; i += 1
+        else:
+            rest.append(a); i += 1
+
+    if not rest:
+        sys.stderr.write("recipe name or kickoff.md path required\n"); return 2
+    first = rest.pop(0)
+
+    if os.path.isfile(first):
+        kickoff = first
+        probe = subprocess.run([_bin(root, "classify"), kickoff],
+                               capture_output=True, text=True, env={**os.environ, "MINI_ORK_DRY_RUN": "1"})
+        if probe.returncode != 0:
+            sys.stderr.write(probe.stderr); return probe.returncode
+        probed_class = _grep_kv(probe.stdout, "task_class")
+        recipe = resolve_recipe(root, probed_class)
+        if not recipe:
+            sys.stderr.write(f"could not resolve recipe for task_class={probed_class}\n"); return 2
+    else:
+        recipe = first
+        if not rest:
+            sys.stderr.write("kickoff.md path required\n"); return 2
+        kickoff = rest.pop(0)
+        if (not os.path.isdir(os.path.join(root, "recipes", recipe))
+                and os.path.isdir(os.path.join(root, "recipes", recipe.replace("_", "-")))):
+            recipe = recipe.replace("_", "-")
+
+    if not os.path.isdir(os.path.join(root, "recipes", recipe)):
+        sys.stderr.write(f"no recipe: {recipe} (ls {root}/recipes/)\n"); return 2
+    os.environ["MINI_ORK_RECIPE"] = recipe
+    os.environ["MINI_ORK_WORKFLOW"] = os.path.join(root, "recipes", recipe, "workflow.yaml")
+    if not os.path.isfile(kickoff):
+        sys.stderr.write(f"kickoff not found: {kickoff}\n"); return 2
+    run_id = os.environ.setdefault("MINI_ORK_RUN_ID", f"run-{int(time.time())}-{os.getpid()}")
+
+    # derived task_class from recipe's task_class.yaml::name
+    derived = ""
+    tc_yaml = os.path.join(root, "recipes", recipe, "task_class.yaml")
+    if os.path.isfile(tc_yaml):
+        try:
+            import yaml
+            derived = ((yaml.safe_load(open(tc_yaml)) or {}).get("name") or "").strip()
+        except Exception:
+            derived = ""
+    if not derived:
+        derived = recipe.replace("-", "_")
+
+    # repo-integrity guard (best-effort bash)
+    guard = os.path.join(root, "lib", "repo_integrity_guard.sh")
+    if os.path.isfile(guard):
+        subprocess.run(["bash", "-c", f'source "{guard}" && repo_integrity_check_and_heal || true'],
+                       capture_output=True)
+
+    # ── classify ──
+    cl = subprocess.run([_bin(root, "classify"), "--task-class", derived, kickoff],
+                        capture_output=True, text=True)
+    if cl.returncode != 0:
+        sys.stderr.write(cl.stderr); return cl.returncode
+    sys.stdout.write(cl.stdout)
+    task_class = _grep_kv(cl.stdout, "task_class")
+    os.environ["MINI_ORK_TASK_CLASS"] = task_class
+
+    home = os.environ.setdefault("MINI_ORK_HOME", os.path.join(os.getcwd(), ".mini-ork"))
+    run_dir = os.path.join(home, "runs", run_id)
+    os.makedirs(run_dir, exist_ok=True)
+    cfg = os.path.join(root, "lib", "config_resolve.sh")
+    if os.path.isfile(cfg):
+        subprocess.run(["bash", "-c", f'source "{cfg}" && mo_snapshot_run_config "$1" || true', "_", run_dir],
+                       capture_output=True)
+    profile_path = os.path.join(run_dir, "run_profile.json")
+    os.environ["MINI_ORK_PROFILE_PATH"] = profile_path
+
+    if deadline and int(deadline) > 0:
+        if _deadline(root, "mo_deadline_init", run_id, deadline, run_dir).returncode != 0:
+            sys.stderr.write("deadline init failed\n"); return 2
+
+    def _gate(where, artifact="") -> bool:
+        if deadline and _deadline(root, "mo_deadline_check", run_id).returncode != 0:
+            tail = f"; best-so-far artifact: {artifact or '<none>'}" if artifact else \
+                   "; no best-so-far artifact yet"
+            sys.stderr.write(f"deadline_hit after {where}{tail}; exiting cleanly\n")
+            return False
+        return True
+
+    if not _gate("classify"):
+        return 0
+
+    # ── profile ──
+    agents_path = os.path.join(home, "config", "agents.yaml")
+    data = gen_profile(kickoff, root, recipe, task_class, profile_path, agents_path)
+    sys.stdout.write(f"profile_path={profile_path}\n")
+    sys.stdout.write(f"profile_status={data['profile_status']}\n")
+    sys.stdout.write(f"profile_confidence={data['confidence']:.2f}\n")
+    if data["human_questions"]:
+        sys.stdout.write("profile_questions=" + json.dumps(data["human_questions"], separators=(",", ":")) + "\n")
+    if os.environ.get("MINI_ORK_PROFILE_STRICT", "0") == "1" and data["profile_status"] == "blocked_profile":
+        sys.stderr.write("profile blocked: answer profile_questions before planning\n"); return 2
+
+    if not _gate("profile"):
+        return 0
+
+    # ── plan ──
+    pl = subprocess.run([_bin(root, "plan"), kickoff], capture_output=True, text=True)
+    if pl.returncode != 0:
+        sys.stderr.write(pl.stderr); return pl.returncode
+    sys.stdout.write(pl.stdout)
+    plan_path = _grep_kv(pl.stdout, "plan_path")
+    os.environ["MINI_ORK_PLAN_PATH"] = plan_path
+    if not _gate("plan", plan_path):
+        return 0
+
+    # ── execute ── (failures do not exit; verify+reflect still fire)
+    ex = subprocess.run([_bin(root, "execute")], capture_output=True, text=True)
+    run_rc = ex.returncode
+    sys.stdout.write(ex.stdout)
+    artifact = _grep_kv(ex.stdout, "artifact_path")
+    if artifact:
+        os.environ["MINI_ORK_ARTIFACT_PATH"] = artifact
+    if deadline and _deadline(root, "mo_deadline_check", run_id).returncode != 0:
+        sys.stderr.write(f"deadline_hit after execute; best-so-far artifact: {artifact or '<none>'}\n")
+        return run_rc
+
+    _run_dir = os.environ.get("MINI_ORK_RUN_DIR", "")
+    if not _run_dir and plan_path:
+        _run_dir = os.path.dirname(plan_path)
+    if _run_dir and _run_dir != "." and os.path.isdir(_run_dir) \
+            and not os.path.isfile(os.path.join(_run_dir, "execute.log")):
+        try:
+            open(os.path.join(_run_dir, "execute.log"), "w").write(ex.stdout)
+        except OSError:
+            pass
+
+    # ── rubric pre-screen (advisory, bash) ──
+    if os.environ.get("MO_RUBRIC", "1") == "1" and _run_dir and os.path.isdir(_run_dir):
+        sys.stdout.write("── rubric (advisory pre-screen) ──\n")
+        subprocess.run(["bash", "-c",
+            'source "$1/lib/llm-dispatch.sh" 2>/dev/null||true; source "$1/lib/trace_store.sh" 2>/dev/null||true; '
+            'source "$1/lib/rubric-prescreen.sh" 2>/dev/null||true; '
+            'declare -f mo_rubric_run_score >/dev/null 2>&1 && mo_rubric_run_score "$2" "$3" "$4"; '
+            'declare -f mo_grade_run_reward >/dev/null 2>&1 && mo_grade_run_reward "$3" "$5" || true',
+            "_", root, kickoff, _run_dir, task_class or "generic", run_id])
+
+    # ── verify ──
+    if _run_dir and _run_dir != "." and os.path.isdir(_run_dir):
+        os.environ["MINI_ORK_RUN_DIR"] = _run_dir
+    vargs = [_bin(root, "verify")] + ([artifact] if artifact else [])
+    vr = subprocess.run(vargs, capture_output=True, text=True)
+    sys.stdout.write(vr.stdout); sys.stderr.write(vr.stderr)
+    if run_rc == 0:
+        run_rc = vr.returncode
+    if not _gate("verify", artifact):
+        return run_rc
+
+    # ── reflect (best-effort, bash) ──
+    if os.environ.get("MO_AUTO_REFLECT", "1") == "1":
+        sys.stdout.write("── reflect (auto, since run start) ──\n")
+        subprocess.run([_bin(root, "reflect"), "--since", str(t0)],
+                       env={**os.environ, "MO_REFLECTION_BATCH": os.environ.get("MO_REFLECTION_BATCH", "25")})
+    return run_rc
+
+
+def main(argv=None, *, root=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    root = root or os.environ.get("MINI_ORK_ROOT") or os.path.dirname(
+        os.path.dirname(os.path.realpath(__file__)))
+    os.environ["MINI_ORK_ROOT"] = root
+    sub = argv[0] if argv else "help"
+    rest = argv[1:]
+
+    if sub in _EXEC_SUBS:
+        return subprocess.run([_bin(root, sub), *rest]).returncode
+    if sub == "run":
+        return _run_lifecycle(rest, root)
+    if sub == "doctor":
+        import shutil
+        print("=== mini-ork doctor ===")
+        for d in ("bash", "sqlite3", "jq", "git", "yq", "curl", "claude", "python3"):
+            print(f"  [OK]      {d}" if shutil.which(d) else f"  [MISSING] {d}")
+        if os.environ.get("MINI_ORK_HOME"):
+            print(f"  [OK]      MINI_ORK_HOME={os.environ['MINI_ORK_HOME']}")
+        else:
+            print("  [WARN]    MINI_ORK_HOME unset (default: <project>/.mini-ork)")
+        if os.environ.get("MINI_ORK_DB"):
+            print(f"  [OK]      MINI_ORK_DB={os.environ['MINI_ORK_DB']}")
+        else:
+            print("  [WARN]    MINI_ORK_DB unset (default: $MINI_ORK_HOME/state.db)")
+        print("")
+        print("Lib presence:")
+        for lib in ("trace_store", "llm-dispatch", "gate_registry", "group_evolver",
+                    "reflection_pipeline", "benchmark_suite", "utility_function",
+                    "promotion_gate", "version_registry"):
+            if os.path.isfile(os.path.join(root, "lib", f"{lib}.sh")):
+                print(f"  [OK]      lib/{lib}.sh")
+            else:
+                print(f"  [MISSING] lib/{lib}.sh (P1 in flight?)")
+        return 0
+    if sub == "version":
+        print("mini-ork 0.6.0 (universal task loop runtime)")
+        return 0
+    if sub in ("help", "--help", "-h"):
+        sys.stdout.write(_HELP)
+        return 0
+    sys.stderr.write(f"Unknown subcommand: {sub}. Try: mini-ork help\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_mini_ork_cli_py.py
+++ b/tests/unit/test_mini_ork_cli_py.py
@@ -1,0 +1,141 @@
+"""Parity gate: mini_ork.ported.mini_ork_cli vs bin/mini-ork.
+
+The full `run` lifecycle drives the (still-bash) classify/plan/execute/verify
+stages — an integration concern. Here we parity the deterministic surface:
+dispatch (version/help/unknown/doctor) + --deadline validation vs live bash, and
+the two embedded-python blocks (recipe resolution, run-profile generation)
+EXTRACTED from bin/mini-ork and run as-is vs the ported functions — proving the
+transcription byte-matches the bash's own python.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mini_ork_cli as cli  # noqa: E402
+
+BIN = REPO / "bin" / "mini-ork"
+
+
+def _extract_py_blocks():
+    src = BIN.read_text().splitlines()
+    blocks, cur = [], None
+    for ln in src:
+        if cur is None and re.search(r"<<'PY'", ln):
+            cur = []
+        elif cur is not None and ln.strip() == "PY":
+            blocks.append("\n".join(cur)); cur = None
+        elif cur is not None:
+            cur.append(ln)
+    profile = next(b for b in blocks if "schema_version" in b)
+    recipe = next(b for b in blocks if "task_class.yaml" in b and "raise SystemExit" in b)
+    return profile, recipe
+
+
+_PROFILE_PY, _RECIPE_PY = _extract_py_blocks()
+
+
+def _run_block(block, *args, tmp_path):
+    p = tmp_path / "b.py"; p.write_text(block)
+    return subprocess.run(["python3", str(p), *map(str, args)], capture_output=True, text=True)
+
+
+# ── dispatch parity ──
+
+def _bash(*args):
+    return subprocess.run(["bash", str(BIN), *args], capture_output=True, text=True,
+                          env={**os.environ, "MINI_ORK_ROOT": str(REPO)})
+
+
+def test_version_parity(capsys):
+    rb = _bash("version")
+    rc = cli.main(["version"], root=str(REPO)); out = capsys.readouterr().out
+    assert rb.returncode == rc == 0
+    assert rb.stdout == out
+
+
+def test_help_and_unknown_parity(capsys):
+    rb = _bash("help"); cli.main(["help"], root=str(REPO)); out = capsys.readouterr().out
+    assert rb.stdout == out
+    rb2 = _bash("bogus"); rc = cli.main(["bogus"], root=str(REPO))
+    assert rb2.returncode == rc == 2
+
+
+def test_doctor_parity(capsys):
+    rb = _bash("doctor")
+    cli.main(["doctor"], root=str(REPO)); out = capsys.readouterr().out
+    assert rb.returncode == 0
+    assert rb.stdout == out
+
+
+def test_deadline_validation_parity():
+    rb = _bash("run", "--deadline", "abc", "k.md")
+    rc = cli.main(["run", "--deadline", "abc", "k.md"], root=str(REPO))
+    assert rb.returncode == rc == 2
+    rb2 = _bash("run", "--deadline")   # missing value
+    rc2 = cli.main(["run", "--deadline"], root=str(REPO))
+    assert rb2.returncode == rc2 == 2
+
+
+# ── recipe-resolution block parity ──
+
+def _recipes(tmp, mapping):
+    root = tmp / "root"; (root / "recipes").mkdir(parents=True)
+    for dirname, tc_name in mapping.items():
+        d = root / "recipes" / dirname; d.mkdir()
+        if tc_name is not None:
+            (d / "task_class.yaml").write_text(f"name: {tc_name}\n")
+    return root
+
+
+def test_resolve_recipe_parity(tmp_path):
+    root = _recipes(tmp_path, {"code-fix": "code_fix", "db-migration": "db_migration",
+                               "empty-dir": None, "ui-audit": "ui_audit"})
+    for tc in ("code_fix", "db_migration", "ui_audit", "does_not_exist", "empty_dir"):
+        rb = _run_block(_RECIPE_PY, str(root), tc, tmp_path=tmp_path).stdout.strip()
+        rp = cli.resolve_recipe(str(root), tc)
+        assert rb == rp, f"tc={tc}: bash={rb!r} py={rp!r}"
+
+
+# ── profile-gen block parity ──
+
+_KICKOFF = """# Ship the widget
+
+## Success
+- widget renders
+- tests pass
+
+## In scope
+- src/widget.py
+
+## Verification commands
+- `pytest tests/widget`
+"""
+
+
+def test_gen_profile_parity(tmp_path):
+    root = _recipes(tmp_path, {"code-fix": "code_fix"})
+    (root / "recipes" / "code-fix" / "artifact_contract.yaml").write_text("outputs:\n  - dist/widget.js\n")
+    agents = root / "agents.yaml"
+    agents.write_text("lanes:\n  implementer: [codex]\n")
+    kickoff = tmp_path / "k.md"; kickoff.write_text(_KICKOFF)
+
+    prof_b = tmp_path / "pb.json"; prof_p = tmp_path / "pp.json"
+    # bash's own python block
+    rb = _run_block(_PROFILE_PY, str(kickoff), str(root), "code-fix", "code_fix",
+                    str(prof_b), str(agents), tmp_path=tmp_path)
+    # ported function
+    data = cli.gen_profile(str(kickoff), str(root), "code-fix", "code_fix", str(prof_p), str(agents))
+
+    assert json.loads(prof_b.read_text()) == json.loads(prof_p.read_text())
+    # ported stdout lines match the block's stdout
+    assert f"profile_status={data['profile_status']}" in rb.stdout
+    assert f"profile_confidence={data['confidence']:.2f}" in rb.stdout
+    assert data["profile_status"] == "ready"          # success+scope+cmd present
+    assert data["verification_command"] == ["pytest tests/widget"]


### PR DESCRIPTION
Ports `bin/mini-ork` → `mini_ork/ported/mini_ork_cli.py`: subcommand dispatch, doctor/version/help, and the full `run` lifecycle (recipe resolution + profile-gen verbatim; stages/libs are subprocess seams). Parity vs live bash: dispatch + --deadline validation + both embedded-python blocks extracted & run as-is. 6/6 pass.