### PR TITLE
port(py): mini-ork-execute GRPO writeback (increment 2)

### DIFF
--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -12,11 +12,16 @@ Ported here (all pure / transcribed verbatim):
     learning_static_lane(node_type, lane)   — static lane synthesis for unpinned nodes
     finish_reason_for_failure(rc, text)     — rc/text → finish reason
     infer_trace_code_region(payload)        — files_written → top-level code region
+    learning_update_conductor_outcomes(db)  — resolve pending conductor decisions
+    write_grpo_advantages(db)               — GRPO group-relative advantage writeback
 """
 from __future__ import annotations
 
+import datetime
 import json
+import math
 import os
+import sqlite3
 
 
 def reward_from_status(status: str = "", verdict: str = "") -> str:
@@ -143,3 +148,252 @@ def infer_trace_code_region(payload: str) -> str:
             continue
         return rel.split("/", 1)[0] if "/" in rel else "(root)"
     return ""
+
+
+# ── GRPO learning writeback (verbatim transcription of the embedded python) ──
+
+def learning_update_conductor_outcomes(db) -> int:
+    """Resolve pending conductor_decisions against their epic's terminal status."""
+    if not (db and os.path.isfile(db)):
+        return 0
+    con = sqlite3.connect(db, timeout=5.0)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    try:
+        rows = con.execute(
+            "SELECT cd.id, e.status FROM conductor_decisions cd JOIN epics e ON e.id = cd.epic_id "
+            "WHERE COALESCE(cd.outcome, 'pending') = 'pending' AND e.status IN ('done', 'escalated')"
+        ).fetchall()
+        for row in rows:
+            success = row["status"] == "done"
+            con.execute("UPDATE conductor_decisions SET outcome=?, realized_score=? WHERE id=?",
+                        ("success" if success else "failure", 1.0 if success else 0.0, row["id"]))
+        con.commit()
+        return len(rows)
+    except sqlite3.OperationalError:
+        return 0
+    finally:
+        con.close()
+
+
+_FAMILY_TOKENS = ("opus", "minimax", "glm", "kimi")
+_APPROVE = {"approve", "approved", "pass", "success", "ok"}
+_REJECT = {"reject", "rejected", "fail", "failed", "request_changes", "needs_revision", "escalate"}
+_VERDICT_BAND = 0.10
+
+
+def write_grpo_advantages(db) -> int:
+    """Compute per-(agent_version_id, task_class) group-relative advantage from
+    execution_traces and UPSERT into agent_performance_memory. Verbatim port."""
+    if not (db and os.path.isfile(db)):
+        return 0
+    con = sqlite3.connect(db, timeout=5.0)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row
+    cols = {r[1] for r in con.execute("PRAGMA table_info(agent_performance_memory)").fetchall()}
+    if "relative_advantage" not in cols:
+        con.close()
+        return 0
+
+    try:
+        decay_alpha = float(os.environ.get("MO_LEARNING_DECAY_ALPHA", "0.30"))
+    except ValueError:
+        decay_alpha = 0.30
+    decay_alpha = max(0.0, min(1.0, decay_alpha))
+    try:
+        halflife_days = float(os.environ.get("MO_LEARNING_HALFLIFE_DAYS", "14"))
+    except ValueError:
+        halflife_days = 14.0
+    if halflife_days < 0.0:
+        halflife_days = 0.0
+
+    def _parse_iso(ts):
+        if not ts:
+            return None
+        s = ts.strip()
+        if not s:
+            return None
+        if s.endswith("Z"):
+            s = s[:-1]
+        try:
+            return datetime.datetime.fromisoformat(s)
+        except ValueError:
+            return None
+
+    _now = datetime.datetime.now(datetime.timezone.utc)
+    _ln2 = math.log(2.0)
+
+    def recency_weight(created_at):
+        if halflife_days <= 0.0:
+            return 1.0
+        dt = _parse_iso(created_at)
+        if dt is None:
+            return 1.0
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        age_days = (_now - dt).total_seconds() / 86400.0
+        if age_days <= 0.0:
+            return 1.0
+        return math.exp(-_ln2 * age_days / halflife_days)
+
+    try:
+        rows = con.execute(
+            "SELECT trace_id, task_class, agent_version_id, verifier_output, status, "
+            "reviewer_verdict, cost_usd, duration_ms, process_reward, created_at "
+            "FROM execution_traces WHERE task_class IS NOT NULL AND task_class <> '' "
+            "AND agent_version_id IS NOT NULL AND agent_version_id <> ''").fetchall()
+    except sqlite3.OperationalError:
+        con.close()
+        return 0
+
+    def _decode_verifier_output(raw):
+        if isinstance(raw, dict):
+            return raw
+        if not isinstance(raw, str):
+            return {}
+        s = raw.strip()
+        if not s or s in ("null", "None", "{}"):
+            return {}
+        try:
+            decoded = json.loads(s)
+        except (ValueError, TypeError):
+            return {}
+        if isinstance(decoded, dict):
+            return decoded
+        if isinstance(decoded, str):
+            try:
+                redecoded = json.loads(decoded)
+            except (ValueError, TypeError):
+                return {}
+            return redecoded if isinstance(redecoded, dict) else {}
+        return {}
+
+    def node_type(row):
+        payload = _decode_verifier_output(row["verifier_output"])
+        value = payload.get("node_type") if isinstance(payload, dict) else None
+        if value:
+            return str(value)
+        tc = row["task_class"] or ""
+        return str(tc) if tc else "_unknown"
+
+    def _lane_family(agent_version_id):
+        if not agent_version_id:
+            return None
+        av = str(agent_version_id).lower()
+        for tok in _FAMILY_TOKENS:
+            if tok in av:
+                return tok
+        return None
+
+    def reward(row):
+        if row["process_reward"] is not None:
+            return max(0.0, min(1.0, float(row["process_reward"])))
+        verdict = (row["reviewer_verdict"] or "").lower()
+        status = (row["status"] or "").lower()
+        same_family = _lane_family(row["agent_version_id"]) is not None
+        if status not in {"success", "failed"}:
+            if verdict in _APPROVE:
+                return 1.0
+            if verdict in _REJECT:
+                return 0.0
+            return 1.0 if row["status"] == "success" else 0.0
+        base = 0.85 if status == "success" else 0.15
+        if same_family:
+            delta = 0.0
+        elif verdict in _APPROVE:
+            delta = _VERDICT_BAND
+        elif verdict in _REJECT:
+            delta = -_VERDICT_BAND
+        else:
+            delta = 0.0
+        return max(0.0, min(1.0, base + delta))
+
+    weight_rows = [(row, reward(row), recency_weight(row["created_at"])) for row in rows]
+    groups = {}
+    for row, score, w in weight_rows:
+        groups.setdefault((node_type(row), row["task_class"]), []).append((row, score, w))
+
+    existing_adv = {}
+    for er in con.execute("SELECT agent_version_id, task_class, relative_advantage "
+                          "FROM agent_performance_memory").fetchall():
+        try:
+            existing_adv[(er["agent_version_id"], er["task_class"])] = float(er["relative_advantage"])
+        except (TypeError, ValueError):
+            pass
+
+    written = 0
+    for (role, task_class), items in groups.items():
+        total_w = sum(w for _, _, w in items)
+        if total_w > 0.0:
+            mean = sum(w * s for _, s, w in items) / total_w
+            variance = sum(w * (s - mean) ** 2 for _, s, w in items) / total_w
+        else:
+            scores = [s for _, s, _ in items]
+            mean = sum(scores) / len(scores)
+            variance = sum((s - mean) ** 2 for s in scores) / len(scores)
+        std = math.sqrt(variance)
+        try:
+            tiebreak_enabled = int(os.environ.get("MO_LEARNING_TIEBREAK", "1")) != 0
+        except ValueError:
+            tiebreak_enabled = True
+        if std == 0 and tiebreak_enabled:
+            costs = sorted({round(float(r["cost_usd"] or 0.0), 6) for r, _, _ in items})
+            cost_min, cost_max = (costs[0], costs[-1]) if costs else (0.0, 0.0)
+            cost_span = cost_max - cost_min
+        else:
+            cost_min = cost_max = cost_span = 0.0
+            if std == 0:
+                tiebreak_enabled = False
+        by_agent = {}
+        for row, score, w in items:
+            bucket = by_agent.setdefault(row["agent_version_id"], {
+                "runs": 0, "success": 0, "cost": 0.0, "duration": 0.0, "adv": [], "w": []})
+            bucket["runs"] += 1
+            bucket["success"] += 1 if row["status"] == "success" else 0
+            bucket["cost"] += float(row["cost_usd"] or 0.0)
+            bucket["duration"] += float(row["duration_ms"] or 0.0)
+            if std == 0:
+                if tiebreak_enabled and cost_span > 0:
+                    c = float(row["cost_usd"] or 0.0)
+                    adv_tb = round(0.1 * (cost_max - c) / cost_span * 2.0 - 0.1, 6)
+                    adv_tb = max(-0.1, min(0.1, adv_tb))
+                    bucket["adv"].append(adv_tb)
+                else:
+                    bucket["adv"].append(0.0)
+            else:
+                bucket["adv"].append((score - mean) / std)
+            bucket["w"].append(w)
+        try:
+            shrink_k = max(0, int(os.environ.get("MO_LEARNING_SHRINKAGE_K", "5")))
+        except ValueError:
+            shrink_k = 5
+        for agent_id, bucket in by_agent.items():
+            runs = bucket["runs"]
+            bw_total = sum(bucket["w"])
+            if bw_total > 0.0:
+                raw_rel_adv = sum(w * a for w, a in zip(bucket["w"], bucket["adv"])) / bw_total
+            else:
+                raw_rel_adv = sum(bucket["adv"]) / len(bucket["adv"])
+            shrink_factor = runs / (runs + shrink_k) if (runs + shrink_k) > 0 else 0.0
+            batch_adv = raw_rel_adv * shrink_factor
+            prior = existing_adv.get((agent_id, task_class))
+            if prior is not None and decay_alpha < 1.0:
+                rel_adv = decay_alpha * batch_adv + (1.0 - decay_alpha) * prior
+            else:
+                rel_adv = batch_adv
+            con.execute(
+                "INSERT INTO agent_performance_memory (agent_version_id, role, model, task_class, "
+                "runs_count, success_count, avg_cost_usd, avg_duration_ms, top_failure_modes, "
+                "relative_advantage, last_updated) VALUES (?,?,?,?,?,?,?,?,'[]',?,"
+                "strftime('%Y-%m-%dT%H:%M:%fZ','now')) "
+                "ON CONFLICT(agent_version_id, task_class) DO UPDATE SET role=excluded.role, "
+                "model=excluded.model, runs_count=excluded.runs_count, "
+                "success_count=excluded.success_count, avg_cost_usd=excluded.avg_cost_usd, "
+                "avg_duration_ms=excluded.avg_duration_ms, "
+                "relative_advantage=excluded.relative_advantage, last_updated=excluded.last_updated",
+                (agent_id, role, agent_id, task_class, runs, bucket["success"],
+                 bucket["cost"] / runs, bucket["duration"] / runs, round(rel_adv, 6)))
+            written += 1
+    con.commit()
+    con.close()
+    return written

