### PR TITLE
test(execute-port): real-LLM integration gate + harsh-critic kickoff

### DIFF
--- a/kickoffs/execute-port-harsh-critic-review.md
+++ b/kickoffs/execute-port-harsh-critic-review.md
@@ -1,0 +1,66 @@
+# Harsh-critic review — the ported executor + runtime cutover
+
+Adversarial cross-family panel (kimi + codex + opus) review of the bash→Python
+migration's highest-risk surface, BEFORE the live-dispatch default is flipped.
+Assume the code is theater until proven otherwise. Your job is to find where the
+Python port silently diverges from the bash it claims to replace.
+
+## Scope (read these, in order)
+
+- `mini_ork/ported/mini_ork_execute.py` — the ported executor (helpers + GRPO +
+  orchestration backbone + `dispatch_node` live routing + `main`).
+- `bin/mini-ork-execute` — the 3449-line bash original it ports.
+- `lib/runtime-select.sh` + the `mo_runtime_maybe_delegate` line wired into
+  `bin/mini-ork*` — the cutover switch.
+- `scripts/runtime-parity-harness.sh` + `scripts/live_dispatch_harness.py` — the gates.
+- `tests/unit/test_mini_ork_execute_py.py` — the tests that claim it works.
+
+## The claims to attack
+
+1. **`dispatch_node` faithfully replicates `_dispatch_node`.** It does NOT — by
+   the author's own admission it omits recipe-specific file-naming (schema-judge-panel,
+   recursive-validate-impl), the recipe dispatchers (per_feature / epic / minimal-scaffold),
+   the publisher's oracle-gates + artifact-contract commit, and trace/heartbeat
+   side-effects. For EACH omission: does it change a node's pass/fail result, the
+   artifact a downstream node reads, or a gate that blocks publish? Name a concrete
+   recipe + node where the omission produces a DIFFERENT run outcome than bash.
+2. **The live path is verified.** It is only tested with a FAKE dispatch. Find a
+   real-provider behavior (agent tool-call Writes vs stdout, gateway capture
+   coin-flip, mtime-marker preserve-agent-Write, MO_TARGET_CWD resolution) where
+   the fake test passes but a real model would break the wiring.
+3. **The reviewer verdict gate matches bash.** Compare the port's pass/revise/fail/
+   unknown mapping and the synth-never-gates branch against the bash case statement
+   line-by-line. Find a verdict string bash treats differently.
+4. **The cutover shim is safe.** Find an entrypoint where `MINI_ORK_RUNTIME=python`
+   delegates to a port that is NOT behaviorally equivalent, or where the shim breaks
+   the bash default (set -e interaction, arg forwarding, cwd, env inheritance across
+   the cascade), or a recipe dispatcher that shells `bin/mini-ork-execute` and now
+   gets the Python one mid-run.
+5. **The harness proves the cutover is safe.** It skips live dispatch and treats
+   `--help` as exit-code-only. What real divergence class does it therefore NOT catch?
+
+## Deliverable
+
+`docs/reviews/execute-port-harsh-critic-<ts>.md` with, per confirmed divergence:
+the file:line in the port, the bash line it should match, the concrete
+recipe+node+input that triggers a different run outcome, and severity
+(blocks-cutover / degrades-quality / cosmetic). End with an explicit verdict:
+is the LIVE dispatch default safe to flip, and if not, the exact must-fix list.
+
+Refute-or-promote: do not accept "looks equivalent". Every claim needs a concrete
+triggering scenario or it is dropped. A missing recipe special-case is only a
+finding if you can name the recipe that breaks.
+
+## Success criteria
+
+- Panel reviewed all scoped files (not skimmed).
+- At least the 5 claims above each get an explicit confirmed/refuted with evidence.
+- Every confirmed divergence names file:line (port) + file:line (bash) + a
+  triggering recipe/node/input.
+- Final go/no-go on flipping the live-dispatch default, with a must-fix list.
+
+## Verification commands
+
+- `python -m pytest tests/unit/test_mini_ork_execute_py.py -q`
+- `bash scripts/runtime-parity-harness.sh`
+- `python3 scripts/live_dispatch_harness.py`

