### PR TITLE
fix(test): de-time-bomb test_learning_loop_writeback (relative seed date)

### DIFF
--- a/tests/unit/test_learning_loop_writeback.sh
+++ b/tests/unit/test_learning_loop_writeback.sh
@@ -46,6 +46,7 @@ source "$LIB_PIPELINE"
 # miner emits one pattern. 2 traces in (code_fix, success) → does NOT emit.
 python3 - "$TEST_DB" <<'PY'
 import sqlite3, sys, time
+from datetime import datetime, timedelta, timezone
 db = sys.argv[1]
 con = sqlite3.connect(db)
 con.execute("PRAGMA busy_timeout=5000")
@@ -68,7 +69,11 @@ con.execute("""
         created_at INTEGER
     )
 """)
-now_iso = "2026-07-01T12:00:00.000Z"
+# created_at must be RELATIVE to now — the miner filters `created_at >= now-<window>`
+# (pattern_store.sh:216). A hardcoded absolute date silently ages out of the default
+# 7d window and the miner returns 0 rows (the time-bomb that broke this test once real
+# time crossed 7 days past the old literal). Seed 1h ago so it's always in-window.
+now_iso = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 rows = [
     ("tr-fix-fail-1", "code_fix", "failure", now_iso),
     ("tr-fix-fail-2", "code_fix", "failure", now_iso),


### PR DESCRIPTION
The pre-existing main-red test. It seeded execution_traces with a hardcoded `created_at='2026-07-01T12:00:00Z'` but mines with a relative `--window 7d` (pattern_store.sh:216 = `created_at >= now-window`). Once real time passed 7 days beyond that literal, the seed aged out of the window → miner returns 0 rows → 5 cascading assertion FAILs. **The write-back code was never broken** — the test was a time-bomb. Fix: seed the traces dynamically (1h ago). 9 OK / 0 FAIL; the 5 sibling date+window tests verified not bombed.