### PR TITLE
audit(execute-port): harsh-critic panel verdict — NO-GO on live cutover

### DIFF
--- a/docs/reviews/execute-port-harsh-critic-20260708-1513.md
+++ b/docs/reviews/execute-port-harsh-critic-20260708-1513.md
@@ -1,0 +1,41 @@
+# Harsh-critic panel verdict — ported executor + runtime cutover
+
+**Date:** 2026-07-08
+**Target:** `mini_ork/ported/mini_ork_execute.py` (`dispatch_node` + live path) under `MINI_ORK_RUNTIME=python`, vs bash `bin/mini-ork-execute`.
+**Panel:** two independent adversarial reviewers (opus, separate contexts), refute-or-promote discipline. Cross-vendor lanes (kimi/codex) were unavailable this run — this is a single-family (Anthropic) panel; a kimi/codex second pass is still advisable but the findings below are code-grounded, not judgment calls, so family diversity does not change them.
+**Gate #1 (live-dispatch harness):** PASS — a real sonnet dispatch through the ported live path called the LLM, wrote the artifact, charged cost $0.34, rc 0. The *wiring* is live; the *fidelity* is where the gaps are.
+
+## VERDICT: NO-GO on flipping the LIVE dispatch default.
+
+The deterministic surface (dry-run / plan / classify / init / review …) IS safe — the parity harness proves it and the default cutover for those is fine. The **live `dispatch_node` path** has 5 blocks-cutover defects. Bash must remain the live executor until they are fixed.
+
+## Blocks-cutover findings (each with a concrete trigger)
+
+| # | Defect | Port | Bash | Trigger → divergent outcome |
+|---|--------|------|------|------------------------------|
+| 1 | **Policy lane-routing is dead.** Port dispatches `lane = model_lane or node_type` raw; never calls the policy router. The entire GRPO/learning-governed routing loop is inert. | `mini_ork_execute.py:870,915` | `bin/mini-ork-execute:2219` (`dispatch_lane=$(_mo_policy_route_lane …)` before dispatch; default policy `learning_governed`) | Any researcher node, `model_lane` unset: bash dispatches the routed lane (e.g. `kimi_lens`/`opus_lens`); port dispatches `--node-type researcher`. **Wrong model invoked + core value-prop disabled.** |
+| 2 | **Publisher is a stub.** Just `set_status("published")`. No oracle gates, no panel-verdict requirement, no artifact-contract copy, no git commit. | `mini_ork_execute.py:1000-1002` | `bin/mini-ork-execute:2909-2998, 3059-3068` (4 oracle gates → `return 1` on `safety_violation`; panel-verdict gate; `_publisher_try_commit_files` / source_artifact→outputs copy) | code-fix recipe: implementer edits never committed. artifact recipe: output file never written. `safety_violation` from a panel: bash BLOCKS, port marks `published`. **Ships unsafe or empty, reports success.** |
+| 3 | **`is_synth` misclassifies the panel gate.** `"synth" in node_id` matches `tier4_synth`, which bash treats as a *panel approval gate*, not an ungated synth. | `mini_ork_execute.py:945,963-966` | `bin/mini-ork-execute:2704-2727,2799-2816` (`_is_panel_gate=1`, `_is_synth=0`, writes `panel-verdict.json`, runs the verdict gate) | recursive-validate-impl `tier4_synth` with verdict=reject: bash fails+rolls back; port returns `0/done` ungated AND writes `synthesis.md` not `panel-verdict.json` (so F2's publisher gate can't read it either). **Approval gate dead.** |
+| 4 | **`MO_TARGET_CWD` never pinned.** Port reads `MO_TARGET_CWD or os.getcwd()` but nothing derives/exports it from the kickoff's git toplevel. | `mini_ork_execute.py:930-933` | `bin/mini-ork-execute:2632-2642` (`export MO_TARGET_CWD=$(… git rev-parse --show-toplevel)`, the CWT-A corruption fix) | `MINI_ORK_RUNTIME=python bin/mini-ork run <recipe> <foreign-repo-kickoff>` from the mini-ork repo: `os.getcwd()`=MINI_ORK_ROOT, so codex runs there AND `apply_impl_output` git-applies into **mini-ork's own tree**. Reintroduces the known repo-corruption hazard. |
+| 5 | **Pre-dispatch gates absent.** No `.stop-requested`, intervention gate, capability assert, or stale-heartbeat watchdog. | `mini_ork_execute.py:864-908` | `bin/mini-ork-execute:2231-2236, 2258-2262, 2296-2318` | UI POSTs `/stop` mid-run: bash halts before next node; port ignores it, keeps spending budget. Node `requires_capabilities` a lane lacks: bash fails `config`; port dispatches anyway. **No soft-stop; incapable-lane dispatch.** |
+
+Degrade-only: **F6** synth artifact naming hardcodes `synthesis.md` ignoring `artifact_contract.source_artifact` (`:946-947`) → downstream reads a missing/stale file for non-default contracts.
+
+## Refuted (confirmed sound)
+
+- **No other silent-no-op entrypoints.** All 13 delegated `mini_ork_<x>.py` have working `__main__`; the ~80 helper modules lacking `__main__` are unreachable by the shim's `basename|tr '-' '_'` mapping. (init/review already fixed, PR #151.)
+- **Reviewer verdict string mapping is correct** — `_REVIEW_PASS`/`_REVIEW_REVISE`/fail+unknown→`verdict_fail` all match bash. It only breaks via the `is_synth` path (F3), not the string set.
+- **Shim arg/env/cwd forwarding is correct** (`exec env PYTHONPATH=… python3 -m … "$@"`; process replacement, no set-e interaction). Minor: unset `MINI_ORK_ROOT` silently stays bash (observability, not correctness).
+
+## Must-fix list before live cutover (ordered)
+
+1. Apply `_mo_policy_route_lane` (or the ported `learning_static_lane` + governed policy) before `dispatch_fn`, so the routed lane — not the raw node_type — reaches `--node-type`.
+2. Port the publisher: oracle gates (block on `safety_violation`), panel-verdict requirement, `_publisher_try_commit_files` + source_artifact→outputs copy.
+3. Fix `is_synth` to distinguish panel-gate nodes (`tier4_synth` etc.) from true synth; write `panel-verdict.json` and run the verdict gate for panel gates.
+4. Derive + export `MO_TARGET_CWD` from the kickoff's git toplevel before implementer/publisher dispatch.
+5. Port the pre-dispatch gates: `.stop-requested`, intervention gate, capability assert, stale-heartbeat watchdog.
+6. (degrade) Read `artifact_contract.source_artifact` for the synth output path.
+
+## Harness blind spot (now documented)
+
+`scripts/runtime-parity-harness.sh` deliberately skips live dispatch and `plan --dry-run` routes through `_dry_dispatch_node`, not `dispatch_node`. So it is structurally blind to the entire live-node side-effect class (edit-surface cwd, apply-impl target, publisher commit, verdict gating). The `live_dispatch_harness.py` gate covers the *researcher* wiring only; extend it to implementer (target-cwd) + publisher (commit) + a panel-gate verdict before trusting the live cutover.