--- a/scripts/live_dispatch_harness.py
+++ b/scripts/live_dispatch_harness.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""live_dispatch_harness.py — real-LLM integration gate for the ported executor.
+
+The deterministic surface of mini_ork.ported.mini_ork_execute is unit-parity- and
+harness-tested (see tests/unit/test_mini_ork_execute_py.py + runtime-parity-harness.sh).
+The LIVE per-node dispatch path (dispatch_node with the real llm_dispatch seam) can
+only be verified against a real provider — that is this harness. It fires ONE cheap
+researcher node through the ported live path and checks the wiring end-to-end:
+
+  * the LLM was actually called (rc 0, non-empty output),
+  * the output artifact was written to the run dir,
+  * cost was charged to task_runs.cost_usd,
+  * the node returned success.
+
+This is the gate that must pass before flipping the LIVE dispatch default to python
+(the deterministic default is already validated). It costs one cheap dispatch.
+
+    python3 scripts/live_dispatch_harness.py [--lane kimi]
+
+Exit: 0 pass · 2 skipped (no lane / dispatch could not run) · 1 fail (wiring broke).
+Requires a configured lane (MINI_ORK_SECRETS or ambient provider keys).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from mini_ork.ported import mini_ork_execute as ex  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lane", default=os.environ.get("MO_HARNESS_LANE", "kimi"),
+                    help="the (cheap) lane to dispatch through")
+    args = ap.parse_args()
+
+    tmp = Path(tempfile.mkdtemp(prefix="mo-live-harness-"))
+    home = tmp / ".mini-ork"; home.mkdir(parents=True)
+    db = str(home / "state.db")
+    subprocess.run(["bash", str(ROOT / "db" / "init.sh")],
+                   env={**os.environ, "MINI_ORK_HOME": str(home), "MINI_ORK_DB": db},
+                   capture_output=True, text=True, check=True)
+    run_dir = home / "runs" / "harness"; run_dir.mkdir(parents=True)
+    plan = run_dir / "plan.json"
+    plan.write_text(json.dumps({"objective": "harness", "artifact_contract": {"outputs": ["out.md"]}}))
+    con = sqlite3.connect(db)
+    con.execute("INSERT INTO task_runs (id,task_class,workflow_version,kickoff_path,status,cost_usd,"
+                "created_at,updated_at) VALUES ('harness','code_fix','v1','k.md','executing',0,"
+                "strftime('%s','now'),strftime('%s','now'))")
+    con.commit(); con.close()
+
+    os.environ["MINI_ORK_RUN_DIR"] = str(run_dir)
+    os.environ["MINI_ORK_DB"] = db
+    fields = ("h1_lens", "researcher", "Return the single word OK and nothing else.",
+              "", "serial", "", args.lane, "")
+
+    print(f"── live-dispatch harness (lane={args.lane}) ──")
+    try:
+        rc, fr = ex.dispatch_node(
+            fields, root=str(ROOT), run_dir=str(run_dir), plan_path=str(plan),
+            task_class="code_fix", db=db, run_id="harness",
+            dispatch_fn=ex._default_llm_dispatch(str(ROOT)))
+    except Exception as e:  # noqa: BLE001
+        print(f"  [skip] dispatch raised (lane not configured?): {e}")
+        return 2
+
+    ctx = run_dir / "lens-h1.md"
+    cost = sqlite3.connect(db).execute(
+        "SELECT cost_usd FROM task_runs WHERE id='harness'").fetchone()[0]
+    out_ok = ctx.exists() and ctx.stat().st_size > 0
+
+    if rc != 0:
+        print(f"  [skip] node rc={rc} reason={fr} — provider likely unavailable/throttled")
+        return 2
+    ok = out_ok and (cost or 0) > 0
+    print(f"  output_written={out_ok} cost_charged={cost} rc={rc} finish={fr}")
+    if ok:
+        print("PASS — live dispatch wired: LLM called, artifact written, cost charged.")
+        return 0
+    print("FAIL — live path ran but wiring broke (missing artifact or cost).")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Gates the LIVE dispatch default flip. `scripts/live_dispatch_harness.py` = one cheap real dispatch through the ported live path (asserts LLM-called + artifact-written + cost-charged; skips gracefully with no lane). `kickoffs/execute-port-harsh-critic-review.md` = adversarial kimi+codex+opus review of the port+cutover with a go/no-go verdict. Both additive; default runtime stays bash.