### PR TITLE
fix(plan): repair invalid planner JSON via bounded LLM retry, not a hardcoded plan

### DIFF
--- a/bin/mini-ork-plan
+++ b/bin/mini-ork-plan
@@ -17,6 +17,11 @@
 #   MINI_ORK_TASK_CLASS     Set by mini-ork-classify (or pass --task-class)
 #   MINI_ORK_WORKFLOW       Path to active workflow.yaml
 #   MINI_ORK_RECIPE         Active recipe name
+#   MO_PLAN_MAX_REPAIRS     Recoverable planner-output repair retries (default: 2)
+#   MO_PLAN_DETERMINISTIC_FALLBACK
+#                           Use deterministic recipe fallback after recoverable
+#                           planner-output rejection (default: 0; otherwise
+#                           repair retries are exhausted, then planning fails)
 #
 # Flags:
 #   --task-class <name>     Override task class
@@ -942,18 +947,262 @@ print(json.dumps(plan, indent=2))
 PY
 }
 
-if [ "$HAS_VERIFIER" = "missing_verifier_contract" ]; then
-  _d015_preserve_raw "missing_verifier_contract"
-  if PLAN_JSON=$(_d015_recipe_fallback_plan); then
-    echo "PLAN WARNING: planner output did not expose verifier_contract.checks; using deterministic recipe fallback plan." >&2
-    HAS_VERIFIER="ok"
-  else
-    echo "PLAN REJECTED: verifier_contract.checks is missing or empty." >&2
-    echo "A plan is not complete until success-check is defined." >&2
-    _d015_mark_plan_failed "missing_verifier_contract"
-    trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"missing_verifier_contract\"}" >/dev/null 2>&1 || true
-    exit 1
+_d015_charge_cost() {
+  if [ -f "${MINI_ORK_DB:-}" ] && [ -n "${RUN_ID:-}" ]; then
+    python3 -c "
+import sqlite3, sys, time
+con = sqlite3.connect(sys.argv[1])
+con.execute('PRAGMA journal_mode=WAL')
+con.execute(\"UPDATE task_runs SET cost_usd=COALESCE(cost_usd,0)+0.05, updated_at=? WHERE id=?\", (int(time.time()), sys.argv[2]))
+con.commit(); con.close()
+" "$MINI_ORK_DB" "$RUN_ID" 2>/dev/null || true
   fi
+}
+
+_d015_detect_truncation() {
+  PLAN_JSON_RAW="$PLAN_JSON_RAW" python3 <<'PY'
+import os
+raw = (os.environ.get("PLAN_JSON_RAW", "") or "").rstrip()[-200:]
+depth = 0
+in_str = False
+esc = False
+for c in raw:
+    if in_str:
+        if esc:
+            esc = False
+        elif c == "\\":
+            esc = True
+        elif c == '"':
+            in_str = False
+        continue
+    if c == '"':
+        in_str = True
+    elif c == "{":
+        depth += 1
+    elif c == "}":
+        depth -= 1
+print("1" if depth > 0 else "0")
+PY
+}
+
+_d015_repair_retry() {
+  local original_prompt="$1"
+  local raw_invalid="$2"
+  local verdict="$3"
+  local truncated="$4"
+  local repair_prompt
+  repair_prompt=$(python3 - "$original_prompt" "$raw_invalid" "$verdict" "$truncated" <<'PY'
+import sys
+
+original_prompt, raw_invalid, verdict, truncated = sys.argv[1:5]
+flag = "yes" if truncated == "1" else "no"
+print(f"""{original_prompt}
+
+--- INVALID PLANNER OUTPUT ---
+{raw_invalid}
+--- /INVALID PLANNER OUTPUT ---
+
+The previous planner output was rejected with verdict: {verdict}
+Trailing-window truncation suspected: {flag}
+
+Return a corrected planner plan using this required JSON schema:
+  objective: string
+  decomposition: array of steps, each with node_type set to one of planner, researcher, implementer, reviewer, verifier, reflector, publisher, rollback
+  verifier_contract.checks: non-empty array
+  artifact_contract: object
+
+No prose, no markdown fences, return ONLY valid JSON.
+""", end="")
+PY
+)
+  if [ -n "$_plan_dispatch_err" ]; then
+    llm_dispatch \
+      --task-class "$TASK_CLASS" \
+      --node-type "planner" \
+      --prompt-text "$repair_prompt" \
+      2>"$_plan_dispatch_err"
+  else
+    llm_dispatch \
+      --task-class "$TASK_CLASS" \
+      --node-type "planner" \
+      --prompt-text "$repair_prompt"
+  fi
+}
+
+_d015_extract_plan_json() {
+  PLAN_JSON_RAW="$PLAN_JSON_RAW" python3 <<'PY'
+import json, os, sys
+txt = os.environ.get("PLAN_JSON_RAW", "")
+
+def objects(s):
+    i = 0
+    while True:
+        start = s.find('{', i)
+        if start < 0:
+            return
+        depth = 0
+        in_str = False
+        esc = False
+        for j in range(start, len(s)):
+            c = s[j]
+            if in_str:
+                if esc:
+                    esc = False
+                elif c == '\\':
+                    esc = True
+                elif c == '"':
+                    in_str = False
+                continue
+            if c == '"':
+                in_str = True
+            elif c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+                if depth == 0:
+                    yield s[start:j+1]
+                    i = j + 1
+                    break
+        else:
+            return
+
+def contains_placeholder(v):
+    if isinstance(v, str):
+        stripped = v.strip()
+        return stripped.startswith('<') and stripped.endswith('>')
+    if isinstance(v, list):
+        return any(contains_placeholder(x) for x in v)
+    if isinstance(v, dict):
+        return any(contains_placeholder(x) for x in v.values())
+    return False
+
+def is_plan(obj):
+    if not isinstance(obj, dict):
+        return False
+    if not isinstance(obj.get('verifier_contract'), dict):
+        return False
+    if not obj.get('verifier_contract', {}).get('checks'):
+        return False
+    if contains_placeholder(obj):
+        return False
+    return any(k in obj for k in ('objective', 'decomposition', 'artifact_contract'))
+
+first = None
+for chunk in objects(txt):
+    if first is None:
+        first = chunk
+    try:
+        parsed = json.loads(chunk)
+    except Exception:
+        continue
+    if is_plan(parsed):
+        sys.stdout.write(json.dumps(parsed, indent=2))
+        sys.exit(0)
+
+sys.stdout.write(first if first is not None else txt)
+PY
+}
+
+_d015_validate_plan() {
+  echo "$PLAN_JSON" | python3 -c "
+import sys, json
+NODE_TYPES = {'planner','researcher','implementer','reviewer','verifier','reflector','publisher','rollback'}
+try:
+    p = json.load(sys.stdin)
+    vc = p.get('verifier_contract', {})
+    checks = vc.get('checks', [])
+    if not checks:
+        print('missing_verifier_contract'); sys.exit(0)
+    def contains_placeholder(v):
+        if isinstance(v, str):
+            s = v.strip()
+            return s.startswith('<') and s.endswith('>')
+        if isinstance(v, list):
+            return any(contains_placeholder(x) for x in v)
+        if isinstance(v, dict):
+            return any(contains_placeholder(x) for x in v.values())
+        return False
+    if contains_placeholder(p):
+        print('placeholder_plan'); sys.exit(0)
+    ac = p.get('artifact_contract', {})
+    if not isinstance(ac, dict):
+        print('bad_artifact_contract'); sys.exit(0)
+    bad_steps = []
+    for i, step in enumerate(p.get('decomposition', []) or []):
+        nt = (step.get('node_type') or '').strip()
+        if not nt:
+            bad_steps.append(f'step[{i}] {step.get(\"id\",\"?\")}: empty node_type')
+        elif nt not in NODE_TYPES:
+            bad_steps.append(f'step[{i}] {step.get(\"id\",\"?\")}: node_type={nt!r} not in {sorted(NODE_TYPES)}')
+    if bad_steps:
+        print('bad_node_types:' + '|'.join(bad_steps), file=sys.stderr)
+        print('bad_node_types'); sys.exit(0)
+    print('ok')
+except Exception as e:
+    print(f'parse_error:{e}', file=sys.stderr)
+    print('parse_error')
+" 2>&1 | tail -1
+}
+
+if [ "$HAS_VERIFIER" = "placeholder_plan" ]; then
+  echo "PLAN REJECTED: planner emitted a template plan with placeholder values." >&2
+  echo "The selected plan must name real files, sections, actions, and verifier checks." >&2
+  _d015_preserve_raw "placeholder_plan"
+  _d015_mark_plan_failed "placeholder_plan"
+  trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"placeholder_plan\"}" >/dev/null 2>&1 || true
+  exit 1
+fi
+
+if [ -z "${MO_GIVEN_PLAN:-}" ]; then
+  case "$HAS_VERIFIER" in
+    parse_error|missing_verifier_contract|bad_artifact_contract|bad_node_types)
+      _d015_first_verdict="$HAS_VERIFIER"
+      _d015_preserve_raw "$_d015_first_verdict"
+      if [ "${MO_PLAN_DETERMINISTIC_FALLBACK:-0}" = "1" ]; then
+        if PLAN_JSON=$(_d015_recipe_fallback_plan); then
+          echo "PLAN WARNING: planner output was invalid; using deterministic recipe fallback plan because MO_PLAN_DETERMINISTIC_FALLBACK=1." >&2
+          HAS_VERIFIER="ok"
+        fi
+      else
+        _d015_max_repairs="${MO_PLAN_MAX_REPAIRS:-2}"
+        case "$_d015_max_repairs" in
+          ''|*[!0-9]*) _d015_max_repairs=2 ;;
+        esac
+        _d015_attempt=1
+        while [ "$_d015_attempt" -le "$_d015_max_repairs" ]; do
+          echo "PLAN REPAIR: retrying planner output repair (${_d015_attempt}/${_d015_max_repairs}) after ${HAS_VERIFIER}." >&2
+          _d015_truncated="$(_d015_detect_truncation)"
+          if PLAN_JSON_RAW=$(_d015_repair_retry "$PROMPT_TEXT" "$PLAN_JSON_RAW" "$HAS_VERIFIER" "$_d015_truncated"); then
+            _d015_charge_cost
+          else
+            _d015_charge_cost
+            echo "LLM dispatch failed for planner repair" >&2
+            if [ -n "$_plan_dispatch_err" ] && [ -s "$_plan_dispatch_err" ]; then
+              echo "  dispatch stderr (last 20 lines from $_plan_dispatch_err):" >&2
+              tail -20 "$_plan_dispatch_err" | sed 's/^/    /' >&2
+            fi
+            _d015_mark_plan_failed "$_d015_first_verdict"
+            trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"${_d015_first_verdict}\"}" >/dev/null 2>&1 || true
+            exit 1
+          fi
+          PLAN_JSON=$(_d015_extract_plan_json)
+          HAS_VERIFIER=$(_d015_validate_plan)
+          _d015_preserve_raw "$_d015_first_verdict"
+          [ "$HAS_VERIFIER" = "ok" ] && break
+          [ "$HAS_VERIFIER" = "placeholder_plan" ] && break
+          _d015_attempt=$((_d015_attempt + 1))
+        done
+      fi
+      ;;
+  esac
+fi
+
+if [ "$HAS_VERIFIER" = "missing_verifier_contract" ]; then
+  echo "PLAN REJECTED: verifier_contract.checks is missing or empty." >&2
+  echo "A plan is not complete until success-check is defined." >&2
+  _d015_mark_plan_failed "missing_verifier_contract"
+  trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"missing_verifier_contract\"}" >/dev/null 2>&1 || true
+  exit 1
 fi
 
 if [ "$HAS_VERIFIER" = "placeholder_plan" ]; then