--- a/mini_ork/ported/mini_ork_conductor.py
+++ b/mini_ork/ported/mini_ork_conductor.py
@@ -146,7 +146,34 @@ def main(argv: list[str] | None = None, *, db: str | None = None, root: str | No
         elif a == "--dry-run": dry_run = 1; i += 1
         elif a == "--explain": explain = 1; i += 1
         elif a in ("--help", "-h"):
-            sys.stdout.write("mini-ork conductor — meta-orchestrator.\n"); return 0
+            sys.stdout.write(
+                "mini-ork conductor — meta-orchestrator (mini-ork-of-mini-orks).\n\n"
+                "Phase 2 of the design grounded in Shepherd (arXiv:2605.10913),\n"
+                "TaskWeave (2606.01199), TacoMAS (2605.09539), Mass (2502.02533),\n"
+                "InfraMind (2606.11440) and TCP-MCP (2605.27850).\n\n"
+                "Per tick:\n"
+                "  1. Read state of: epic queue, prompt_win_rates, agent_performance_memory,\n"
+                "     topology_win_rates, role_evolver_log proposals, 24h cost vs cap.\n"
+                "  2. Pick the next epic from epic_graph_ready_now.\n"
+                "  3. Decide:\n"
+                "       - Recipe / topology  (highest win_rate per task_class, ties broken\n"
+                "         by lower avg_cost; falls back to the epic's kickoff hint)\n"
+                "       - Lane hints         (highest relative_advantage per (lane, task_class))\n"
+                "       - Prompt seeds       (top-quartile prompt_version_hash for the role)\n"
+                "     Under high budget pressure (>70% spend), prefer cheaper topologies\n"
+                "     with sample_size >= 3 over higher-win-rate but expensive ones\n"
+                "     (InfraMind-style budget bias).\n"
+                "  4. Write the decision to conductor_decisions.\n"
+                "  5. Stage the lane hints + prompt seeds into env vars and call\n"
+                "     bin/mini-ork-scheduler --once.\n\n"
+                "Modes:\n"
+                "  --once               One decision + dispatch then exit\n"
+                "  --max-iters N        Bound iterations (default unbounded)\n"
+                "  --idle-secs N        Poll interval when queue empty (default 60)\n"
+                "  --dry-run            Decide + log but skip dispatch\n"
+                "  --explain            Emit a verbose rationale per decision\n"
+                "  --help\n\n"
+                "All decisions logged to conductor_decisions. Re-runnable.\n"); return 0
         else:
             sys.stderr.write(f"conductor: unknown flag {a}\n"); return 2
 

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -556,8 +556,18 @@ def main(argv=None, *, root=None, dispatch_fn=None) -> int:
     while i < len(argv):
         a = argv[i]
         if a in ("--help", "-h"):
-            sys.stdout.write("Usage: mini-ork execute [<plan.json>] [--node-type <type>] "
-                             "[--dispatch-mode <mode>] [--dry-run]\n")
+            sys.stdout.write(
+                "Usage: mini-ork execute [<plan.json>] [--node-type <type>] "
+                "[--dispatch-mode <mode>] [--dry-run]\n\n"
+                "Dispatch plan steps to node-type handlers.\n\n"
+                "Node types: planner | researcher | implementer | reviewer | verifier |\n"
+                "            reflector | publisher | rollback\n\n"
+                "Dispatch modes: serial | parallel | partitioned | speculative\n\n"
+                "Options:\n"
+                "  --node-type <type>        Execute only nodes of this type (filter)\n"
+                "  --dispatch-mode <mode>    Override workflow dispatch mode\n"
+                "  --dry-run                 Print what would be dispatched; no LLM calls\n"
+                "  --help                    Show this help\n")
             return 0
         elif a == "--dry-run":
             dry_run = True; i += 1

--- a/mini_ork/ported/mini_ork_init.py
+++ b/mini_ork/ported/mini_ork_init.py
@@ -249,12 +249,18 @@ def mini_ork_init(
     project_root = Path(project_root)
     mini_ork_repo = Path(mini_ork_repo).resolve()
 
+    # Match bash: MINI_ORK_HOME="${MINI_ORK_HOME:-$(pwd)/.mini-ork}" — the default
+    # is derived from the un-resolved cwd and bash never resolve()s it. Resolving
+    # here diverges from bash's stdout on a symlinked cwd (macOS /tmp), same
+    # reason project_root is left un-resolved above. Use abspath to guarantee an
+    # absolute path (bash's default is absolute via $(pwd)) without following
+    # symlinks.
     if mini_ork_home is None:
         mini_ork_home = Path(
-            os.environ.get("MINI_ORK_HOME", str(project_root / ".mini-ork"))
-        ).resolve()
+            os.path.abspath(os.environ.get("MINI_ORK_HOME", str(project_root / ".mini-ork")))
+        )
     else:
-        mini_ork_home = Path(mini_ork_home).resolve()
+        mini_ork_home = Path(os.path.abspath(mini_ork_home))
 
     buf = StringIO()
     env = os.environ.copy()
@@ -341,3 +347,25 @@ def mini_ork_init(
     buf.write("\n")
 
     return buf.getvalue()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry mirroring bin/mini-ork-init.
+
+    Bash init takes no meaningful flags (it scaffolds unconditionally and even
+    ignores --help), so argv is accepted but unused. project_root is the cwd
+    (bash uses the invocation directory); mini_ork_repo is MINI_ORK_ROOT
+    (exported by the bin wrapper before delegation), falling back to the repo
+    root inferred from this file's location.
+    """
+    repo = os.environ.get("MINI_ORK_ROOT") or str(Path(__file__).resolve().parents[2])
+    # Bash uses the logical cwd ($PWD, symlinks intact); Path.cwd()/getcwd()
+    # resolve symlinks, which diverges when the project dir is a symlink
+    # (e.g. macOS /tmp → /private/tmp). Prefer $PWD to mirror bash exactly.
+    proj = os.environ.get("PWD") or os.getcwd()
+    sys.stdout.write(mini_ork_init(proj, repo))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mini_ork/ported/mini_ork_plan.py
+++ b/mini_ork/ported/mini_ork_plan.py
@@ -50,6 +50,16 @@ _USAGE = """Usage: mini-ork plan <kickoff.md> [--task-class <name>] [--out <plan
 Generate a structured plan JSON from a kickoff file.
 
 The plan MUST include a verifier_contract (checks[]) — planning fails if missing.
+
+Outputs:
+  <out-file>   JSON plan written to .mini-ork/runs/<run>/plan.json (or --out path)
+  stdout       plan path on success
+
+Options:
+  --task-class <name>   Override task_class (default: $MINI_ORK_TASK_CLASS)
+  --out <path>          Write plan to this path instead of default
+  --dry-run             Print plan JSON to stdout; do not write files or DB
+  --help                Show this help
 """
 
 _BUILTIN_PROMPT = """You are a meticulous task planner. Given the kickoff document below, produce a

--- a/mini_ork/ported/mini_ork_review.py
+++ b/mini_ork/ported/mini_ork_review.py
@@ -69,6 +69,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any, Callable, Iterable
@@ -1043,3 +1044,37 @@ def run_cli(argv: Iterable[str] | None = None) -> str:
         n = int(rest[0]) if rest else 10
         return review_list(n)
     raise ValueError(f"review: unknown subcommand {sub}")
+
+
+_USAGE = """Usage: mini-ork review <subcommand> [args]
+
+  run <source_sha> <target_branch> [--mode heuristic|llm_panel]
+  show <review_id>
+  verdict <review_id>
+  forward <review_id>
+  list [N]
+"""
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry mirroring bin/mini-ork-review's case dispatch.
+
+    empty / help / --help / -h → usage on stdout, rc 0.
+    unknown subcommand         → error on stderr + usage on stdout, rc 2.
+    known subcommand           → run_cli output on stdout, rc 0.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in ("help", "--help", "-h"):
+        sys.stdout.write(_USAGE)
+        return 0
+    try:
+        sys.stdout.write(run_cli(args))
+    except ValueError as e:
+        sys.stderr.write(f"{e}\n")
+        sys.stdout.write(_USAGE)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mini_ork/ported/mini_ork_scheduler.py
+++ b/mini_ork/ported/mini_ork_scheduler.py
@@ -151,7 +151,24 @@ def main(argv: list[str] | None = None, *, db: str | None = None, root: str | No
         elif a == "--budget-cap-usd": cap = float(argv[i + 1]); i += 2
         elif a == "--dry-run": dry_run = 1; i += 1
         elif a in ("--help", "-h"):
-            sys.stdout.write("mini-ork scheduler — autonomous multi-epic delivery loop.\n"); return 0
+            sys.stdout.write(
+                "mini-ork scheduler — autonomous multi-epic delivery loop.\n\n"
+                "Pulls the next-ready epic from `epics` (status='not started' AND all hard\n"
+                "deps resolved) and dispatches it via `mini-ork run epic-runner <kickoff>`.\n"
+                "On verdict=success, marks epic 'done' and cascades dep resolution. On\n"
+                "failure, marks epic 'escalated' (visible in `mini-ork-epics list`).\n\n"
+                "Flags:\n"
+                "  --once               Run a single pick→dispatch→verdict cycle then exit\n"
+                "  --idle-secs N        Sleep N seconds between empty-queue polls (default 60)\n"
+                "  --max-iters N        Hard stop after N dispatches (default unlimited)\n"
+                "  --budget-cap-usd X   Daily cost cap; refuses to dispatch when exceeded\n"
+                "                       (defaults to MO_DAILY_BUDGET_USD or 50.0)\n"
+                "  --dry-run            Print what would be dispatched, do not invoke runner\n"
+                "  --help\n\n"
+                "Exit codes:\n"
+                "  0   queue drained (no ready epics) OR --once cycle finished cleanly\n"
+                "  1   fatal: missing deps (no DB, no epic-runner recipe)\n"
+                "  2   cost-pause sentinel encountered\n"); return 0
         else:
             sys.stderr.write(f"scheduler: unknown flag {a}\n"); return 2
 

--- a/scripts/live_dispatch_harness.py
+++ b/scripts/live_dispatch_harness.py
@@ -57,6 +57,11 @@ def main() -> int:
                 "strftime('%s','now'),strftime('%s','now'))")
     con.commit(); con.close()
 
+    # Export the full run env the dispatch subprocess needs — mirrors what a real
+    # `mini-ork run` exports. Missing MINI_ORK_HOME sends llm-dispatch to a stale
+    # cwd-relative .mini-ork with no lane config → the dispatch silently errors.
+    os.environ["MINI_ORK_HOME"] = str(home)
+    os.environ["MINI_ORK_ROOT"] = str(ROOT)
     os.environ["MINI_ORK_RUN_DIR"] = str(run_dir)
     os.environ["MINI_ORK_DB"] = db
     fields = ("h1_lens", "researcher", "Return the single word OK and nothing else.",

--- a/scripts/runtime-parity-harness.sh
+++ b/scripts/runtime-parity-harness.sh
@@ -20,7 +20,7 @@ FAILS=0
 
 # normalize volatile bits (tmp paths, run ids, timestamps) so only real
 # behavioral differences surface.
-_norm() { sed -E "s#$TMP[^ ]*#<TMP>#g; s/run-[0-9]+-[0-9]+/<RUN>/g; s/[0-9]{10,}/<TS>/g"; }
+_norm() { sed -E "s#${TMP}[^ ]*#<TMP>#g; s/run-[0-9]+-[0-9]+/<RUN>/g; s/[0-9]{10,}/<TS>/g"; }
 
 # behavioral parity: stdout+stderr+exit-code must match.
 _check() {
@@ -36,34 +36,22 @@ _check() {
   fi
 }
 
-# exit-code-only parity: for --help/usage, where the ported one-line stubs are a
-# documented COSMETIC gap (help text ≠ runtime behavior); both must still exit 0.
-_check_rc() {
-  local name="$1" want="$2"; shift 2
-  local brc prc
-  MINI_ORK_RUNTIME=bash   "$@" >/dev/null 2>&1; brc=$?
-  MINI_ORK_RUNTIME=python "$@" >/dev/null 2>&1; prc=$?
-  if [ "$brc" = "$prc" ] && { [ -z "$want" ] || [ "$brc" = "$want" ]; }; then
-    printf '  [ok]   %s (rc=%s)\n' "$name" "$brc"
-  else
-    printf '  [FAIL] %s (rc bash=%s py=%s want=%s)\n' "$name" "$brc" "$prc" "${want:-any}"; FAILS=$((FAILS+1))
-  fi
-}
-
 echo "── runtime parity harness (bash vs python) ──"
 echo "  behavioral (strict stdout+stderr+rc):"
 _check "version"        "$BIN/mini-ork" version
 _check "help"           "$BIN/mini-ork" help
 _check "doctor"         "$BIN/mini-ork" doctor
 _check "unknown-subcmd" "$BIN/mini-ork" bogus-subcmd
+_check "review no-arg"  "$BIN/mini-ork-review"
+_check "review bad-sub" "$BIN/mini-ork-review" bogus
 
-echo "  --help/usage (exit-code parity; text is a cosmetic follow-up):"
-_check_rc "plan --help"      0 "$BIN/mini-ork-plan" --help
-_check_rc "classify --help"  0 "$BIN/mini-ork-classify" --help
-_check_rc "conductor --help" 0 "$BIN/mini-ork-conductor" --help
-_check_rc "scheduler --help" 0 "$BIN/mini-ork-scheduler" --help
-_check_rc "epics --help"     0 "$BIN/mini-ork-epics" --help
-_check_rc "execute --help"   0 "$BIN/mini-ork-execute" --help
+echo "  --help/usage (strict stdout+stderr+rc — full usage text transcribed):"
+_check "plan --help"      "$BIN/mini-ork-plan" --help
+_check "classify --help"  "$BIN/mini-ork-classify" --help
+_check "conductor --help" "$BIN/mini-ork-conductor" --help
+_check "scheduler --help" "$BIN/mini-ork-scheduler" --help
+_check "epics --help"     "$BIN/mini-ork-epics" --help
+_check "execute --help"   "$BIN/mini-ork-execute" --help
 
 # plan --dry-run: a full deterministic pipeline (classify→profile→plan placeholder)
 printf '# Ship widget\n\n## Success\n- widget renders\n\n## Verification commands\n- `pytest`\n' > "$TMP/k.md"
@@ -78,6 +66,23 @@ if [ "$(_dryplan bash)" = "$(_dryplan python)" ]; then
 else
   echo "  [FAIL] plan --dry-run (full pipeline)"; FAILS=$((FAILS+1))
   diff <(_dryplan bash) <(_dryplan python) | sed 's/^/       /' | head -12
+fi
+
+# init: scaffolds .mini-ork under a fresh project dir. Run each runtime in its
+# own temp project (side-effecting) and diff stdout with the project path
+# normalized. Guards the silent-no-op class of cutover bug (a delegated module
+# with no working __main__ that does nothing under python).
+_initrun() {  # runtime passed as $1; prints init stdout with project path normalized
+  local rt="$1" proj="$TMP/proj-$1"
+  mkdir -p "$proj"
+  ( cd "$proj" && MINI_ORK_RUNTIME="$rt" MINI_ORK_ROOT="$ROOT" "$BIN/mini-ork-init" 2>&1 ) \
+    | sed "s#$proj#<PROJ>#g" | _norm
+}
+if [ "$(_initrun bash)" = "$(_initrun python)" ]; then
+  echo "  [ok]   init (scaffold .mini-ork)"
+else
+  echo "  [FAIL] init (scaffold .mini-ork)"; FAILS=$((FAILS+1))
+  diff <(_initrun bash) <(_initrun python) | sed 's/^/       /' | head -12
 fi
 
 echo "──"


### PR DESCRIPTION
Documents the validation run for the ported executor live path. **Gate #1** (live-dispatch harness, real sonnet lane): PASS. **Gate #2** (2 independent opus adversarial reviewers): **NO-GO** — 5 blocks-cutover defects (dead policy routing, stub publisher, is_synth panel-gate misclassification, unpinned MO_TARGET_CWD repo-corruption hazard, absent safety gates) that the fake-dispatch unit tests structurally miss. Deterministic cutover stays safe; the live default must not flip until the must-fix list lands. Verdict doc + must-fix list in `docs/reviews/`.