--- a/tests/unit/test_mini_ork_execute_py.py
+++ b/tests/unit/test_mini_ork_execute_py.py
@@ -108,3 +108,100 @@ def test_infer_code_region_parity(tmp_path):
         finally:
             os.chdir(cwd); os.environ.clear(); os.environ.update(old)
         assert rb == rp, f"{p!r}: bash={rb!r} py={rp!r}"
+
+
+# ── GRPO writeback parity (DB-deterministic) ──
+
+def _seed_db(tmp, name):
+    home = tmp / name / ".mini-ork"; home.mkdir(parents=True)
+    db = str(home / "state.db")
+    subprocess.run(["bash", str(REPO / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": db},
+                   capture_output=True, text=True, check=True)
+    return db
+
+
+def _sql(db, s):
+    return subprocess.run(["sqlite3", db, s], capture_output=True, text=True)
+
+
+def _seed_traces(db):
+    traces = [
+        ("t1", "opus_lens", "success", 1.0, 1000), ("t2", "minimax_lens", "failed", 0.5, 800),
+        ("t3", "kimi_lens", "success", 0.2, 500), ("t4", "opus_lens", "failed", 1.1, 900),
+    ]
+    for tid, av, status, cost, dur in traces:
+        _sql(db, "INSERT INTO execution_traces (trace_id,run_id,workflow_version_id,agent_version_id,"
+                 "task_class,prompt_version_hash,context_bundle_hash,tool_calls,files_read,"
+                 "files_written,verifier_output,reviewer_verdict,cost_usd,duration_ms,"
+                 "final_artifact_ref,status,created_at) VALUES "
+                 f"('{tid}','r1','wf1','{av}','code_fix','ph','ch','[]','[]','[]',"
+                 f"'{{\"node_type\":\"researcher\"}}','',{cost},{dur},'','{status}','2026-07-01T00:00:00Z');")
+
+
+def _apm_rows(db):
+    return _sql(db, "SELECT agent_version_id,role,task_class,runs_count,success_count,"
+                    "printf('%.6f',avg_cost_usd),printf('%.6f',avg_duration_ms),"
+                    "printf('%.6f',relative_advantage) FROM agent_performance_memory "
+                    "ORDER BY agent_version_id;").stdout.strip()
+
+
+def test_grpo_advantages_parity(tmp_path):
+    db_b = _seed_db(tmp_path, "gb"); db_p = _seed_db(tmp_path, "gp")
+    _seed_traces(db_b); _seed_traces(db_p)
+    # halflife=0 disables recency drift so bash/py compute identical weights
+    env = {"MO_LEARNING_HALFLIFE_DAYS": "0", "MINI_ORK_DB": db_b}
+    nb = subprocess.run(["bash", "-c", f'{_extract("mo_learning_write_grpo_advantages")}\n'
+                         'mo_learning_write_grpo_advantages', "_"],
+                        capture_output=True, text=True, env={**os.environ, **env}).stdout.strip()
+    old = dict(os.environ)
+    os.environ.update({"MO_LEARNING_HALFLIFE_DAYS": "0"})
+    try:
+        np_ = ex.write_grpo_advantages(db_p)
+    finally:
+        os.environ.clear(); os.environ.update(old)
+    assert nb == str(np_), f"count bash={nb} py={np_}"
+    assert _apm_rows(db_b) == _apm_rows(db_p) and _apm_rows(db_p), "agent_performance_memory differs"
+
+
+def test_grpo_sigma_zero_tiebreak_parity(tmp_path):
+    # all-success same-reward group → std==0 → cost tiebreak path
+    db_b = _seed_db(tmp_path, "sb"); db_p = _seed_db(tmp_path, "sp")
+    for db in (db_b, db_p):
+        for tid, av, cost in [("a", "opus_lens", 2.0), ("b", "kimi_lens", 0.1)]:
+            _sql(db, "INSERT INTO execution_traces (trace_id,run_id,workflow_version_id,"
+                     "agent_version_id,task_class,prompt_version_hash,context_bundle_hash,tool_calls,"
+                     "files_read,files_written,verifier_output,reviewer_verdict,cost_usd,duration_ms,"
+                     "final_artifact_ref,status,created_at) VALUES "
+                     f"('{tid}','r','w','{av}','code_fix','p','c','[]','[]','[]',"
+                     f"'{{\"node_type\":\"impl\"}}','',{cost},100,'','success','2026-07-01T00:00:00Z');")
+    env = {"MO_LEARNING_HALFLIFE_DAYS": "0", "MINI_ORK_DB": db_b}
+    subprocess.run(["bash", "-c", f'{_extract("mo_learning_write_grpo_advantages")}\n'
+                    'mo_learning_write_grpo_advantages', "_"],
+                   capture_output=True, text=True, env={**os.environ, **env})
+    old = dict(os.environ); os.environ.update({"MO_LEARNING_HALFLIFE_DAYS": "0"})
+    try:
+        ex.write_grpo_advantages(db_p)
+    finally:
+        os.environ.clear(); os.environ.update(old)
+    assert _apm_rows(db_b) == _apm_rows(db_p)
+    # cheaper lane (kimi) got the positive bump
+    kimi = _sql(db_p, "SELECT relative_advantage FROM agent_performance_memory "
+                      "WHERE agent_version_id='kimi_lens';").stdout.strip()
+    assert float(kimi) > 0
+
+
+def test_conductor_outcomes_parity(tmp_path):
+    db_b = _seed_db(tmp_path, "cb"); db_p = _seed_db(tmp_path, "cp")
+    for db in (db_b, db_p):
+        _sql(db, "INSERT INTO epics (id,title,status) VALUES ('e1','E1','done'),('e2','E2','escalated');")
+        _sql(db, "INSERT INTO conductor_decisions (decided_at,epic_id,task_class,outcome) VALUES "
+                 "(1,'e1','x','pending'),(1,'e2','x','pending');")
+    nb = subprocess.run(["bash", "-c", f'{_extract("mo_learning_update_conductor_outcomes")}\n'
+                         'mo_learning_update_conductor_outcomes', "_"],
+                        capture_output=True, text=True,
+                        env={**os.environ, "MINI_ORK_DB": db_b}).stdout.strip()
+    np_ = ex.learning_update_conductor_outcomes(db_p)
+    assert nb == str(np_) == "2"
+    q = "SELECT epic_id,outcome,realized_score FROM conductor_decisions ORDER BY epic_id;"
+    assert _sql(db_b, q).stdout == _sql(db_p, q).stdout


### PR DESCRIPTION
Increment 2: the learning writeback (learning_update_conductor_outcomes + write_grpo_advantages) → `mini_ork/ported/mini_ork_execute.py`, transcribed verbatim. Parity vs live bash seeding execution_traces + comparing agent_performance_memory (std>0 + std==0 tiebreak paths) + conductor-outcomes. 8/8 pass. Remaining: _dispatch_node + DAG loop (harsh-critic gated).