@@ -967,7 +1216,6 @@ fi
 
 if [ "$HAS_VERIFIER" = "bad_artifact_contract" ]; then
   echo "PLAN REJECTED: artifact_contract must be an object." >&2
-  _d015_preserve_raw "bad_artifact_contract"
   _d015_mark_plan_failed "bad_artifact_contract"
   trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"bad_artifact_contract\"}" >/dev/null 2>&1 || true
   exit 1
@@ -976,23 +1224,16 @@ fi
 if [ "$HAS_VERIFIER" = "bad_node_types" ]; then
   echo "PLAN REJECTED: one or more decomposition[].node_type values are empty or invalid (D-008b)." >&2
   echo "Each step must declare node_type as one of: planner|researcher|implementer|reviewer|verifier|reflector|publisher|rollback" >&2
-  _d015_preserve_raw "bad_node_types"
   _d015_mark_plan_failed "bad_node_types"
   trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"bad_node_types\"}" >/dev/null 2>&1 || true
   exit 1
 fi
 
 if [ "$HAS_VERIFIER" = "parse_error" ]; then
-  _d015_preserve_raw "parse_error"
-  if PLAN_JSON=$(_d015_recipe_fallback_plan); then
-    echo "PLAN WARNING: planner emitted invalid JSON; using deterministic recipe fallback plan." >&2
-    HAS_VERIFIER="ok"
-  else
-    echo "PLAN REJECTED: planner emitted non-JSON output." >&2
-    _d015_mark_plan_failed "parse_error"
-    trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"parse_error\"}" >/dev/null 2>&1 || true
-    exit 1
-  fi
+  echo "PLAN REJECTED: planner emitted non-JSON output." >&2
+  _d015_mark_plan_failed "parse_error"
+  trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"failure\",\"reviewer_verdict\":\"parse_error\"}" >/dev/null 2>&1 || true
+  exit 1
 fi
 
 # ── write plan ────────────────────────────────────────────────────────────────

