### PR TITLE
fix(epics): harden ingest — skip (no-epic) headings + resolve dep targets

### DIFF
--- a/bin/mini-ork-epics
+++ b/bin/mini-ork-epics
@@ -8,13 +8,18 @@
 #   show <epic_id>         Inspect one epic + its deps
 #
 # Heuristic for ingest:
-#   Every `## <title>` heading becomes an epic. The epic id is the heading
-#   slug, with any explicit `(id: foo-1)` overriding. A line within the epic
-#   body matching one of:
+#   Every `## <title>` heading becomes an epic unless the heading ends with
+#   `(no-epic)`, `(context)`, or `(ignore)`. The epic id is the heading slug,
+#   with any explicit `(id: foo-1)` overriding. A line within the epic body
+#   matching one of:
 #       - depends on: <id>[, <id>...]
 #       - blocked by: <id>[, <id>...]
 #       - after: <id>[, <id>...]
 #   creates a hard `from → this` dependency. Soft deps use `should follow:`.
+#   Dependency lists split on commas only. Each token resolves by exact id,
+#   slugified exact id, unique slug prefix, then unique slug substring against
+#   parsed epics plus existing DB epics. Unresolved or ambiguous tokens emit a
+#   WARNING and are counted as skipped in the ingest summary.
 #   Headings not in any roadmap section are silently skipped.
 
 set -Eeuo pipefail
@@ -78,7 +83,7 @@ db, roadmap, repo_root = sys.argv[1:4]
 repo_root = Path(repo_root)
 text = Path(roadmap).read_text(encoding="utf-8", errors="replace")
 
-EPIC_RE = re.compile(r"^##\s+(.+?)\s*(?:\(id:\s*([\w.-]+)\))?\s*$")
+EPIC_RE = re.compile(r"^##\s+(.+?)\s*(?:\(id:\s*([\w.-]+)\))?\s*(?:\((no-epic|context|ignore)\))?\s*$", re.I)
 DEP_PATTERNS = (
     r"^\s*(?:-\s+)?(?:depends on|blocked by|after|requires|should follow|prefer after|related to|see also|context)\s*:.*$"
 )
@@ -86,6 +91,7 @@ DEP_RE = re.compile(DEP_PATTERNS, re.I)
 
 def slugify(title: str) -> str:
     s = re.sub(r"[^a-z0-9-]+", "-", title.lower().strip()).strip("-")
+    s = re.sub(r"-+", "-", s)
     return s or "epic"
 
 def extract_path_hints(body):
@@ -121,6 +127,9 @@ cur = None
 for raw in text.splitlines():
     m = EPIC_RE.match(raw)
     if m:
+        if m.group(3):
+            cur = None
+            continue
         title, explicit_id = m.group(1).strip(), (m.group(2) or "").strip()
         eid = explicit_id or slugify(title)
         cur = {"id": eid, "title": title, "body": []}
@@ -219,7 +228,7 @@ db, roadmap = sys.argv[1:3]
 text = Path(roadmap).read_text(encoding="utf-8", errors="replace")
 
 # Parse: split by `## ` headings. Body = lines until next ## heading.
