### PR TITLE
fix(cutover): real python entries for init+review + full --help parity

### DIFF
--- a/mini_ork/ported/mini_ork_conductor.py
+++ b/mini_ork/ported/mini_ork_conductor.py
@@ -146,7 +146,34 @@ def main(argv: list[str] | None = None, *, db: str | None = None, root: str | No
         elif a == "--dry-run": dry_run = 1; i += 1
         elif a == "--explain": explain = 1; i += 1
         elif a in ("--help", "-h"):
-            sys.stdout.write("mini-ork conductor — meta-orchestrator.\n"); return 0
+            sys.stdout.write(
+                "mini-ork conductor — meta-orchestrator (mini-ork-of-mini-orks).\n\n"
+                "Phase 2 of the design grounded in Shepherd (arXiv:2605.10913),\n"
+                "TaskWeave (2606.01199), TacoMAS (2605.09539), Mass (2502.02533),\n"
+                "InfraMind (2606.11440) and TCP-MCP (2605.27850).\n\n"
+                "Per tick:\n"
+                "  1. Read state of: epic queue, prompt_win_rates, agent_performance_memory,\n"
+                "     topology_win_rates, role_evolver_log proposals, 24h cost vs cap.\n"
+                "  2. Pick the next epic from epic_graph_ready_now.\n"
+                "  3. Decide:\n"
+                "       - Recipe / topology  (highest win_rate per task_class, ties broken\n"
+                "         by lower avg_cost; falls back to the epic's kickoff hint)\n"
+                "       - Lane hints         (highest relative_advantage per (lane, task_class))\n"
+                "       - Prompt seeds       (top-quartile prompt_version_hash for the role)\n"
+                "     Under high budget pressure (>70% spend), prefer cheaper topologies\n"
+                "     with sample_size >= 3 over higher-win-rate but expensive ones\n"
+                "     (InfraMind-style budget bias).\n"
+                "  4. Write the decision to conductor_decisions.\n"
+                "  5. Stage the lane hints + prompt seeds into env vars and call\n"
+                "     bin/mini-ork-scheduler --once.\n\n"
+                "Modes:\n"
+                "  --once               One decision + dispatch then exit\n"
+                "  --max-iters N        Bound iterations (default unbounded)\n"
+                "  --idle-secs N        Poll interval when queue empty (default 60)\n"
+                "  --dry-run            Decide + log but skip dispatch\n"
+                "  --explain            Emit a verbose rationale per decision\n"
+                "  --help\n\n"
+                "All decisions logged to conductor_decisions. Re-runnable.\n"); return 0
         else:
             sys.stderr.write(f"conductor: unknown flag {a}\n"); return 2
 

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -556,8 +556,18 @@ def main(argv=None, *, root=None, dispatch_fn=None) -> int:
     while i < len(argv):
         a = argv[i]
         if a in ("--help", "-h"):
-            sys.stdout.write("Usage: mini-ork execute [<plan.json>] [--node-type <type>] "
-                             "[--dispatch-mode <mode>] [--dry-run]\n")
+            sys.stdout.write(
+                "Usage: mini-ork execute [<plan.json>] [--node-type <type>] "
+                "[--dispatch-mode <mode>] [--dry-run]\n\n"
+                "Dispatch plan steps to node-type handlers.\n\n"
+                "Node types: planner | researcher | implementer | reviewer | verifier |\n"
+                "            reflector | publisher | rollback\n\n"
+                "Dispatch modes: serial | parallel | partitioned | speculative\n\n"
+                "Options:\n"
+                "  --node-type <type>        Execute only nodes of this type (filter)\n"
+                "  --dispatch-mode <mode>    Override workflow dispatch mode\n"
+                "  --dry-run                 Print what would be dispatched; no LLM calls\n"
+                "  --help                    Show this help\n")
             return 0
         elif a == "--dry-run":
             dry_run = True; i += 1

--- a/mini_ork/ported/mini_ork_init.py
+++ b/mini_ork/ported/mini_ork_init.py
@@ -249,12 +249,18 @@ def mini_ork_init(
     project_root = Path(project_root)
     mini_ork_repo = Path(mini_ork_repo).resolve()
 
+    # Match bash: MINI_ORK_HOME="${MINI_ORK_HOME:-$(pwd)/.mini-ork}" — the default
+    # is derived from the un-resolved cwd and bash never resolve()s it. Resolving
+    # here diverges from bash's stdout on a symlinked cwd (macOS /tmp), same
+    # reason project_root is left un-resolved above. Use abspath to guarantee an
+    # absolute path (bash's default is absolute via $(pwd)) without following
+    # symlinks.
     if mini_ork_home is None:
         mini_ork_home = Path(
-            os.environ.get("MINI_ORK_HOME", str(project_root / ".mini-ork"))
-        ).resolve()
+            os.path.abspath(os.environ.get("MINI_ORK_HOME", str(project_root / ".mini-ork")))
+        )
     else:
-        mini_ork_home = Path(mini_ork_home).resolve()
+        mini_ork_home = Path(os.path.abspath(mini_ork_home))
 
     buf = StringIO()
     env = os.environ.copy()
@@ -341,3 +347,25 @@ def mini_ork_init(
     buf.write("\n")
 
     return buf.getvalue()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry mirroring bin/mini-ork-init.
+
+    Bash init takes no meaningful flags (it scaffolds unconditionally and even
+    ignores --help), so argv is accepted but unused. project_root is the cwd
+    (bash uses the invocation directory); mini_ork_repo is MINI_ORK_ROOT
+    (exported by the bin wrapper before delegation), falling back to the repo
+    root inferred from this file's location.
+    """
+    repo = os.environ.get("MINI_ORK_ROOT") or str(Path(__file__).resolve().parents[2])
+    # Bash uses the logical cwd ($PWD, symlinks intact); Path.cwd()/getcwd()
+    # resolve symlinks, which diverges when the project dir is a symlink
+    # (e.g. macOS /tmp → /private/tmp). Prefer $PWD to mirror bash exactly.
+    proj = os.environ.get("PWD") or os.getcwd()
+    sys.stdout.write(mini_ork_init(proj, repo))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mini_ork/ported/mini_ork_plan.py
+++ b/mini_ork/ported/mini_ork_plan.py
@@ -50,6 +50,16 @@ _USAGE = """Usage: mini-ork plan <kickoff.md> [--task-class <name>] [--out <plan
 Generate a structured plan JSON from a kickoff file.
 
 The plan MUST include a verifier_contract (checks[]) — planning fails if missing.
+
+Outputs:
+  <out-file>   JSON plan written to .mini-ork/runs/<run>/plan.json (or --out path)
+  stdout       plan path on success
+
+Options:
+  --task-class <name>   Override task_class (default: $MINI_ORK_TASK_CLASS)
+  --out <path>          Write plan to this path instead of default
+  --dry-run             Print plan JSON to stdout; do not write files or DB
+  --help                Show this help
 """
 
 _BUILTIN_PROMPT = """You are a meticulous task planner. Given the kickoff document below, produce a

--- a/mini_ork/ported/mini_ork_review.py
+++ b/mini_ork/ported/mini_ork_review.py
@@ -69,6 +69,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -1043,3 +1044,37 @@ def run_cli(argv: Iterable[str] | None = None) -> str:
         n = int(rest[0]) if rest else 10
         return review_list(n)
     raise ValueError(f"review: unknown subcommand {sub}")
+
+
+_USAGE = """Usage: mini-ork review <subcommand> [args]
+
+  run <source_sha> <target_branch> [--mode heuristic|llm_panel]
+  show <review_id>
+  verdict <review_id>
+  forward <review_id>
+  list [N]
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry mirroring bin/mini-ork-review's case dispatch.
+
+    empty / help / --help / -h → usage on stdout, rc 0.
+    unknown subcommand         → error on stderr + usage on stdout, rc 2.
+    known subcommand           → run_cli output on stdout, rc 0.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in ("help", "--help", "-h"):
+        sys.stdout.write(_USAGE)
+        return 0
+    try:
+        sys.stdout.write(run_cli(args))
+    except ValueError as e:
+        sys.stderr.write(f"{e}\n")
+        sys.stdout.write(_USAGE)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mini_ork/ported/mini_ork_scheduler.py
+++ b/mini_ork/ported/mini_ork_scheduler.py
@@ -151,7 +151,24 @@ def main(argv: list[str] | None = None, *, db: str | None = None, root: str | No
         elif a == "--budget-cap-usd": cap = float(argv[i + 1]); i += 2
         elif a == "--dry-run": dry_run = 1; i += 1
         elif a in ("--help", "-h"):
-            sys.stdout.write("mini-ork scheduler — autonomous multi-epic delivery loop.\n"); return 0
+            sys.stdout.write(
+                "mini-ork scheduler — autonomous multi-epic delivery loop.\n\n"
+                "Pulls the next-ready epic from `epics` (status='not started' AND all hard\n"
+                "deps resolved) and dispatches it via `mini-ork run epic-runner <kickoff>`.\n"
+                "On verdict=success, marks epic 'done' and cascades dep resolution. On\n"
+                "failure, marks epic 'escalated' (visible in `mini-ork-epics list`).\n\n"
+                "Flags:\n"
+                "  --once               Run a single pick→dispatch→verdict cycle then exit\n"
+                "  --idle-secs N        Sleep N seconds between empty-queue polls (default 60)\n"
+                "  --max-iters N        Hard stop after N dispatches (default unlimited)\n"
+                "  --budget-cap-usd X   Daily cost cap; refuses to dispatch when exceeded\n"
+                "                       (defaults to MO_DAILY_BUDGET_USD or 50.0)\n"
+                "  --dry-run            Print what would be dispatched, do not invoke runner\n"
+                "  --help\n\n"
+                "Exit codes:\n"
+                "  0   queue drained (no ready epics) OR --once cycle finished cleanly\n"
+                "  1   fatal: missing deps (no DB, no epic-runner recipe)\n"
+                "  2   cost-pause sentinel encountered\n"); return 0
         else:
             sys.stderr.write(f"scheduler: unknown flag {a}\n"); return 2
 

--- a/scripts/runtime-parity-harness.sh
+++ b/scripts/runtime-parity-harness.sh
@@ -20,7 +20,7 @@ FAILS=0
 
 # normalize volatile bits (tmp paths, run ids, timestamps) so only real
 # behavioral differences surface.
-_norm() { sed -E "s#$TMP[^ ]*#<TMP>#g; s/run-[0-9]+-[0-9]+/<RUN>/g; s/[0-9]{10,}/<TS>/g"; }
+_norm() { sed -E "s#${TMP}[^ ]*#<TMP>#g; s/run-[0-9]+-[0-9]+/<RUN>/g; s/[0-9]{10,}/<TS>/g"; }
 
 # behavioral parity: stdout+stderr+exit-code must match.
 _check() {
@@ -36,34 +36,22 @@ _check() {
   fi
 }
 
-# exit-code-only parity: for --help/usage, where the ported one-line stubs are a
-# documented COSMETIC gap (help text ≠ runtime behavior); both must still exit 0.
-_check_rc() {
-  local name="$1" want="$2"; shift 2
-  local brc prc
-  MINI_ORK_RUNTIME=bash   "$@" >/dev/null 2>&1; brc=$?
-  MINI_ORK_RUNTIME=python "$@" >/dev/null 2>&1; prc=$?
-  if [ "$brc" = "$prc" ] && { [ -z "$want" ] || [ "$brc" = "$want" ]; }; then
-    printf '  [ok]   %s (rc=%s)\n' "$name" "$brc"
-  else
-    printf '  [FAIL] %s (rc bash=%s py=%s want=%s)\n' "$name" "$brc" "$prc" "${want:-any}"; FAILS=$((FAILS+1))
-  fi
-}
-
 echo "── runtime parity harness (bash vs python) ──"
 echo "  behavioral (strict stdout+stderr+rc):"
 _check "version"        "$BIN/mini-ork" version
 _check "help"           "$BIN/mini-ork" help
 _check "doctor"         "$BIN/mini-ork" doctor
 _check "unknown-subcmd" "$BIN/mini-ork" bogus-subcmd
+_check "review no-arg"  "$BIN/mini-ork-review"
+_check "review bad-sub" "$BIN/mini-ork-review" bogus
 
-echo "  --help/usage (exit-code parity; text is a cosmetic follow-up):"
-_check_rc "plan --help"      0 "$BIN/mini-ork-plan" --help
-_check_rc "classify --help"  0 "$BIN/mini-ork-classify" --help
-_check_rc "conductor --help" 0 "$BIN/mini-ork-conductor" --help
-_check_rc "scheduler --help" 0 "$BIN/mini-ork-scheduler" --help
-_check_rc "epics --help"     0 "$BIN/mini-ork-epics" --help
-_check_rc "execute --help"   0 "$BIN/mini-ork-execute" --help
+echo "  --help/usage (strict stdout+stderr+rc — full usage text transcribed):"
+_check "plan --help"      "$BIN/mini-ork-plan" --help
+_check "classify --help"  "$BIN/mini-ork-classify" --help
+_check "conductor --help" "$BIN/mini-ork-conductor" --help
+_check "scheduler --help" "$BIN/mini-ork-scheduler" --help
+_check "epics --help"     "$BIN/mini-ork-epics" --help
+_check "execute --help"   "$BIN/mini-ork-execute" --help
 
 # plan --dry-run: a full deterministic pipeline (classify→profile→plan placeholder)
 printf '# Ship widget\n\n## Success\n- widget renders\n\n## Verification commands\n- `pytest`\n' > "$TMP/k.md"
@@ -78,6 +66,23 @@ if [ "$(_dryplan bash)" = "$(_dryplan python)" ]; then
 else
   echo "  [FAIL] plan --dry-run (full pipeline)"; FAILS=$((FAILS+1))
   diff <(_dryplan bash) <(_dryplan python) | sed 's/^/       /' | head -12
+fi
+
+# init: scaffolds .mini-ork under a fresh project dir. Run each runtime in its
+# own temp project (side-effecting) and diff stdout with the project path
+# normalized. Guards the silent-no-op class of cutover bug (a delegated module
+# with no working __main__ that does nothing under python).
+_initrun() {  # runtime passed as $1; prints init stdout with project path normalized
+  local rt="$1" proj="$TMP/proj-$1"
+  mkdir -p "$proj"
+  ( cd "$proj" && MINI_ORK_RUNTIME="$rt" MINI_ORK_ROOT="$ROOT" "$BIN/mini-ork-init" 2>&1 ) \
+    | sed "s#$proj#<PROJ>#g" | _norm
+}
+if [ "$(_initrun bash)" = "$(_initrun python)" ]; then
+  echo "  [ok]   init (scaffold .mini-ork)"
+else
+  echo "  [FAIL] init (scaffold .mini-ork)"; FAILS=$((FAILS+1))
+  diff <(_initrun bash) <(_initrun python) | sed 's/^/       /' | head -12
 fi
 
 echo "──"


### PR DESCRIPTION
Closes two silent-no-op cutover holes and finishes the --help parity gap.

**Silent no-op fix (correctness):** `init` and `review` ported modules had no `__main__`/`main()`, so under `MINI_ORK_RUNTIME=python` they defined functions and exited 0 doing **nothing**. The parity harness never invoked them, so it was invisible. Both now have a `main()` mirroring bash exactly (verified byte-for-byte). `init` also drops a `.resolve()` that diverged on symlinked cwd (macOS /tmp).

**--help parity (cosmetic → strict):** transcribed full usage text into plan/execute/scheduler/conductor (were one-line stubs), upgraded those harness checks from exit-code-only to strict, and **added review + init guards** to the harness so this no-op class can't regress.

Harness PASSES; 44 module + 26 init/review unit tests green; shellcheck SC1087 fixed.