### PR TITLE
port(py): mini-ork-execute live-path support helpers (increment 4)

### DIFF
--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -14,6 +14,8 @@ Ported here (all pure / transcribed verbatim):
     infer_trace_code_region(payload)        — files_written → top-level code region
     learning_update_conductor_outcomes(db)  — resolve pending conductor decisions
     write_grpo_advantages(db)               — GRPO group-relative advantage writeback
+    set_status / charge_node_cost           — per-node DB status + cost writes
+    apply_impl_output                       — 'capture coin-flip' diff/fenced-block applier
 """
 from __future__ import annotations
 
@@ -21,8 +23,11 @@ import datetime
 import json
 import math
 import os
+import re
 import sqlite3
+import subprocess
 import sys
+import time
 
 _SEP = "\x1f"
 _NODE_TYPE_ORDER = ("planner", "researcher", "implementer", "reviewer", "verifier",
@@ -614,6 +619,155 @@ def main(argv=None, *, root=None, dispatch_fn=None) -> int:
         return 1
     print("\nexecute: all nodes complete")
     return 0
+
+
+# ── per-node live-path support helpers (deterministic; increment 4) ──
+#
+# These are the deterministic operations _dispatch_node's live (non-dry-run)
+# branches wire around the LLM call: DB status/cost writes and the "capture
+# coin-flip" output applier. Ported + parity-gated ahead of the live routing
+# (whose LLM dispatch is integration territory).
+
+def set_status(db, run_id, new_status, *, dry_run=False):
+    """Verbatim port of _d021_set_status: retrying task_runs status write;
+    terminal states stamp ended_at + duration_ms."""
+    if dry_run or not db or not run_id or not os.path.isfile(db):
+        return
+    terminal = {"published", "rolled_back", "failed"}
+    last_err = None
+    for attempt in range(3):
+        try:
+            con = sqlite3.connect(db, timeout=15.0)
+            con.execute("PRAGMA busy_timeout = 15000")
+            con.execute("PRAGMA journal_mode=WAL")
+            try:
+                if new_status in terminal:
+                    now = int(time.time())
+                    con.execute(
+                        "UPDATE task_runs SET status = ?, updated_at = ?, ended_at = COALESCE(ended_at, ?), "
+                        "duration_ms = CASE WHEN COALESCE(duration_ms, 0) = 0 "
+                        "THEN MAX(COALESCE(ended_at, ?) - created_at, 0) * 1000 "
+                        "ELSE duration_ms END WHERE id = ?",
+                        (new_status, now, now, now, run_id))
+                else:
+                    con.execute("UPDATE task_runs SET status = ?, updated_at = ? WHERE id = ?",
+                                (new_status, int(time.time()), run_id))
+                con.commit()
+                last_err = None
+                break
+            finally:
+                con.close()
+        except sqlite3.OperationalError as e:
+            last_err = e
+            time.sleep(0.5 * (attempt + 1))
+    if last_err is not None:
+        sys.stderr.write(f"[warn] set_status({new_status}) failed after retries: {last_err}\n")
+
+
+def charge_node_cost(db, run_id, cost_file="", *, dry_run=False, root=None):
+    """Verbatim port of _d022_charge_node_cost: charge the node's real LLM cost
+    (from the .last-llm-cost sidecar; $0.01 placeholder otherwise), then the
+    reactive cost-pause check (bash lib seam — sets MO_NODE_FINISH_REASON)."""
+    if dry_run or not db or not run_id or not os.path.isfile(db):
+        return
+    cost = "0.01"
+    if cost_file and os.path.isfile(cost_file):
+        raw = open(cost_file).read().strip()
+        try:
+            v = float(raw)
+            if 0 < v < 10:
+                cost = raw
+        except ValueError:
+            pass
+    try:
+        con = sqlite3.connect(db)
+        con.execute("PRAGMA journal_mode=WAL")
+        con.execute("PRAGMA busy_timeout=5000")
+        con.execute("UPDATE task_runs SET cost_usd = COALESCE(cost_usd,0) + ?, updated_at = ? WHERE id = ?",
+                    (float(cost), int(time.time()), run_id))
+        con.commit(); con.close()
+    except Exception:
+        pass
+    root = root or os.environ.get("MINI_ORK_ROOT", "")
+    pause = os.path.join(root, "lib", "cost_pause.sh") if root else ""
+    if pause and os.path.isfile(pause):
+        r = subprocess.run(["bash", "-c", f'source "{pause}"; mo_cost_pause_check "$1" "$2"',
+                            "_", run_id, cost], capture_output=True)
+        if r.returncode != 0:
+            os.environ["MO_NODE_FINISH_REASON"] = "paused_for_approval"
+
+
+def apply_impl_output(impl_log, target):
+    """Verbatim port of mo_apply_impl_output (the 'capture coin-flip' fix): when
+    the implementer applied NOTHING to the tree, parse its text output for a
+    unified diff (git apply) or fenced file blocks with a path marker (write the
+    files). Path-safe: rejects absolute / .. / out-of-target paths."""
+    if os.environ.get("MO_APPLY_IMPL_OUTPUT", "1") != "1":
+        return
+    if not (impl_log and os.path.isfile(impl_log) and os.path.getsize(impl_log) > 0
+            and os.path.isdir(target)):
+        return
+    porc = subprocess.run(["git", "-C", target, "status", "--porcelain"],
+                          capture_output=True, text=True).stdout
+    if porc.splitlines()[:1]:
+        return
+    text = open(impl_log, encoding="utf-8", errors="replace").read()
+    target_real = os.path.realpath(target)
+
+    def safe_path(p):
+        p = p.strip().strip('`"\'')
+        if not p or os.path.isabs(p) or ".." in p.split("/"):
+            return None
+        full = os.path.realpath(os.path.join(target_real, p))
+        if not full.startswith(target_real + os.sep):
+            return None
+        return p
+
+    applied = []
+    if re.search(r"^--- (a/|/dev/null)", text, re.M) and re.search(r"^\+\+\+ b/", text, re.M):
+        m = re.search(r"(^--- .*?)(?=\n```|\Z)", text, re.S | re.M)
+        if m:
+            try:
+                subprocess.run(["git", "-C", target, "apply", "--whitespace=nowarn", "-"],
+                               input=m.group(1), text=True, capture_output=True, check=True)
+                applied.append("<unified-diff>")
+            except subprocess.CalledProcessError:
+                pass
+    if not applied:
+        lines = text.splitlines()
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            fm = re.match(r"^```[\w+-]*\s+(?:file=|path=)?([\w./_-]+\.[\w]+)\s*$", line)
+            path = safe_path(fm.group(1)) if fm else None
+            if not path and line.startswith("```") and line.strip() != "```":
+                path = None
+            if not path and line.startswith("```"):
+                for back in range(1, 4):
+                    if i - back < 0:
+                        break
+                    pm = re.match(
+                        r"^\s*(?:#{2,4}\s*)?(?:\*\*)?(?:FILE:|File:|file:)?\s*`?"
+                        r"([\w./_-]+\.(?:py|sh|md|yaml|yml|json|toml|txt|cfg|ini))`?:?(?:\*\*)?\s*$",
+                        lines[i - back])
+                    if pm:
+                        path = safe_path(pm.group(1))
+                        break
+            if line.startswith("```") and path:
+                body = []
+                i += 1
+                while i < len(lines) and not lines[i].startswith("```"):
+                    body.append(lines[i])
+                    i += 1
+                if body:
+                    full = os.path.join(target_real, path)
+                    os.makedirs(os.path.dirname(full) or ".", exist_ok=True)
+                    with open(full, "w", encoding="utf-8") as fh:
+                        fh.write("\n".join(body) + "\n")
+                    applied.append(path)
+            i += 1
+    if applied:
+        print("  [apply-impl-output] applied from implementer text: " + ", ".join(applied))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_mini_ork_execute_py.py
+++ b/tests/unit/test_mini_ork_execute_py.py
@@ -208,6 +208,124 @@ def test_conductor_outcomes_parity(tmp_path):
     assert _sql(db_b, q).stdout == _sql(db_p, q).stdout
 
 
+# ── live-path support helpers (increment 4) ──
+
+def _seed_task_run(db, rid="r1", status="planned", cost=0.0):
+    _sql(db, f"INSERT INTO task_runs (id,task_class,workflow_version,kickoff_path,status,"
+             f"cost_usd,created_at,updated_at) VALUES ('{rid}','x','v1','k.md','{status}',"
+             f"{cost},strftime('%s','now','-60 seconds'),strftime('%s','now'));")
+
+
+def test_set_status_parity(tmp_path):
+    db_b, db_p = _seed_db(tmp_path, "ssb"), _seed_db(tmp_path, "ssp")
+    for db in (db_b, db_p):
+        _seed_task_run(db)
+    fn = _extract("_d021_set_status")
+    subprocess.run(["bash", "-c", f'DRY_RUN=0\nMINI_ORK_DB="{db_b}"\nMINI_ORK_RUN_ID="r1"\n{fn}\n'
+                    '_d021_set_status "published"'], capture_output=True, text=True)
+    ex.set_status(db_p, "r1", "published")
+    q = "SELECT status, ended_at IS NOT NULL AND ended_at>0, duration_ms>0 FROM task_runs WHERE id='r1';"
+    assert _sql(db_b, q).stdout.strip() == _sql(db_p, q).stdout.strip()
+    assert _sql(db_p, q).stdout.strip() == "published|1|1"   # terminal stamps ended_at + duration
+    # non-terminal transition: no ended_at
+    for db in (db_b, db_p):
+        _seed_task_run(db, rid="r2")
+    subprocess.run(["bash", "-c", f'DRY_RUN=0\nMINI_ORK_DB="{db_b}"\nMINI_ORK_RUN_ID="r2"\n{fn}\n'
+                    '_d021_set_status "reviewing"'], capture_output=True, text=True)
+    ex.set_status(db_p, "r2", "reviewing")
+    q2 = "SELECT status, ended_at FROM task_runs WHERE id='r2';"
+    assert _sql(db_b, q2).stdout == _sql(db_p, q2).stdout
+    assert _sql(db_p, q2).stdout.strip() == "reviewing|"
+
+
+def test_charge_node_cost_parity(tmp_path):
+    db_b, db_p = _seed_db(tmp_path, "ccb"), _seed_db(tmp_path, "ccp")
+    for db in (db_b, db_p):
+        _seed_task_run(db, cost=0.10)
+    cost_file = tmp_path / "cost"; cost_file.write_text("0.037")
+    fn = _extract("_d022_charge_node_cost")
+    subprocess.run(["bash", "-c", f'DRY_RUN=0\nMINI_ORK_DB="{db_b}"\nMINI_ORK_RUN_ID="r1"\n'
+                    f'MINI_ORK_ROOT="{tmp_path}"\n{fn}\n_d022_charge_node_cost "{cost_file}"'],
+                   capture_output=True, text=True)
+    ex.charge_node_cost(db_p, "r1", str(cost_file), root=str(tmp_path))
+    q = "SELECT printf('%.4f', cost_usd) FROM task_runs WHERE id='r1';"
+    assert _sql(db_b, q).stdout == _sql(db_p, q).stdout
+    assert _sql(db_p, q).stdout.strip() == "0.1370"   # 0.10 + 0.037
+    # invalid cost file → $0.01 placeholder on both
+    for db in (db_b, db_p):
+        _seed_task_run(db, rid="r3", cost=0)
+    bad = tmp_path / "bad"; bad.write_text("not-a-number")
+    subprocess.run(["bash", "-c", f'DRY_RUN=0\nMINI_ORK_DB="{db_b}"\nMINI_ORK_RUN_ID="r3"\n'
+                    f'{fn}\n_d022_charge_node_cost "{bad}"'], capture_output=True, text=True)
+    ex.charge_node_cost(db_p, "r3", str(bad))
+    q3 = "SELECT printf('%.4f', cost_usd) FROM task_runs WHERE id='r3';"
+    assert _sql(db_b, q3).stdout == _sql(db_p, q3).stdout == "0.0100\n"
+
+
+def _git_repo(d):
+    d.mkdir(parents=True)
+    for a in (["init", "-q", "-b", "main"], ["config", "user.email", "t@e"],
+              ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(d), *a], capture_output=True)
+    (d / "app.py").write_text("x = 1\n")
+    subprocess.run(["git", "-C", str(d), "add", "-A"], capture_output=True)
+    subprocess.run(["git", "-C", str(d), "commit", "-qm", "base"], capture_output=True)
+    return d
+
+
+_DIFF_LOG = """The implementer emitted a diff instead of applying it:
+
+--- a/app.py
++++ b/app.py
+@@ -1 +1,2 @@
+ x = 1
++y = 2
+"""
+
+_FENCED_LOG = """I created the file:
+
+### FILE: `newmod.py`
+```python
+def hello():
+    return "hi"
+```
+done.
+"""
+
+
+def _run_bash_apply(impl_log, target):
+    fn = _extract("mo_apply_impl_output")
+    subprocess.run(["bash", "-c", f'MO_APPLY_IMPL_OUTPUT=1\n{fn}\n'
+                    f'mo_apply_impl_output "{impl_log}" "{target}"'], capture_output=True, text=True)
+
+
+def test_apply_impl_output_diff_parity(tmp_path):
+    logf = tmp_path / "impl.log"; logf.write_text(_DIFF_LOG)
+    rb = _git_repo(tmp_path / "rb"); rp = _git_repo(tmp_path / "rp")
+    _run_bash_apply(str(logf), str(rb))
+    ex.apply_impl_output(str(logf), str(rp))
+    assert (rb / "app.py").read_text() == (rp / "app.py").read_text() == "x = 1\ny = 2\n"
+
+
+def test_apply_impl_output_fenced_parity(tmp_path):
+    logf = tmp_path / "impl.log"; logf.write_text(_FENCED_LOG)
+    rb = _git_repo(tmp_path / "rb"); rp = _git_repo(tmp_path / "rp")
+    _run_bash_apply(str(logf), str(rb))
+    ex.apply_impl_output(str(logf), str(rp))
+    assert (rb / "newmod.py").exists() and (rp / "newmod.py").exists()
+    assert (rb / "newmod.py").read_text() == (rp / "newmod.py").read_text()
+    assert 'def hello():' in (rp / "newmod.py").read_text()
+
+
+def test_apply_impl_output_skips_dirty_tree(tmp_path):
+    # implementer already changed the tree → applier must NO-OP (both)
+    logf = tmp_path / "impl.log"; logf.write_text(_DIFF_LOG)
+    rp = _git_repo(tmp_path / "rp")
+    (rp / "app.py").write_text("x = 999\n")   # dirty
+    ex.apply_impl_output(str(logf), str(rp))
+    assert (rp / "app.py").read_text() == "x = 999\n"   # untouched
+
+
 # ── orchestration backbone parity (NODE_IDS + --dry-run) ──
 
 def _py_blocks():


### PR DESCRIPTION
Ports the deterministic per-node support ops _dispatch_node's live branches wire around the LLM call: set_status (_d021), charge_node_cost (_d022 + cost-pause seam), apply_impl_output (the 'capture coin-flip' diff/fenced-block applier). Parity vs live bash (extracted): status transitions, cost charge (valid+invalid), apply-impl on real git repos (diff/fenced/dirty-noop). 17/17 pass. Remaining: _dispatch_node's per-node LLM branches (integration-gated).