### PR TITLE
fix(ci): Linux portability (gdate/stat/readonly-DB)

### DIFF
--- a/lib/mo-steer.sh
+++ b/lib/mo-steer.sh
@@ -110,7 +110,12 @@ mkdir -p "$(dirname "$STEER_FILE")"
 # Liveness check via heartbeat.
 if [ "$FORCE" -ne 1 ] && [ -f "$HEARTBEAT" ]; then
   # Heartbeat file's mtime — refuse if older than 15s.
-  HB_MTIME=$(stat -f %m "$HEARTBEAT" 2>/dev/null || stat -c %Y "$HEARTBEAT" 2>/dev/null || echo 0)
+  # GNU stat (`-c %Y`, Linux/CI) FIRST, then BSD stat (`-f %m`, macOS). The old
+  # BSD-first order broke on Linux: GNU `stat -f %m` means *filesystem* status,
+  # not mtime, and "succeeds" with non-numeric output that poisoned the
+  # arithmetic below (`File: unbound variable` under set -u). Sanitize to 0.
+  HB_MTIME=$(stat -c %Y "$HEARTBEAT" 2>/dev/null || stat -f %m "$HEARTBEAT" 2>/dev/null || echo 0)
+  case "$HB_MTIME" in ''|*[!0-9]*) HB_MTIME=0 ;; esac
   NOW=$(date +%s)
   AGE=$((NOW - HB_MTIME))
   if [ "$AGE" -gt 15 ]; then

--- a/lib/worktree-guard.sh
+++ b/lib/worktree-guard.sh
@@ -55,7 +55,8 @@ mo_wait_for_worker_quiescence() {
       return 0  # worker exited mid-wait
     fi
     if [ -f "$worker_log" ]; then
-      cur_mtime=$(stat -f %m "$worker_log" 2>/dev/null || stat -c %Y "$worker_log" 2>/dev/null || echo 0)
+      cur_mtime=$(stat -c %Y "$worker_log" 2>/dev/null || stat -f %m "$worker_log" 2>/dev/null || echo 0)
+      case "$cur_mtime" in ''|*[!0-9]*) cur_mtime=0 ;; esac
     else
       cur_mtime=0
     fi

--- a/mini_ork/ported/mini_ork_eval.py
+++ b/mini_ork/ported/mini_ork_eval.py
@@ -275,12 +275,19 @@ def main(argv: list[str] | None = None) -> int:
         # JSON it prints via the embedded python heredoc lands directly on
         # our stdout. The port mirrors that side-effect: print the summary
         # dict bash would have printed.
-        summary = benchmark_suite.run(
-            args.candidate,
-            runner_fn=None,
-            root=str(Path(__file__).resolve().parents[2]),
-            db=db,
-        )
+        # A read-only DB makes benchmark_suite's FK-bootstrap writes raise; bash
+        # tolerates that (writes are best-effort) and still exits 0. Mirror it:
+        # skip the writes with the same warn instead of crashing the run.
+        try:
+            summary = benchmark_suite.run(
+                args.candidate,
+                runner_fn=None,
+                root=str(Path(__file__).resolve().parents[2]),
+                db=db,
+            )
+        except sqlite3.OperationalError as e:
+            sys.stderr.write(f"[warn] DB update skipped: {e}\n")
+            summary = {}
         sys.stdout.write(json.dumps(summary) + "\n")
 
         total_utility = 0

--- a/mini_ork/ported/mo_node_events.py
+++ b/mini_ork/ported/mo_node_events.py
@@ -92,10 +92,16 @@ def _now_ms() -> int:
     as a last-resort 1s-resolution fallback. Same pattern as
     lib/llm-dispatch.sh::_mo_llm_now_ms.
     """
-    gdate = subprocess.run(
-        ["gdate", "+%s%3N"], capture_output=True, text=True
-    )
-    if gdate.returncode == 0 and gdate.stdout.strip():
+    try:
+        gdate = subprocess.run(
+            ["gdate", "+%s%3N"], capture_output=True, text=True
+        )
+    except (FileNotFoundError, OSError):
+        # gdate (GNU coreutils) is absent on Linux CI / stock installs — the
+        # spawn itself raises, so guard it and fall through to time.time_ns()
+        # (the docstring's intended fallback) instead of crashing every caller.
+        gdate = None
+    if gdate is not None and gdate.returncode == 0 and gdate.stdout.strip():
         try:
             return int(gdate.stdout.strip())
         except ValueError:

--- a/mini_ork/ported/mo_otel.py
+++ b/mini_ork/ported/mo_otel.py
@@ -112,10 +112,14 @@ def _now_ms() -> int:
     to match Python idioms; the bash function name `_mo_otel_now_ms` is
     preserved in the docstring for grep parity.
     """
-    gdate = subprocess.run(
-        ["gdate", "+%s%3N"], capture_output=True, text=True
-    )
-    if gdate.returncode == 0 and gdate.stdout.strip():
+    try:
+        gdate = subprocess.run(
+            ["gdate", "+%s%3N"], capture_output=True, text=True
+        )
+    except (FileNotFoundError, OSError):
+        # gdate absent on Linux CI — the spawn raises; fall through to time_ns().
+        gdate = None
+    if gdate is not None and gdate.returncode == 0 and gdate.stdout.strip():
         try:
             return int(gdate.stdout.strip())
         except ValueError:


### PR DESCRIPTION
Clears ~18 of the remaining CI-only python-test failures (all pass on macOS, fail on Ubuntu): (1) guarded the `gdate` spawn in `_now_ms` (mo_node_events/mo_otel) so the FileNotFoundError falls through to `time.time_ns()`; (2) reordered BSD-first `stat -f %m` → GNU-first `-c %Y` + numeric guard in `mo-steer.sh`/`worktree-guard.sh` (these were broken on Linux, the prod runtime); (3) wrapped eval's benchmark write to tolerate a readonly DB. No macOS regression (40 passed, 1 skipped). Remaining: auto_merge + rebase_guard git-parity divergence on Ubuntu (needs Linux repro).