### PR TITLE
port(py): mini-ork-execute helper layer (increment 1)

### DIFF
--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -1,0 +1,145 @@
+"""Python port of bin/mini-ork-execute — the executor (INCREMENTAL).
+
+bin/mini-ork-execute is the 3449-line node-dispatch engine. Its orchestration
+core (_dispatch_node + the DAG loop) drives every run and warrants dedicated
+harsh-critic review before its default flips; this module lands the deterministic
+HELPER LAYER first, behind a live-bash parity gate, so the risky core ports onto
+verified foundations.
+
+Ported here (all pure / transcribed verbatim):
+    reward_from_status(status, verdict)     — status/verdict → GRPO reward
+    dispatch_chain(node_type, lead)         — role-aware fallback lane chain (deduped)
+    learning_static_lane(node_type, lane)   — static lane synthesis for unpinned nodes
+    finish_reason_for_failure(rc, text)     — rc/text → finish reason
+    infer_trace_code_region(payload)        — files_written → top-level code region
+"""
+from __future__ import annotations
+
+import json
+import os
+
+
+def reward_from_status(status: str = "", verdict: str = "") -> str:
+    v = (verdict or "").lower()
+    if v in ("approve", "approved", "pass", "passed", "success", "ok"):
+        return "1.0"
+    if v in ("reject", "rejected", "fail", "failed", "request_changes", "needs_revision", "escalate"):
+        return "0.0"
+    s = (status or "").lower()
+    if s in ("success", "published", "done", "approve", "approved", "pass", "passed"):
+        return "1.0"
+    if s in ("failure", "failed", "rolled_back", "blocked", "crash", "escalated", "reject", "rejected"):
+        return "0.0"
+    return "0.5"
+
+
+_CODING_ROLES = {"implementer", "worker", "spec_author", "healer", "planner", "researcher",
+                 "reflector", "replanner", "synthesizer", "bdd_runner"}
+_REVIEW_ROLES = {"reviewer", "spec_reviewer", "verifier", "brain"}
+
+
+def dispatch_chain(node_type: str, lead: str) -> str:
+    """Lead lane + role-category fallback tail, comma-joined, order-preserving dedup."""
+    tail = ""
+    if node_type in _CODING_ROLES:
+        tail = os.environ.get("MO_FALLBACK_CODING", "minimax,codex,sonnet")
+    elif node_type in _REVIEW_ROLES:
+        tail = os.environ.get("MO_FALLBACK_REVIEW", "opus,kimi,sonnet")
+    if not tail:
+        return lead
+    seen = set()
+    out = []
+    for x in (lead + "," + tail).split(","):
+        if x and x not in seen:
+            seen.add(x)
+            out.append(x)
+    return ",".join(out)
+
+
+def learning_static_lane(node_type: str, current_lane: str) -> str:
+    frontier = os.environ.get("MO_FRONTIER_LANE", "opus_lens")
+    cheap = os.environ.get("MO_CHEAP_LANE", "kimi_lens")
+    # A recipe-pinned lane (current_lane != node_type) is explicit author intent
+    # + the learning loop's exploration arm — keep it.
+    if current_lane != node_type:
+        return current_lane
+    if node_type == "reviewer":
+        return frontier
+    if node_type in ("researcher", "implementer"):
+        return cheap
+    return current_lane
+
+
+def finish_reason_for_failure(rc, text: str = "") -> str:
+    rc = int(rc) if str(rc).lstrip("-").isdigit() else 1
+    if rc == 124:
+        return "timeout"
+    if rc == 43 or "lane_fuse_open" in (text or ""):
+        return "error"
+    if "cost_circuit_open" in (text or ""):
+        return "cost_limit"
+    return "error"
+
+
+def infer_trace_code_region(payload: str) -> str:
+    """files_written → the top-level dir of the first in-repo relative file
+    ('(root)' for root-level files). Verbatim transcription of the bash's
+    embedded python; returns '' when nothing maps (bash prints nothing)."""
+    try:
+        data = json.loads(payload or "{}")
+    except json.JSONDecodeError:
+        return ""
+    run_dir = os.environ.get("MINI_ORK_RUN_DIR") or os.environ.get("RUN_DIR") or ""
+    roots = [os.environ.get("MO_TARGET_CWD") or "", os.environ.get("MINI_ORK_ROOT") or "", os.getcwd()]
+    roots = [os.path.abspath(r) for r in roots if r]
+
+    def _decode_files(value):
+        if isinstance(value, list):
+            return value
+        if isinstance(value, str):
+            s = value.strip()
+            if not s:
+                return []
+            try:
+                decoded = json.loads(s)
+            except json.JSONDecodeError:
+                return [s]
+            return decoded if isinstance(decoded, list) else []
+        return []
+
+    def _relativize(path):
+        if not isinstance(path, str):
+            return None
+        p = path.strip()
+        if not p or "://" in p:
+            return None
+        if run_dir:
+            run_abs = os.path.abspath(run_dir)
+            p_abs = os.path.abspath(p) if os.path.isabs(p) else os.path.abspath(os.path.join(os.getcwd(), p))
+            try:
+                if os.path.commonpath([run_abs, p_abs]) == run_abs:
+                    return None
+            except ValueError:
+                pass
+        if os.path.isabs(p):
+            p_abs = os.path.abspath(p)
+            for root in roots:
+                try:
+                    if os.path.commonpath([root, p_abs]) == root:
+                        return os.path.relpath(p_abs, root)
+                except ValueError:
+                    continue
+            return None
+        return p
+
+    for raw in _decode_files(data.get("files_written")):
+        rel = _relativize(raw)
+        if not rel:
+            continue
+        rel = rel.replace("\\", "/")
+        while rel.startswith("./"):
+            rel = rel[2:]
+        if not rel or rel.startswith("../"):
+            continue
+        return rel.split("/", 1)[0] if "/" in rel else "(root)"
+    return ""

