### PR TITLE
fix(ci): git-identity fallback in auto_merge + rebase_guard (real root cause)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[yaml]"
-          pip install pytest fastapi uvicorn pytest-forked
+          pip install pytest fastapi uvicorn
 
       # The web smoke suite points the FastAPI route handlers at a real
       # state.db; init bootstraps the full schema so those tests run
@@ -127,14 +127,8 @@ jobs:
       - name: Bootstrap state.db
         run: ./bin/mini-ork init
 
-      # --forked runs each test in its own subprocess, so the parity suite's
-      # process-global state (leaked threads, sqlite WAL handles, accumulated
-      # FDs/temp state across 1200+ subprocess-spawning parity tests) can't bleed
-      # across tests. Every residual failure reproduced ONLY under full-suite
-      # accumulation, never in isolation; tests/conftest.py already restores
-      # env+cwd per test — --forked covers the rest at the process boundary.
       - name: Run pytest
-        run: python -m pytest tests/ -q -p no:cacheprovider --forked
+        run: python -m pytest tests/ -q -p no:cacheprovider
 
   ui:
     name: ui typecheck + build

--- a/mini_ork/ported/auto_merge.py
+++ b/mini_ork/ported/auto_merge.py
@@ -22,9 +22,27 @@ import subprocess
 from pathlib import Path
 
 
-def _git(cwd, *args) -> tuple[str, int]:
-    r = subprocess.run(["git", "-C", str(cwd), *args], capture_output=True, text=True)
+def _git(cwd, *args, env=None) -> tuple[str, int]:
+    r = subprocess.run(["git", "-C", str(cwd), *args], capture_output=True, text=True, env=env)
     return r.stdout.strip(), r.returncode
+
+
+def _identity_env(cwd) -> dict:
+    """Ambient env + a fallback git identity when the repo/global config (and
+    GIT_*_EMAIL env) provide none — so the squash `git commit` never dies with
+    'Author identity unknown' in identity-less environments (CI runners, fresh
+    repos). Configured identity is preserved (setdefault + only-when-unconfigured)."""
+    e = dict(os.environ)
+    if e.get("GIT_AUTHOR_EMAIL") and e.get("GIT_COMMITTER_EMAIL"):
+        return e
+    cfg = subprocess.run(["git", "-C", str(cwd), "config", "user.email"],
+                         capture_output=True, text=True).stdout.strip()
+    if not cfg:
+        e.setdefault("GIT_AUTHOR_NAME", "mini-ork")
+        e.setdefault("GIT_AUTHOR_EMAIL", "mini-ork@localhost")
+        e.setdefault("GIT_COMMITTER_NAME", "mini-ork")
+        e.setdefault("GIT_COMMITTER_EMAIL", "mini-ork@localhost")
+    return e
 
 
 def _sql(db, stmt) -> str:
@@ -221,7 +239,8 @@ def auto_merge(repo_root, mini_orch_dir, job_id, *, mini_ork_home, state_db,
                 _git(repo_root, "checkout", "--", ".")
                 failed += 1
                 continue
-            _, rc = _git(repo_root, "commit", "--no-verify", "-m", squash_msg)
+            _, rc = _git(repo_root, "commit", "--no-verify", "-m", squash_msg,
+                         env=_identity_env(repo_root))
             if rc != 0:
                 _git(repo_root, "checkout", "--", ".")
                 failed += 1

--- a/mini_ork/ported/rebase_guard.py
+++ b/mini_ork/ported/rebase_guard.py
@@ -22,9 +22,27 @@ import subprocess
 from pathlib import Path
 
 
-def _git(cwd, *args) -> tuple[str, int]:
-    r = subprocess.run(["git", "-C", str(cwd), *args], capture_output=True, text=True)
+def _git(cwd, *args, env=None) -> tuple[str, int]:
+    r = subprocess.run(["git", "-C", str(cwd), *args], capture_output=True, text=True, env=env)
     return r.stdout.strip(), r.returncode
+
+
+def _identity_env(cwd) -> dict:
+    """Ambient env + a fallback git identity when none is configured. `git rebase`
+    replays commits (new committer), so without an identity it dies with
+    'Committer identity unknown' in identity-less environments (CI, fresh repos).
+    Configured/env identity is preserved."""
+    e = dict(os.environ)
+    if e.get("GIT_AUTHOR_EMAIL") and e.get("GIT_COMMITTER_EMAIL"):
+        return e
+    cfg = subprocess.run(["git", "-C", str(cwd), "config", "user.email"],
+                         capture_output=True, text=True).stdout.strip()
+    if not cfg:
+        e.setdefault("GIT_AUTHOR_NAME", "mini-ork")
+        e.setdefault("GIT_AUTHOR_EMAIL", "mini-ork@localhost")
+        e.setdefault("GIT_COMMITTER_NAME", "mini-ork")
+        e.setdefault("GIT_COMMITTER_EMAIL", "mini-ork@localhost")
+    return e
 
 
 def _name_list(cwd, *diff_args) -> list[str]:
@@ -74,12 +92,12 @@ def rebase_branch_onto_main(epic: str, worktree: str, phase: str = "dispatch", *
     decision_path = os.path.join(run_dir, "rebase-decision.json")
 
     if not overlap_files:
-        _git(worktree, "rebase", "main")
+        _git(worktree, "rebase", "main", env=_identity_env(worktree))
         _write_rebase_decision(decision_path, branch_files, main_files, overlap_files,
                                "no_overlap_auto")
         return 0
 
-    _, rc = _git(worktree, "rebase", "main")
+    _, rc = _git(worktree, "rebase", "main", env=_identity_env(worktree))
     if rc == 0:
         decision = "overlap_attempted"
     else:


### PR DESCRIPTION
The last 2 CI failures were a real robustness bug, found via on-runner diagnostics: `git commit`/`git rebase` in the ports died with **'Author identity unknown'** because the GitHub runner has no git identity for the throwaway test repos (the bash side works only because the test passes GIT_AUTHOR_* to the bash subprocess; the ports run in-process). Reproduced the instant I dropped `git config --global user.*` from the container. Fix: a `mini-ork` fallback identity when none is configured (production identity preserved). Also reverts the #141 `--forked` change (wrong hypothesis — the tail was deterministic, not flaky).