--- a/mini_ork/ported/mini_ork_plan.py
+++ b/mini_ork/ported/mini_ork_plan.py
@@ -4,8 +4,13 @@ Strangler-fig parity port. Reads task_class + kickoff, builds the planner prompt
 (recipe > workflow > built-in), injects learnings/CN context (best-effort),
 dispatches the planner LLM, then extracts + validates the plan JSON through a
 chain of quality gates (D-011/016/052 extraction, D-008b node-type check,
-placeholder/parse rejection with recipe-fallback), overlays the recipe
-artifact_contract, and writes plan.json + the task_runs row.
+placeholder/parse rejection), retries recoverable invalid planner output with a
+repair prompt, overlays the recipe artifact_contract, and writes plan.json + the
+task_runs row.
+
+Recoverable planner verdicts default to repair-then-fail: the port retries up
+to MO_PLAN_MAX_REPAIRS times (default: 2), then rejects the plan. The old
+deterministic recipe fallback is only used when MO_PLAN_DETERMINISTIC_FALLBACK=1.
 
 The one non-deterministic seam is the LLM dispatch (``dispatch=``); MO_GIVEN_PLAN
 and --dry-run skip it. Every embedded-python block (extraction, validation,
@@ -24,6 +29,8 @@ from pathlib import Path
 
 _NODE_TYPES = {"planner", "researcher", "implementer", "reviewer", "verifier",
                "reflector", "publisher", "rollback"}
+_RECOVERABLE_VERDICTS = {"parse_error", "missing_verifier_contract",
+                         "bad_artifact_contract", "bad_node_types"}
 
 # Verbatim heredoc from bin/mini-ork-plan (dry-run placeholder, inline objects).
 _DRY_RUN_PLACEHOLDER = """{
@@ -167,6 +174,50 @@ def validate_plan(plan_json: str) -> str:
     except Exception as e:
         sys.stderr.write(f"parse_error:{e}\n")
         return "parse_error"
+
+
+def _detect_truncation(raw: str) -> bool:
+    depth = 0
+    in_str = False
+    esc = False
+    for c in (raw or "").rstrip()[-200:]:
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+            continue
+        if c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+    return depth > 0
+
+
+def _build_repair_prompt(root, kickoff, workflow, profile_path, raw_invalid, verdict, truncated) -> str:
+    original = _build_prompt(root, kickoff, workflow, profile_path)
+    truncation_note = "yes" if truncated else "no"
+    return f"""{original}
+
+--- INVALID PLANNER OUTPUT ---
+{raw_invalid or ""}
+--- /INVALID PLANNER OUTPUT ---
+
+The previous planner output was rejected with verdict: {verdict}
+Trailing-window truncation suspected: {truncation_note}
+
+Return a corrected planner plan using this required JSON schema:
+  objective: string
+  decomposition: array of steps, each with node_type set to one of planner, researcher, implementer, reviewer, verifier, reflector, publisher, rollback
+  verifier_contract.checks: non-empty array
+  artifact_contract: object
+
+No prose, no markdown fences, return ONLY valid JSON.
+"""
 
 
 def recipe_fallback_plan(recipe, workflow_path, root, kickoff) -> str | None:
@@ -448,33 +499,54 @@ def main(argv=None, *, root=None, dispatch=None) -> int:
     _charge_cost(db, run_id)
     verdict = validate_plan(plan_json)
 
-    if verdict == "missing_verifier_contract":
-        _preserve_raw(home, run_id, verdict, raw, plan_json)
-        fb = recipe_fallback_plan(recipe, workflow, root, kickoff)
-        if fb:
-            plan_json, verdict = fb, "ok"
-            sys.stderr.write("PLAN WARNING: planner output did not expose verifier_contract.checks; using deterministic recipe fallback plan.\n")
+    if not given and verdict in _RECOVERABLE_VERDICTS:
+        first_verdict = verdict
+        _preserve_raw(home, run_id, first_verdict, raw, plan_json)
+        if os.environ.get("MO_PLAN_DETERMINISTIC_FALLBACK", "0") == "1":
+            fb = recipe_fallback_plan(recipe, workflow, root, kickoff)
+            if fb:
+                plan_json, verdict = fb, "ok"
+                sys.stderr.write("PLAN WARNING: planner output was invalid; using deterministic recipe fallback plan because MO_PLAN_DETERMINISTIC_FALLBACK=1.\n")
         else:
-            sys.stderr.write("PLAN REJECTED: verifier_contract.checks is missing or empty.\n")
-            _mark_failed(db, run_id, verdict); return 1
+            try:
+                max_repairs = int(os.environ.get("MO_PLAN_MAX_REPAIRS", "2"))
+            except ValueError:
+                max_repairs = 2
+            for attempt in range(1, max(0, max_repairs) + 1):
+                sys.stderr.write(f"PLAN REPAIR: retrying planner output repair ({attempt}/{max_repairs}) after {verdict}.\n")
+                truncated = _detect_truncation(raw)
+                repair_prompt = _build_repair_prompt(root, kickoff, workflow, profile_path,
+                                                     raw, verdict, truncated)
+                rc, repaired = dispatch(task_class, "planner", repair_prompt)
+                _charge_cost(db, run_id)
+                if rc != 0:
+                    sys.stderr.write("LLM dispatch failed for planner repair\n")
+                    _mark_failed(db, run_id, first_verdict)
+                    return 1
+                raw = repaired
+                plan_json = extract_plan_json(raw)
+                verdict = validate_plan(plan_json)
+                _preserve_raw(home, run_id, first_verdict, raw, plan_json)
+                if verdict == "ok":
+                    break
+                if verdict == "placeholder_plan":
+                    break
+
+    if verdict == "missing_verifier_contract":
+        sys.stderr.write("PLAN REJECTED: verifier_contract.checks is missing or empty.\n")
+        _mark_failed(db, run_id, verdict); return 1
     if verdict == "placeholder_plan":
         sys.stderr.write("PLAN REJECTED: planner emitted a template plan with placeholder values.\n")
         _preserve_raw(home, run_id, verdict, raw, plan_json); _mark_failed(db, run_id, verdict); return 1
     if verdict == "bad_artifact_contract":
         sys.stderr.write("PLAN REJECTED: artifact_contract must be an object.\n")
-        _preserve_raw(home, run_id, verdict, raw, plan_json); _mark_failed(db, run_id, verdict); return 1
+        _mark_failed(db, run_id, verdict); return 1
     if verdict == "bad_node_types":
         sys.stderr.write("PLAN REJECTED: one or more decomposition[].node_type values are empty or invalid (D-008b).\n")
-        _preserve_raw(home, run_id, verdict, raw, plan_json); _mark_failed(db, run_id, verdict); return 1
+        _mark_failed(db, run_id, verdict); return 1
     if verdict == "parse_error":
-        _preserve_raw(home, run_id, verdict, raw, plan_json)
-        fb = recipe_fallback_plan(recipe, workflow, root, kickoff)
-        if fb:
-            plan_json, verdict = fb, "ok"
-            sys.stderr.write("PLAN WARNING: planner emitted invalid JSON; using deterministic recipe fallback plan.\n")
-        else:
-            sys.stderr.write("PLAN REJECTED: planner emitted non-JSON output.\n")
-            _mark_failed(db, run_id, verdict); return 1
+        sys.stderr.write("PLAN REJECTED: planner emitted non-JSON output.\n")
+        _mark_failed(db, run_id, verdict); return 1
 
     plan_json = overlay_plan(plan_json, task_class, profile_path, root)
     os.makedirs(os.path.dirname(out_file), exist_ok=True)

--- a/tests/unit/test_mini_ork_plan_py.py
+++ b/tests/unit/test_mini_ork_plan_py.py
@@ -47,7 +47,9 @@ def _kick(tmp):
 def _env(home, db, given=None, extra=None):
     e = {**os.environ, "MINI_ORK_ROOT": str(REPO), "MINI_ORK_HOME": home, "MINI_ORK_DB": db,
          "MINI_ORK_TASK_CLASS": "code_fix", "MO_INJECT_LEARNINGS": "0",
-         "MINI_ORK_PROFILE_GATE": "0", "MINI_ORK_RUN_ID": "run-fixed-1"}
+         "MINI_ORK_PROFILE_GATE": "0", "MINI_ORK_PROFILE_PATH": "",
+         "MINI_ORK_NONINTERACTIVE": "1", "MO_AUTO_ANSWER_PROFILE": "0",
+         "MINI_ORK_RUN_ID": "run-fixed-1"}
     if given:
         e["MO_GIVEN_PLAN"] = given
     if extra:
@@ -68,6 +70,28 @@ def _run_py(home, db, kickoff, out, given=None, extra=None):
     finally:
         os.environ.clear(); os.environ.update(old)
     return rc
+
+
+def _run_py_dispatch(home, db, kickoff, out, dispatch, extra=None):
+    old = dict(os.environ)
+    os.environ.clear(); os.environ.update(_env(home, db, extra=extra))
+    try:
+        rc = plan.main([kickoff, "--out", out], root=str(REPO), dispatch=dispatch)
+    finally:
+        os.environ.clear(); os.environ.update(old)
+    return rc
+
+
+def _fake_dispatch(*responses):
+    calls = {"n": 0}
+
+    def dispatch(_task_class, _node_type, _prompt):
+        i = min(calls["n"], len(responses) - 1)
+        calls["n"] += 1
+        return 0, responses[i]
+
+    dispatch.calls = calls
+    return dispatch
 
 
 def _taskrow(db):
@@ -180,3 +204,60 @@ def test_flag_errors_parity(tmp_path):
         plan.main(["--bogus"], root=str(REPO)) == 2
     assert subprocess.run(["bash", str(BIN), "/no/such.md"], capture_output=True, env=e).returncode == \
         plan.main(["/no/such.md"], root=str(REPO)) == 2
+
+
+def test_repair_recovers_parse_error(tmp_path):
+    home, db = _home(tmp_path, "repair-ok")
+    k = _kick(tmp_path)
+    out = str(tmp_path / "repair-ok.json")
+    dispatch = _fake_dispatch("not json", json.dumps(_VALID))
+
+    rc = _run_py_dispatch(home, db, k, out, dispatch)
+
+    assert rc == 0
+    assert dispatch.calls["n"] == 2
+    assert json.loads(Path(out).read_text())["objective"] == _VALID["objective"]
+
+
+def test_repair_exhausted_hard_fail(tmp_path, capsys):
+    home, db = _home(tmp_path, "repair-fail")
+    k = _kick(tmp_path)
+    out = str(tmp_path / "repair-fail.json")
+    dispatch = _fake_dispatch("not json")
+
+    rc = _run_py_dispatch(home, db, k, out, dispatch)
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert dispatch.calls["n"] == 3
+    assert "PLAN REJECTED" in captured.err
+
+
+def test_mo_plan_deterministic_fallback_opt_in(tmp_path):
+    home, db = _home(tmp_path, "repair-fallback")
+    k = _kick(tmp_path)
+    out = str(tmp_path / "repair-fallback.json")
+    recipe = tmp_path / "recipes" / "demo"
+    recipe.mkdir(parents=True)
+    workflow = recipe / "workflow.yaml"
+    workflow.write_text(
+        "nodes:\n"
+        "  - name: implement\n"
+        "    type: implementer\n"
+        "edges: []\n"
+        "outputs:\n"
+        "  - plan.json\n"
+        "success_verifiers:\n"
+        "  - verifiers/test.sh\n"
+    )
+    dispatch = _fake_dispatch("not json")
+
+    rc = _run_py_dispatch(home, db, k, out, dispatch, extra={
+        "MO_PLAN_DETERMINISTIC_FALLBACK": "1",
+        "MINI_ORK_RECIPE": "demo",
+        "MINI_ORK_WORKFLOW": str(workflow),
+    })
+
+    assert rc == 0
+    assert dispatch.calls["n"] == 1
+    assert json.loads(Path(out).read_text())["objective"].startswith("Execute recipe ")


### PR DESCRIPTION
## Problem

When the planner LLM returns invalid JSON (or a plan missing `verifier_contract.checks`), mini-ork prints `PLAN WARNING: planner emitted invalid JSON; using deterministic recipe fallback plan.` and silently substitutes a hardcoded plan built from `workflow.yaml`. That plan lacks model-authored verifier commands and degrades planning quality — planning stops being LLM-driven exactly when it matters.

## Fix — bounded LLM repair-retry, grounded in the literature

Replace the deterministic degradation with an LLM repair-retry loop:

- **Iterative self-repair** (arXiv:2604.10508) + **error-reflection prompting** (arXiv:2508.16729): re-invoke the planner with its raw invalid output + the EXACT validation error + an instruction to return ONLY valid JSON, restating the required schema keys (**schema-key wording**, arXiv:2604.14862).
- **Truncation guard** (arXiv:2605.13076 / JSONSchemaBench arXiv:2501.10868): detect unbalanced-brace truncation — a top cause of invalid JSON — and flag it in the repair prompt.

### Behavior

- Recoverable validation failures (`parse_error` / `missing_verifier_contract` / `bad_artifact_contract` / `bad_node_types`) trigger up to `MO_PLAN_MAX_REPAIRS` (default 2) LLM repair attempts, re-validated each time.
- Repairs exhausted → planning **hard-fails** (`exit 1`, D-015 forensics preserved) — Zero-Fallback, never a silent hardcoded plan.
- The old deterministic fallback survives only behind explicit `MO_PLAN_DETERMINISTIC_FALLBACK=1` (default OFF).

## Parity

Applied identically to `bin/mini-ork-plan` and `mini_ork/ported/mini_ork_plan.py`; keeps `tests/unit/test_mini_ork_plan_py.py` green and adds tests for repair-recovery, exhaustion hard-fail, and the deterministic opt-in.

## Verification

- `python3 -m pytest tests/unit/test_mini_ork_plan_py.py -q` — 12 passed.
- `bash -n bin/mini-ork-plan`; `python3 -m py_compile mini_ork/ported/mini_ork_plan.py` — clean.

_Local pre-push Layer-1 drift gate bypassed via the hook-sanctioned `MO_README_DRIFT_SKIP=1` (drift is from the main checkout's unrelated WIP; this branch's own claim-check passes)._

https://claude.ai/code/session_01MEQ3iCysDCxmTbvYa8PgMj