--- a/tests/unit/test_mini_ork_execute_py.py
+++ b/tests/unit/test_mini_ork_execute_py.py
@@ -1,0 +1,110 @@
+"""Parity gate: mini_ork.ported.mini_ork_execute helper layer vs bin/mini-ork-execute.
+
+bin/mini-ork-execute is a CLI (runs setup at top level), so we EXTRACT each pure
+helper's definition by name, source that in isolation, and compare its output to
+the port. Covers the deterministic helper layer (reward/lane/chain/finish-reason/
+code-region); the orchestration core (_dispatch_node + DAG loop) is a separate,
+harsh-critic-gated increment.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mini_ork_execute as ex  # noqa: E402
+
+BIN = REPO / "bin" / "mini-ork-execute"
+_SRC = BIN.read_text().splitlines()
+
+
+def _extract(name: str) -> str:
+    """Pull `<name>() { ... }` (closing brace at column 0) from the CLI."""
+    start = None
+    for i, ln in enumerate(_SRC):
+        if re.match(rf"^{re.escape(name)}\(\) *\{{", ln):
+            start = i
+            break
+    assert start is not None, f"function {name} not found"
+    body = [_SRC[start]]
+    for ln in _SRC[start + 1:]:
+        body.append(ln)
+        if ln == "}":
+            break
+    return "\n".join(body)
+
+
+def _call(name, *args, env=None):
+    fn = _extract(name)
+    script = f'{fn}\n{name} "$@"'
+    return subprocess.run(["bash", "-c", script, "_", *map(str, args)],
+                          capture_output=True, text=True,
+                          env={**os.environ, **(env or {})}).stdout.strip()
+
+
+def test_reward_from_status_parity():
+    cases = [("", "approve"), ("", "needs_revision"), ("published", ""), ("failed", ""),
+             ("reviewing", ""), ("success", "pass"), ("", "ESCALATE"), ("PUBLISHED", ""),
+             ("weird", "weird")]
+    for status, verdict in cases:
+        rb = _call("_mo_reward_from_status", status, verdict)
+        rp = ex.reward_from_status(status, verdict)
+        assert rb == rp, f"({status!r},{verdict!r}): bash={rb!r} py={rp!r}"
+
+
+def test_dispatch_chain_parity():
+    env = {"MO_FALLBACK_CODING": "minimax,codex,sonnet", "MO_FALLBACK_REVIEW": "opus,kimi,sonnet"}
+    for nt, lead in [("implementer", "minimax"), ("implementer", "glm"), ("reviewer", "opus"),
+                     ("reviewer", "sonnet"), ("verifier", "kimi"), ("unknown_role", "codex"),
+                     ("planner", "codex")]:
+        rb = _call("_mo_dispatch_chain", nt, lead, env=env)
+        rp = ex.dispatch_chain(nt, lead)
+        assert rb == rp, f"({nt},{lead}): bash={rb!r} py={rp!r}"
+
+
+def test_learning_static_lane_parity():
+    env = {"MO_FRONTIER_LANE": "opus_lens", "MO_CHEAP_LANE": "kimi_lens"}
+    for nt, lane in [("reviewer", "reviewer"), ("researcher", "researcher"),
+                     ("implementer", "implementer"), ("planner", "planner"),
+                     ("researcher", "glm_lens"), ("reviewer", "custom_lane")]:
+        rb = _call("_mo_learning_static_lane", nt, lane, env=env)
+        rp = ex.learning_static_lane(nt, lane)
+        assert rb == rp, f"({nt},{lane}): bash={rb!r} py={rp!r}"
+
+
+def test_finish_reason_parity():
+    for rc, text in [(124, ""), (43, ""), (1, "lane_fuse_open here"),
+                     (1, "cost_circuit_open spent"), (2, "generic error"), (0, "")]:
+        rb = _call("_mo_finish_reason_for_failure", rc, text)
+        rp = ex.finish_reason_for_failure(rc, text)
+        assert rb == rp, f"({rc},{text!r}): bash={rb!r} py={rp!r}"
+
+
+def test_infer_code_region_parity(tmp_path):
+    import json
+    payloads = [
+        json.dumps({"files_written": ["src/foo.py", "src/bar.py"]}),
+        json.dumps({"files_written": ["README.md"]}),
+        json.dumps({"files_written": []}),
+        json.dumps({"files_written": "[\"lib/x.sh\"]"}),          # json-string form
+        json.dumps({"files_written": ["./pkg/mod.py"]}),
+        json.dumps({"other": 1}),
+        "not json",
+    ]
+    # run both with MINI_ORK_RUN_DIR unset + a shared cwd so relative paths match
+    env = {k: v for k, v in os.environ.items() if k not in ("MINI_ORK_RUN_DIR", "RUN_DIR")}
+    for p in payloads:
+        rb = subprocess.run(["bash", "-c", f'{_extract("_mo_infer_trace_code_region")}\n'
+                             '_mo_infer_trace_code_region "$1"', "_", p],
+                            capture_output=True, text=True, cwd=tmp_path, env=env).stdout.strip()
+        old = dict(os.environ); os.environ.clear(); os.environ.update(env)
+        cwd = os.getcwd(); os.chdir(tmp_path)
+        try:
+            rp = ex.infer_trace_code_region(p)
+        finally:
+            os.chdir(cwd); os.environ.clear(); os.environ.update(old)
+        assert rb == rp, f"{p!r}: bash={rb!r} py={rp!r}"


### PR DESCRIPTION
First verified increment of the executor port: the deterministic helper layer (reward_from_status, dispatch_chain, learning_static_lane, finish_reason_for_failure, infer_trace_code_region) → `mini_ork/ported/mini_ork_execute.py`, transcribed verbatim. Parity test extracts each bash helper by name + compares to the port. 5/5 pass. The orchestration core (_dispatch_node + DAG loop) is the next increment, gated on the harsh-critic panel.