-EPIC_RE = re.compile(r"^##\s+(.+?)\s*(?:\(id:\s*([\w.-]+)\))?\s*$")
+EPIC_RE = re.compile(r"^##\s+(.+?)\s*(?:\(id:\s*([\w.-]+)\))?\s*(?:\((no-epic|context|ignore)\))?\s*$", re.I)
 DEP_RES = {
     "hard": re.compile(r"^\s*(?:-\s+)?(?:depends on|blocked by|after|requires)\s*:\s*(.+)$", re.I),
     "soft": re.compile(r"^\s*(?:-\s+)?(?:should follow|prefer after)\s*:\s*(.+)$", re.I),
@@ -228,6 +237,7 @@ DEP_RES = {
 
 def slugify(title: str) -> str:
     s = re.sub(r"[^a-z0-9-]+", "-", title.lower().strip()).strip("-")
+    s = re.sub(r"-+", "-", s)
     return s or "epic"
 
 epics = []  # (id, title, body_lines)
@@ -235,6 +245,9 @@ cur = None
 for raw in text.splitlines():
     m = EPIC_RE.match(raw)
     if m:
+        if m.group(3):
+            cur = None
+            continue
         title, explicit_id = m.group(1).strip(), (m.group(2) or "").strip()
         eid = explicit_id or slugify(title)
         cur = {"id": eid, "title": title, "body": []}
@@ -258,7 +271,25 @@ epics = deduped
 con = sqlite3.connect(db)
 con.execute("PRAGMA busy_timeout=5000")
 
-inserted, dep_count = 0, 0
+parsed_epic_ids = {e["id"] for e in epics}
+existing_epic_ids = {row[0] for row in con.execute("SELECT id FROM epics").fetchall()}
+resolvable_epic_ids = parsed_epic_ids | existing_epic_ids
+
+def resolve_dep(token):
+    slug = slugify(token)
+    if token in resolvable_epic_ids:
+        return token
+    if slug in resolvable_epic_ids:
+        return slug
+    matches = [eid for eid in resolvable_epic_ids if eid.startswith(slug)]
+    if len(matches) == 1:
+        return matches[0]
+    matches = [eid for eid in resolvable_epic_ids if slug in eid]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+inserted, dep_count, skipped = 0, 0, 0
 for e in epics:
     # 1. Upsert the epic row. New epics default to 'not started'; existing
     #    rows are left alone (so re-ingest doesn't clobber in-flight state).
@@ -275,9 +306,18 @@ for e in epics:
             m = rgx.match(line)
             if not m:
                 continue
-            for raw_dep in re.split(r"[,\s]+", m.group(1)):
-                dep = raw_dep.strip().strip("`")
+            for raw_dep in re.split(r"\s*,\s*", m.group(1)):
+                token = raw_dep.strip().strip("`")
+                if not token:
+                    continue
+                dep = resolve_dep(token)
                 if not dep or dep == e["id"]:
+                    if token and not dep:
+                        print(
+                            f"WARNING: ingest: dep \"{token}\" from \"{e['id']}\" did not resolve; skipped",
+                            file=sys.stderr,
+                        )
+                        skipped += 1
                     continue
                 try:
                     con.execute(
@@ -303,7 +343,7 @@ con.execute("""
        )
 """)
 con.commit()
-print(f"ingest: {inserted} new epic(s), {dep_count} dep edge(s) processed")
+print(f"ingest: {inserted} new epic(s), {dep_count} dep edge(s) processed, {skipped} dep(s) skipped (unresolved)")
 PY
 }
 

--- a/mini_ork/ported/mini_ork_epics.py
+++ b/mini_ork/ported/mini_ork_epics.py
@@ -2,8 +2,12 @@
 
 Strangler-fig parity port of the subcommand CLI: ingest (roadmap md → epics +
 epic_dependencies + auto-block), split (per-epic kickoff files + kickoff_path),
-list, ready (via ported epic_graph), show, priority. Verbatim markdown/dep
-regexes and slug/dedupe/auto-block logic.
+list, ready (via ported epic_graph), show, priority. Every `## <title>`
+heading becomes an epic unless it ends with `(no-epic)`, `(context)`, or
+`(ignore)`. Dependency lists split on commas only; each token resolves by exact
+id, slugified exact id, unique slug prefix, then unique slug substring against
+parsed epics plus existing DB epics. Unresolved or ambiguous tokens emit a
+WARNING and are counted as skipped in the ingest summary.
 
     main(argv=None, *, db=None, root=None) -> int
 """
@@ -32,7 +36,7 @@ _USAGE = """Usage: mini-ork epics <subcommand> [args]
                                waiters (priority inheritance, Track B5).
 """
 
-_EPIC_RE = re.compile(r"^##\s+(.+?)\s*(?:\(id:\s*([\w.-]+)\))?\s*$")
+_EPIC_RE = re.compile(r"^##\s+(.+?)\s*(?:\(id:\s*([\w.-]+)\))?\s*(?:\((no-epic|context|ignore)\))?\s*$", re.I)
 _DEP_RES = {
     "hard": re.compile(r"^\s*(?:-\s+)?(?:depends on|blocked by|after|requires)\s*:\s*(.+)$", re.I),
     "soft": re.compile(r"^\s*(?:-\s+)?(?:should follow|prefer after)\s*:\s*(.+)$", re.I),
@@ -50,6 +54,7 @@ def _resolve_db(db):
 
 def _slugify(title: str) -> str:
     s = re.sub(r"[^a-z0-9-]+", "-", title.lower().strip()).strip("-")
+    s = re.sub(r"-+", "-", s)
     return s or "epic"
 
 
@@ -58,6 +63,9 @@ def _parse_epics(text: str):
     for raw in text.splitlines():
         m = _EPIC_RE.match(raw)
         if m:
+            if m.group(3):
+                cur = None
+                continue
             title = m.group(1).strip()
             eid = (m.group(2) or "").strip() or _slugify(title)
             cur = {"id": eid, "title": title, "body": []}
@@ -80,7 +88,25 @@ def ingest(roadmap: str, db: str) -> int:
     if not epics:
         sys.stderr.write("ingest: no '## <title>' headings found\n"); return 1
     con = sqlite3.connect(db); con.execute("PRAGMA busy_timeout=5000")
-    inserted = dep_count = 0
+    parsed_epic_ids = {e["id"] for e in epics}
+    existing_epic_ids = {row[0] for row in con.execute("SELECT id FROM epics").fetchall()}
+    resolvable_epic_ids = parsed_epic_ids | existing_epic_ids
+
+    def resolve_dep(token: str):
+        slug = _slugify(token)
+        if token in resolvable_epic_ids:
+            return token
+        if slug in resolvable_epic_ids:
+            return slug
+        matches = [eid for eid in resolvable_epic_ids if eid.startswith(slug)]
+        if len(matches) == 1:
+            return matches[0]
+        matches = [eid for eid in resolvable_epic_ids if slug in eid]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
+    inserted = dep_count = skipped = 0
     for e in epics:
         if not con.execute("SELECT id FROM epics WHERE id=?", (e["id"],)).fetchone():
             con.execute("INSERT INTO epics(id, title, status) VALUES(?,?,'not started')",
@@ -91,23 +117,31 @@ def ingest(roadmap: str, db: str) -> int:
                 m = rgx.match(line)
                 if not m:
                     continue
-                for raw_dep in re.split(r"[,\s]+", m.group(1)):
-                    dep = raw_dep.strip().strip("`")
+                for raw_dep in re.split(r"\s*,\s*", m.group(1)):
+                    token = raw_dep.strip().strip("`")
+                    if not token:
+                        continue
+                    dep = resolve_dep(token)
                     if not dep or dep == e["id"]:
+                        if not dep:
+                            sys.stderr.write(
+                                f"WARNING: ingest: dep \"{token}\" from \"{e['id']}\" did not resolve; skipped\n")
+                            skipped += 1
                         continue
                     try:
                         con.execute("INSERT OR IGNORE INTO epic_dependencies "
                                     "(from_epic_id, to_epic_id, kind) VALUES(?,?,?)",
                                     (dep, e["id"], kind))
                         dep_count += 1
-                    except sqlite3.Error:
-                        pass
+                    except sqlite3.Error as err:
+                        sys.stderr.write(f"ingest: dep insert failed ({dep}->{e['id']}): {err}\n")
     con.execute("""UPDATE epics SET status='blocked'
         WHERE status='not started' AND id IN (
             SELECT DISTINCT to_epic_id FROM epic_dependencies
              WHERE kind='hard' AND resolved_at IS NULL)""")
     con.commit(); con.close()
-    sys.stdout.write(f"ingest: {inserted} new epic(s), {dep_count} dep edge(s) processed\n")
+    sys.stdout.write(
+        f"ingest: {inserted} new epic(s), {dep_count} dep edge(s) processed, {skipped} dep(s) skipped (unresolved)\n")
     return 0
 
 

--- a/tests/unit/test_mini_ork_epics_py.py
+++ b/tests/unit/test_mini_ork_epics_py.py
@@ -34,7 +34,7 @@ def _env(root, home, db):
     return {**os.environ, "MINI_ORK_ROOT": str(root), "MINI_ORK_HOME": str(home), "MINI_ORK_DB": db}
 
 
-def _side(tmp_path, name):
+def _side(tmp_path, name, roadmap=ROADMAP):
     """A repo copy (so split writes into an isolated kickoffs/auto) + fresh db."""
     root = tmp_path / name
     root.mkdir()
@@ -49,7 +49,7 @@ def _side(tmp_path, name):
     subprocess.run(["bash", str(REPO / "db" / "init.sh")],
                    env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": db},
                    capture_output=True, text=True, check=True)
-    (root / "roadmap.md").write_text(ROADMAP)
+    (root / "roadmap.md").write_text(roadmap)
     return root, home, db
 
 
@@ -112,3 +112,76 @@ def test_priority_parity(tmp_path):
     rb_rc = subprocess.run(["bash", str(rb / "bin" / "mini-ork-epics"), "priority", "base-1", "x"],
                            env=_env(rb, hb, db_b), capture_output=True, text=True).returncode
     assert rb_rc == ep.main(["priority", "base-1", "x"], db=db_p, root=str(rp)) == 2
+
+
+def test_skip_marker_parity(tmp_path):
+    roadmap = """# Roadmap
+
+## Symptom (no-epic)
+This context must not become an epic or kickoff.
+
+## Epic A
+Do A.
+
+## Epic B
+Do B.
+"""
+    rb, hb, db_b = _side(tmp_path, "b", roadmap)
+    rp, hp, db_p = _side(tmp_path, "p", roadmap)
+    subprocess.run(["bash", str(rb / "bin" / "mini-ork-epics"), "ingest", str(rb / "roadmap.md")],
+                   env=_env(rb, hb, db_b), capture_output=True, text=True)
+    ep.main(["ingest", str(rp / "roadmap.md")], db=db_p, root=str(rp))
+    subprocess.run(["bash", str(rb / "bin" / "mini-ork-epics"), "split", str(rb / "roadmap.md")],
+                   env=_env(rb, hb, db_b), capture_output=True, text=True)
+    ep.main(["split", str(rp / "roadmap.md")], db=db_p, root=str(rp))
+    q_e = "SELECT id, title, status FROM epics ORDER BY id"
+    assert _rows(db_b, q_e) == _rows(db_p, q_e)
+    assert not _rows(db_p, "SELECT id FROM epics WHERE id='symptom'")
+    assert not (rb / "kickoffs" / "auto" / "symptom.md").exists()
+    assert not (rp / "kickoffs" / "auto" / "symptom.md").exists()
+
+
+def test_prose_dep_resolution_parity(tmp_path):
+    roadmap = """# Roadmap
+
+## Epic 0 - verify the diagnosis
+Verify the diagnosis.
+
+## Epic 1
+Implement the fix.
+depends on: Epic 0
+"""
+    rb, hb, db_b = _side(tmp_path, "b", roadmap)
+    rp, hp, db_p = _side(tmp_path, "p", roadmap)
+    subprocess.run(["bash", str(rb / "bin" / "mini-ork-epics"), "ingest", str(rb / "roadmap.md")],
+                   env=_env(rb, hb, db_b), capture_output=True, text=True)
+    ep.main(["ingest", str(rp / "roadmap.md")], db=db_p, root=str(rp))
+    q_d = "SELECT from_epic_id, to_epic_id, kind FROM epic_dependencies ORDER BY from_epic_id, to_epic_id"
+    assert _rows(db_b, q_d) == _rows(db_p, q_d)
+    assert ("epic-0-verify-the-diagnosis", "epic-1", "hard") in _rows(db_p, q_d)
+
+
+def test_unresolved_dep_warns_and_skips_parity(tmp_path):
+    roadmap = """# Roadmap
+
+## Epic 1
+Implement the fix.
+depends on: NonexistentEpic
+"""
+    rb, hb, db_b = _side(tmp_path, "b", roadmap)
+    rp, hp, db_p = _side(tmp_path, "p", roadmap)
+    ob = subprocess.run(["bash", str(rb / "bin" / "mini-ork-epics"), "ingest", str(rb / "roadmap.md")],
+                        env=_env(rb, hb, db_b), capture_output=True, text=True)
+    import io
+    from contextlib import redirect_stderr, redirect_stdout
+    stdout, stderr = io.StringIO(), io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        ep.main(["ingest", str(rp / "roadmap.md")], db=db_p, root=str(rp))
+    q_d = "SELECT from_epic_id, to_epic_id, kind FROM epic_dependencies ORDER BY from_epic_id, to_epic_id"
+    assert _rows(db_b, q_d) == _rows(db_p, q_d) == []
+    assert "WARNING" in ob.stderr
+    assert "NonexistentEpic" in ob.stderr
+    assert "WARNING" in stderr.getvalue()
+    assert "NonexistentEpic" in stderr.getvalue()
+    assert "1 dep(s) skipped" in ob.stdout
+    assert "1 dep(s) skipped" in stdout.getvalue()


### PR DESCRIPTION
## Problem

Two generic footguns in `epics ingest`, reproduced when ingesting a roadmap that has a context preamble plus epics with prose dependency lines:

1. **Every `## heading` became an epic.** Context/preamble sections (Symptom, Evidence, Constraints, ...) turned into junk epic rows — there was no way to mark a heading as non-epic.
2. **Dependency targets were never resolved to real epic ids, and failures were silent.** A natural `depends on: Epic 0` was split on whitespace and inserted raw as `from_epic_id` (the real id is the full slug, e.g. `epic-0-verify-the-diagnosis`). Result: bogus/dropped edges and a silent `0 dep edge(s)` — the dependent then runs out of order or blocks forever, with no signal to the author.

## Fix

- **Opt-out marker:** a heading ending in `(no-epic)` / `(context)` / `(ignore)` is skipped (heading + body). Backward-compatible — no existing roadmap uses these.
- **Dependency resolution:** split dep lists on commas only, and resolve each token to a real epic id — exact id, slugified-exact, unique slug-prefix, then unique slug-substring, across parsed + already-in-DB epics. Insert the edge only when it resolves to exactly one epic; otherwise emit a `WARNING` and count it as skipped in the summary. Never silently drop a dependency again.

## Parity

Applied identically to the legacy bash CLI (`bin/mini-ork-epics`) and the Python port (`mini_ork/ported/mini_ork_epics.py`) so the parity test stays green. Adds unit tests for the marker-skip, dep resolution, and the unresolved-warning path.

## Verification

- `python3 -m pytest tests/unit/test_mini_ork_epics_py.py -q` — 6 passed (3 original parity + 3 new).
- `bash -n bin/mini-ork-epics`; `python3 -m py_compile mini_ork/ported/mini_ork_epics.py` — clean.
- README Layer-1 claim-check — 7/7 probes CLEAN (no count drift from this change).

Note: local pre-push Layer-1 drift gate was bypassed with the hook sanctioned `MO_README_DRIFT_SKIP=1` — the drift originates from the main checkout unrelated WIP, not this change (this branch own claim-check passes 7/7).

https://claude.ai/code/session_01MEQ3iCysDCxmTbvYa8PgMj
