### PR TITLE
fix(ci): test isolation + README count + secret-parity tighten

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Cost guard: `MO_DAILY_BUDGET_USD` ($50 default) is enforced inside the dispatche
 Shipped totals (regenerable via `scripts/readme-claim-check.sh`):
 
 - **89 framework primitives** in `lib/` (lifecycle + memory + gates + agent registry + runtime + observability + the 4 calibration-list gates + HarnessBridge stack + live control plane + per-run config isolation + `lib/migrate.sh` checksummed transactional DB migrations).
-- **31 user-facing `bin/mini-ork` entrypoints** (the 6-stage loop + `eval` / `improve` / `promote` / `metrics` / `spawn` / `epics` / `scheduler` / `review` / `bugs` / `lifetime` / `coord` / `usage-report` / `watchdog` / `conductor` and friends).
+- **32 user-facing `bin/mini-ork` entrypoints** (the `mini-ork` dispatcher + the 6-stage loop + `eval` / `improve` / `promote` / `metrics` / `spawn` / `epics` / `scheduler` / `review` / `bugs` / `lifetime` / `coord` / `usage-report` / `watchdog` / `conductor` and friends).
 - **48 schema migrations** under `db/migrations/` (memory namespaces, execution traces, gradients, panel topology, recursive orchestration, llm_calls, lifecycle widening, error taxonomy, heartbeat, agent performance, epic + bug + pre-push review tables, HarnessBridge grounded-rejections, run-artifacts trajectory store).
 - **28 recipes** shipped — see [Recipes table](#recipes) above.
 - **7 model-family wrappers** under [lib/providers/](lib/providers/) + BYO-key registry (`config/providers.yaml`) for custom Anthropic/OpenAI-compatible endpoints.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+"""Suite-wide test isolation.
+
+Many ported ``main()`` functions mirror the bash entrypoints by exporting
+process env (``os.environ["MINI_ORK_HOME"]``, ``MINI_ORK_DB``, ``MINI_ORK_RUN_ID``,
+``MINI_ORK_ROOT``, …). That is correct for the real CLI (process-scoped) but, when
+a test calls ``main()`` in-process, the mutation persists into the shared
+``os.environ`` and leaks into later tests. A downstream bash-parity test then
+spawns bash with ``{**os.environ, ...}`` and inherits a stale (often deleted)
+``MINI_ORK_HOME``/``MINI_ORK_DB`` from the earlier test — so bash and the port
+diverge and the parity assertion fails. Each such test passes in isolation but
+fails in the full suite (the CI-only, single-process failure mode).
+
+This autouse fixture snapshots and restores ``os.environ`` and the working
+directory around every test, isolating that leakage suite-wide.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_process_state():
+    env_snapshot = dict(os.environ)
+    try:
+        cwd_snapshot = os.getcwd()
+    except OSError:
+        cwd_snapshot = None
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(env_snapshot)
+        if cwd_snapshot is not None:
+            try:
+                os.chdir(cwd_snapshot)
+            except OSError:
+                pass

--- a/tests/unit/test_mini_ork_review_py.py
+++ b/tests/unit/test_mini_ork_review_py.py
@@ -352,15 +352,12 @@ def test_check_secret_patterns_vs_bash_parity(secret_line: str, kind: str, tmp_p
     """For each of the 5 secret patterns, both ports must emit exactly
     one critical issue with the same JSONL shape.
 
-    KNOWN BASH BUG (do NOT edit lib/pre_push_review.sh per the kickoff's
-    strangler-fig rule): the bash ``_check_secret_patterns`` heredoc ends
-    with a top-level Python ``return``, which is a SyntaxError. The bash
-    subprocess therefore aborts with rc=1 and emits NO JSONL output. The
-    Python port fixes this — it correctly emits one critical issue per
-    matched pattern and returns on the first match. This test documents
-    both behaviors (bash broken, py fixed) and asserts the Python port's
-    correct output shape so a regression in either direction is
-    observable.
+    The bash ``_check_secret_patterns`` heredoc previously ended with a
+    top-level Python ``return`` (a SyntaxError → silent no-op → dead secret
+    scanner). That was FIXED in PR #131 (``return`` → ``sys.exit(0)``). This
+    test now enforces true bash+py parity: both must succeed, emit exactly one
+    critical finding per matched pattern (returning on the first match), and
+    produce the identical finding field-for-field.
     """
     diff_text = (
         "diff --git a/lib/example.sh b/lib/example.sh\n"
@@ -379,21 +376,18 @@ def test_check_secret_patterns_vs_bash_parity(secret_line: str, kind: str, tmp_p
         "_check_secret_patterns", [str(diff_path)],
         db=str(tmp_path / "unused.db"),
     )
-    # The bash subprocess must fail with the known SyntaxError. If it
-    # ever starts succeeding, the bash bug is fixed upstream and the
-    # parity test should be tightened.
-    assert bash_r.returncode != 0, (
-        f"{kind}: bash unexpectedly succeeded — bash source bug is fixed; "
-        f"tighten this test to enforce bash+py parity."
+    # The bash secret scanner bug (top-level `return` → SyntaxError → silent
+    # no-op) was FIXED (lib/pre_push_review.sh: `return` → `sys.exit(0)`, PR #131).
+    # It must now succeed and emit the SAME single finding as the Python port.
+    assert bash_r.returncode == 0, (
+        f"{kind}: bash secret check failed: {bash_r.stderr!r}"
     )
-    assert "SyntaxError" in bash_r.stderr, (
-        f"{kind}: bash failed but not with the expected SyntaxError: "
-        f"{bash_r.stderr!r}"
-    )
+    import json as _json
     bash_lines = [ln for ln in bash_r.stdout.splitlines() if ln.strip()]
-    assert bash_lines == [], (
-        f"{kind}: bash emitted JSONL despite the SyntaxError: {bash_lines!r}"
+    assert len(bash_lines) == 1, (
+        f"{kind}: bash expected exactly 1 JSONL finding, got {bash_lines!r}"
     )
+    bash_issue = _json.loads(bash_lines[0])
 
     # Python port — must emit exactly one critical issue per match with
     # the bash-INTENDED shape.
@@ -412,6 +406,12 @@ def test_check_secret_patterns_vs_bash_parity(secret_line: str, kind: str, tmp_p
         f"{kind}: title prefix mismatch: {issue['title']!r}"
     )
     assert issue["suggested_fix"].startswith("Remove the secret")
+    # bash+py parity on the fixed behavior: identical finding, field for field.
+    # The bash JSONL omits the `line` key entirely; the port emits an explicit
+    # `line: None` — semantically identical, so normalize before comparing.
+    assert {**bash_issue, "line": bash_issue.get("line")} == issue, (
+        f"{kind}: bash/py secret finding mismatch:\n bash={bash_issue!r}\n py  ={issue!r}"
+    )
 
 
 def test_check_secret_patterns_returns_on_first_match():


### PR DESCRIPTION
Gets CI green (red since 2026-07-04 across accumulated migration work).

**1. tests/conftest.py — the root cause.** ~30 CI-only failures (auto_merge, eval, reflect, mo_node_events, mo_otel, mo_steer, rebase_guard, …) all pass in isolation but fail in the single-process full suite: ported `main()` functions export `MINI_ORK_HOME/DB/RUN_ID/ROOT` into `os.environ`; called in-process from a test that leaks into the shared env, and a later bash-parity test inherits a stale/deleted `MINI_ORK_HOME` → bash and port diverge. An autouse env+cwd snapshot/restore fixture isolates it suite-wide (full suite: ~30 failures → 0; only local residue is web_smoke, which needs CI's `mini-ork init`).

**2. README.md** — entrypoint count 31 → 32 (the check counts `ls bin/mini-ork*` = dispatcher + 31 subcommands).

**3. secret-parity test** — a canary that asserted the pre-#131 broken bash secret scanner; tightened to enforce real bash+py parity now that it's fixed.

CodeQL already passes on the latest run.