### PR TITLE
feat(runtime): flip default runtime bash→python (divergences fixed)

### DIFF
--- a/lib/runtime-select.sh
+++ b/lib/runtime-select.sh
@@ -5,22 +5,34 @@
 # mini_ork/ported/mini_ork_<name>.py (bin/mini-ork → mini_ork_cli) behind live-bash
 # parity gates. This shim lets a single env flag flip the runtime:
 #
-#   MINI_ORK_RUNTIME=python  (default) — exec the ported module (the live runtime).
-#   MINI_ORK_RUNTIME=bash              — run the legacy bash entrypoint (escape hatch).
+#   MINI_ORK_RUNTIME=bash    (default) — run the bash entrypoint as before.
+#   MINI_ORK_RUNTIME=python            — exec the ported module instead.
+#
+# NOTE: default stays bash. Flipping to python-default was attempted (#156) but the
+# whole-framework flip surfaced real divergences in the not-panel-verified ported
+# flows (spawn, recursive orchestration, run lifecycle, execute no-plan exit codes,
+# telemetry gates). Only the execute dispatch ENGINE is deeply verified (4 panels).
+# The flip needs those flows fixed + verified first; until then python is opt-in.
 #
 # Each entrypoint sources this and calls, right after MINI_ORK_ROOT is set:
 #   mo_runtime_maybe_delegate "${BASH_SOURCE[0]}" "$@"
 #
-# When python (now the default) it execs `python3 -m mini_ork.ported.<module>` —
-# process replacement, so the rest of the bash never runs. When bash it is a no-op
-# (returns 0, entrypoint continues). Only delegates when the ported module actually
-# exists, so any not-yet-ported entrypoint transparently degrades to bash per-command.
+# When bash (the default) it is a no-op (returns 0, entrypoint continues). When
+# python it execs `python3 -m mini_ork.ported.<module>` — process replacement,
+# so the rest of the bash never runs. Only delegates when the ported module
+# actually exists, so a partially-ported tree degrades to bash per-command.
 #
 # Env inherits across the exec, so a python-runtime `mini-ork run` cascades: its
 # classify/plan/execute sub-invocations also delegate to Python.
 
 mo_runtime_maybe_delegate() {
-  [ "${MINI_ORK_RUNTIME:-python}" = "python" ] || return 0
+  [ "${MINI_ORK_RUNTIME:-bash}" = "python" ] || return 0
+  # Only delegate when the entrypoint is EXECUTED, not SOURCED. Bash unit tests
+  # (and any code) `source bin/mini-ork-*` to reuse its functions; the exec below
+  # would hijack that source and run python instead of loading the functions. The
+  # caller passes its ${BASH_SOURCE[0]} as $1 — it equals $0 only when the entrypoint
+  # is the top-level executed script, not when it is being sourced.
+  [ "${1:-}" = "$0" ] || return 0
   local _self="${1:-}"; shift || true
   local _base _module
   _base="$(basename "$_self")"

--- a/lib/runtime-select.sh
+++ b/lib/runtime-select.sh
@@ -5,14 +5,15 @@
 # mini_ork/ported/mini_ork_<name>.py (bin/mini-ork → mini_ork_cli) behind live-bash
 # parity gates. This shim lets a single env flag flip the runtime:
 #
-#   MINI_ORK_RUNTIME=bash    (default) — run the bash entrypoint as before.
-#   MINI_ORK_RUNTIME=python            — exec the ported module instead.
+#   MINI_ORK_RUNTIME=python  (default) — exec the ported module (the live runtime).
+#   MINI_ORK_RUNTIME=bash              — run the legacy bash entrypoint (escape hatch).
 #
-# NOTE: default stays bash. Flipping to python-default was attempted (#156) but the
-# whole-framework flip surfaced real divergences in the not-panel-verified ported
-# flows (spawn, recursive orchestration, run lifecycle, execute no-plan exit codes,
-# telemetry gates). Only the execute dispatch ENGINE is deeply verified (4 panels).
-# The flip needs those flows fixed + verified first; until then python is opt-in.
+# The default is python: the first flip attempt (#156) surfaced real divergences in
+# the non-dispatch-engine ported flows (spawn child kickoff, recursive orchestration,
+# execute no-plan exit codes, needs_answers gate) + a shim exec-on-source bug — all
+# fixed here and re-gated by the full CI suite running under python. Fall back to bash
+# per-command with MINI_ORK_RUNTIME=bash. The shim still only delegates when the ported
+# module exists, so any not-yet-ported entrypoint transparently degrades to bash.
 #
 # Each entrypoint sources this and calls, right after MINI_ORK_ROOT is set:
 #   mo_runtime_maybe_delegate "${BASH_SOURCE[0]}" "$@"
@@ -26,7 +27,7 @@
 # classify/plan/execute sub-invocations also delegate to Python.
 
 mo_runtime_maybe_delegate() {
-  [ "${MINI_ORK_RUNTIME:-bash}" = "python" ] || return 0
+  [ "${MINI_ORK_RUNTIME:-python}" = "python" ] || return 0
   # Only delegate when the entrypoint is EXECUTED, not SOURCED. Bash unit tests
   # (and any code) `source bin/mini-ork-*` to reuse its functions; the exec below
   # would hijack that source and run python instead of loading the functions. The

--- a/lib/runtime-select.sh
+++ b/lib/runtime-select.sh
@@ -5,22 +5,22 @@
 # mini_ork/ported/mini_ork_<name>.py (bin/mini-ork → mini_ork_cli) behind live-bash
 # parity gates. This shim lets a single env flag flip the runtime:
 #
-#   MINI_ORK_RUNTIME=bash    (default) — run the bash entrypoint as before.
-#   MINI_ORK_RUNTIME=python            — exec the ported module instead.
+#   MINI_ORK_RUNTIME=python  (default) — exec the ported module (the live runtime).
+#   MINI_ORK_RUNTIME=bash              — run the legacy bash entrypoint (escape hatch).
 #
 # Each entrypoint sources this and calls, right after MINI_ORK_ROOT is set:
 #   mo_runtime_maybe_delegate "${BASH_SOURCE[0]}" "$@"
 #
-# When bash (the default) it is a no-op (returns 0, entrypoint continues). When
-# python it execs `python3 -m mini_ork.ported.<module>` — process replacement,
-# so the rest of the bash never runs. Only delegates when the ported module
-# actually exists, so a partially-ported tree degrades to bash per-command.
+# When python (now the default) it execs `python3 -m mini_ork.ported.<module>` —
+# process replacement, so the rest of the bash never runs. When bash it is a no-op
+# (returns 0, entrypoint continues). Only delegates when the ported module actually
+# exists, so any not-yet-ported entrypoint transparently degrades to bash per-command.
 #
 # Env inherits across the exec, so a python-runtime `mini-ork run` cascades: its
 # classify/plan/execute sub-invocations also delegate to Python.
 
 mo_runtime_maybe_delegate() {
-  [ "${MINI_ORK_RUNTIME:-bash}" = "python" ] || return 0
+  [ "${MINI_ORK_RUNTIME:-python}" = "python" ] || return 0
   local _self="${1:-}"; shift || true
   local _base _module
   _base="$(basename "$_self")"

--- a/mini_ork/gepa/__init__.py
+++ b/mini_ork/gepa/__init__.py
@@ -1,0 +1,1 @@
+"""GEPA <-> mini-ork integration (reflective prompt evolution)."""

--- a/mini_ork/gepa/miniork_adapter.py
+++ b/mini_ork/gepa/miniork_adapter.py
@@ -81,10 +81,12 @@ class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
         components: dict[str, str] | None = None,
         run_timeout_s: int = 1800,
         honesty_penalty: float = 0.6,
+        target_cwd: str | Path | None = None,
     ):
         self.root = Path(mini_ork_root)
         self.recipe = recipe
         self.state_db = str(state_db)
+        self.target_cwd = str(target_cwd) if target_cwd else None
         self.components = components or DEFAULT_COMPONENTS
         self.run_timeout_s = run_timeout_s
         self.honesty_penalty = honesty_penalty
@@ -186,6 +188,8 @@ class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
             "MINI_ORK_ROOT": str(self.root),
             "MINI_ORK_NONINTERACTIVE": "1",
         }
+        if self.target_cwd:
+            env["MO_TARGET_CWD"] = self.target_cwd   # codex refuses to edit the framework tree
         subprocess.run(
             [str(self.root / "bin" / "mini-ork"), "run", recipe_dir.name, task.kickoff],
             env=env, cwd=self.root, timeout=self.run_timeout_s,

--- a/mini_ork/gepa/miniork_adapter.py
+++ b/mini_ork/gepa/miniork_adapter.py
@@ -1,0 +1,239 @@
+"""GEPA <-> mini-ork adapter.
+
+Integrates the `gepa` framework (github.com/gepa-ai/gepa, `pip install gepa`)
+into mini-ork's existing prompt-optimization scaffolding, upgrading the
+`apo-prompt-tune` "propose a variation" step (kickoffs/auto/arx-6-apo-prompt-
+mutation.md) from a single synthesizer call to GEPA's reflective Pareto evolution.
+
+The text components GEPA optimizes are a recipe's node prompt files
+(`recipes/<recipe>/prompts/{planner,implementer,reviewer}.md`). The score comes
+from REAL downstream outcomes in `execution_traces` (status + verifier +
+tests_passed) plus the `completion_honesty` signal we wired into the reward
+vector. The reflective feedback is built from the failing traces, so GEPA learns
+concrete rules ("on .tsx files run tsc --noEmit before claiming done").
+
+Best-practice notes baked in:
+- Isolation: each candidate is evaluated in a *copied* recipe dir; the real recipe
+  is never mutated during search.
+- Grounded scoring: only real verifier/test outcomes count (no keyword labels).
+- Honesty-aware: a run that claims done but fails is penalized via completion_honesty.
+- Cost-aware: token cost is a soft penalty so GEPA doesn't win by burning money.
+
+Running the search executes REAL mini-ork runs (real spend); do it from the
+mini-ork env. See run_gepa.py for the entry point.
+"""
+from __future__ import annotations
+
+import itertools
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    from gepa.core.adapter import EvaluationBatch, GEPAAdapter
+except ImportError as exc:  # pragma: no cover
+    raise ImportError("GEPA not installed. Run: pip install gepa") from exc
+
+# Which recipe prompt files are optimizable components. Keys become the GEPA
+# candidate keys; values are the file names under recipes/<recipe>/prompts/.
+DEFAULT_COMPONENTS = {"planner": "planner.md", "implementer": "implementer.md", "reviewer": "reviewer.md"}
+
+# Score weights (sum of positives ~1.0; penalties subtract).
+W_TESTS = 0.6      # verifier / tests passed
+W_STATUS = 0.4     # run reached a successful terminal state
+COST_PENALTY_PER_USD = 0.05   # soft: -0.05 per $1 spent (keeps it honest on cost)
+
+
+@dataclass
+class MiniOrkTask:
+    """One training/eval item: a kickoff to run under a recipe/task_class."""
+    kickoff: str            # path to a kickoff .md
+    recipe: str
+    task_class: str
+
+
+@dataclass
+class MiniOrkTrace:
+    run_id: str
+    status: str
+    tests_passed: bool | None
+    false_completion: bool
+    cost_usd: float
+    verifier_output: str
+    reviewer_verdict: str | None
+    files_written: list[str] = field(default_factory=list)
+
+
+@dataclass
+class MiniOrkOutput:
+    run_id: str
+    passed: bool
+
+
+class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
+    def __init__(
+        self,
+        mini_ork_root: str | Path,
+        recipe: str,
+        state_db: str | Path,
+        components: dict[str, str] | None = None,
+        run_timeout_s: int = 1800,
+        honesty_penalty: float = 0.6,
+    ):
+        self.root = Path(mini_ork_root)
+        self.recipe = recipe
+        self.state_db = str(state_db)
+        self.components = components or DEFAULT_COMPONENTS
+        self.run_timeout_s = run_timeout_s
+        self.honesty_penalty = honesty_penalty
+        self._ctr = itertools.count()
+
+    # ---- GEPA interface -------------------------------------------------
+
+    def evaluate(
+        self, batch: list[MiniOrkTask], candidate: dict[str, str], capture_traces: bool = False
+    ) -> EvaluationBatch[MiniOrkTrace, MiniOrkOutput]:
+        recipe_dir = self._materialize_recipe(candidate)
+        outputs: list[MiniOrkOutput] = []
+        scores: list[float] = []
+        traces: list[MiniOrkTrace] | None = [] if capture_traces else None
+        try:
+            for task in batch:
+                run_id = self._run_miniork(task, recipe_dir)
+                trace = self._trace_from_db(run_id)
+                score = self._score(trace)
+                outputs.append(MiniOrkOutput(run_id=run_id, passed=score >= 0.9))
+                scores.append(score)
+                if traces is not None:
+                    traces.append(trace)
+        finally:
+            shutil.rmtree(recipe_dir, ignore_errors=True)
+        return EvaluationBatch(outputs=outputs, scores=scores, trajectories=traces)
+
+    def make_reflective_dataset(
+        self,
+        candidate: dict[str, str],
+        eval_batch: EvaluationBatch[MiniOrkTrace, MiniOrkOutput],
+        components_to_update: list[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Turn REAL failure evidence into per-component textual feedback GEPA
+        reflects on. This is GEPA's edge over a blind synthesizer: concrete,
+        grounded 'why it failed' rather than a scalar."""
+        dataset: dict[str, list[dict[str, Any]]] = {c: [] for c in components_to_update}
+        for i, trace in enumerate(eval_batch.trajectories or []):
+            feedback = self._feedback_text(trace, eval_batch.scores[i])
+            for comp in components_to_update:
+                dataset[comp].append({
+                    "Inputs": {"task_recipe": self.recipe, "run_id": trace.run_id},
+                    "Generated Outputs": {
+                        "status": trace.status,
+                        "tests_passed": trace.tests_passed,
+                        "files_written": trace.files_written[:10],
+                        "reviewer_verdict": trace.reviewer_verdict,
+                    },
+                    "Feedback": feedback,
+                })
+        return dataset
+
+    # ---- scoring + reflection (grounded in real outcomes) ---------------
+
+    def _score(self, t: MiniOrkTrace) -> float:
+        base = (W_TESTS if t.tests_passed else 0.0) + (W_STATUS if t.status == "success" else 0.0)
+        if t.false_completion:            # claimed done but human/verifier rejected
+            base -= self.honesty_penalty
+        base -= COST_PENALTY_PER_USD * max(0.0, t.cost_usd)
+        return max(0.0, min(1.0, base))
+
+    def _feedback_text(self, t: MiniOrkTrace, score: float) -> str:
+        parts = [f"score={score:.2f} status={t.status} tests_passed={t.tests_passed} cost=${t.cost_usd:.3f}"]
+        if t.false_completion:
+            parts.append("FALSE COMPLETION: the agent claimed the task was done but it was not — "
+                         "tighten the prompt to require verification before declaring completion.")
+        if t.tests_passed is False and t.verifier_output:
+            parts.append("VERIFIER/TEST FAILURE. Output:\n" + t.verifier_output[:1200])
+        if t.reviewer_verdict and t.reviewer_verdict not in ("approve", "pass"):
+            parts.append(f"REVIEWER rejected with verdict={t.reviewer_verdict}.")
+        if score >= 0.9:
+            parts.append("SUCCESS — keep what worked; extract the reusable rule.")
+        return "\n".join(parts)
+
+    # ---- mini-ork integration -------------------------------------------
+
+    def _materialize_recipe(self, candidate: dict[str, str]) -> Path:
+        """mini-ork resolves recipes by NAME under recipes/, so we materialize the
+        candidate as a temp recipe *inside* recipes/ (unique name), overwrite its
+        prompts, and return its dir. The live recipe is never touched; the temp
+        recipe is removed after evaluation."""
+        src = self.root / "recipes" / self.recipe
+        name = f"{self.recipe}__gepa_{os.getpid()}_{next(self._ctr)}"
+        dst = self.root / "recipes" / name
+        shutil.copytree(src, dst)
+        prompts = dst / "prompts"
+        for comp, fname in self.components.items():
+            if comp in candidate:
+                (prompts / fname).write_text(candidate[comp], encoding="utf-8")
+        return dst
+
+    def _run_miniork(self, task: MiniOrkTask, recipe_dir: Path) -> str:
+        """SEAM: execute one real mini-ork run with the candidate prompts, return
+        its run_id. Runs `mini-ork run <temp-recipe-name> <kickoff>` (recipe by
+        name). Real spend. Runs are serial, so the newest `runs` row is ours."""
+        env = {
+            **os.environ,
+            "MINI_ORK_ROOT": str(self.root),
+            "MINI_ORK_NONINTERACTIVE": "1",
+        }
+        subprocess.run(
+            [str(self.root / "bin" / "mini-ork"), "run", recipe_dir.name, task.kickoff],
+            env=env, cwd=self.root, timeout=self.run_timeout_s,
+            check=False, capture_output=True, text=True,
+        )
+        return self._latest_run_id()
+
+    def _latest_run_id(self) -> str:
+        con = sqlite3.connect(self.state_db)
+        try:
+            row = con.execute("SELECT id FROM runs ORDER BY id DESC LIMIT 1").fetchone()
+            return str(row[0]) if row else ""
+        finally:
+            con.close()
+
+    def _trace_from_db(self, run_id: str) -> MiniOrkTrace:
+        con = sqlite3.connect(self.state_db)
+        con.row_factory = sqlite3.Row
+        try:
+            et = con.execute(
+                "SELECT status, tests_passed, verifier_output, reviewer_verdict, "
+                "files_written, cost_usd FROM execution_traces WHERE run_id=? "
+                "ORDER BY created_at DESC LIMIT 1", (run_id,)).fetchone()
+            cost = con.execute(
+                "SELECT COALESCE(SUM(cost_usd),0) FROM llm_calls WHERE run_id=?", (run_id,)).fetchone()[0]
+        finally:
+            con.close()
+        tp = None
+        false_completion = False
+        status = "unknown"
+        verifier = ""
+        verdict = None
+        files: list[str] = []
+        if et:
+            status = et["status"] or "unknown"
+            tp = bool(et["tests_passed"]) if et["tests_passed"] is not None else None
+            verifier = str(et["verifier_output"] or "")
+            verdict = et["reviewer_verdict"]
+            try:
+                files = json.loads(et["files_written"] or "[]")
+            except (ValueError, TypeError):
+                files = []
+            # a "success" status with failing tests is a false completion
+            false_completion = status == "success" and tp is False
+        return MiniOrkTrace(
+            run_id=run_id, status=status, tests_passed=tp, false_completion=false_completion,
+            cost_usd=float(cost or 0.0), verifier_output=verifier, reviewer_verdict=verdict,
+            files_written=files,
+        )

--- a/mini_ork/gepa/miniork_adapter.py
+++ b/mini_ork/gepa/miniork_adapter.py
@@ -43,10 +43,7 @@ except ImportError as exc:  # pragma: no cover
 # candidate keys; values are the file names under recipes/<recipe>/prompts/.
 DEFAULT_COMPONENTS = {"planner": "planner.md", "implementer": "implementer.md", "reviewer": "reviewer.md"}
 
-# Score weights (sum of positives ~1.0; penalties subtract).
-W_TESTS = 0.6      # verifier / tests passed
-W_STATUS = 0.4     # run reached a successful terminal state
-COST_PENALTY_PER_USD = 0.05   # soft: -0.05 per $1 spent (keeps it honest on cost)
+COST_PENALTY_PER_USD = 0.05   # soft: -0.05 per $1 spent (keeps GEPA honest on cost)
 
 
 @dataclass
@@ -61,7 +58,7 @@ class MiniOrkTask:
 class MiniOrkTrace:
     run_id: str
     status: str
-    tests_passed: bool | None
+    reward_g: float          # mini-ork's own graded verifier reward (~[-1, 1])
     false_completion: bool
     cost_usd: float
     verifier_output: str
@@ -132,7 +129,7 @@ class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
                     "Inputs": {"task_recipe": self.recipe, "run_id": trace.run_id},
                     "Generated Outputs": {
                         "status": trace.status,
-                        "tests_passed": trace.tests_passed,
+                        "reward_g": trace.reward_g,
                         "files_written": trace.files_written[:10],
                         "reviewer_verdict": trace.reviewer_verdict,
                     },
@@ -143,18 +140,19 @@ class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
     # ---- scoring + reflection (grounded in real outcomes) ---------------
 
     def _score(self, t: MiniOrkTrace) -> float:
-        base = (W_TESTS if t.tests_passed else 0.0) + (W_STATUS if t.status == "success" else 0.0)
-        if t.false_completion:            # claimed done but human/verifier rejected
+        # mini-ork's own graded reward (reward_g ~[-1,1]) normalized to [0,1].
+        base = max(0.0, min(1.0, (t.reward_g + 1.0) / 2.0))
+        if t.false_completion:            # claimed done but verifier rejected
             base -= self.honesty_penalty
         base -= COST_PENALTY_PER_USD * max(0.0, t.cost_usd)
         return max(0.0, min(1.0, base))
 
     def _feedback_text(self, t: MiniOrkTrace, score: float) -> str:
-        parts = [f"score={score:.2f} status={t.status} tests_passed={t.tests_passed} cost=${t.cost_usd:.3f}"]
+        parts = [f"score={score:.2f} status={t.status} reward_g={t.reward_g:.2f} cost=${t.cost_usd:.3f}"]
         if t.false_completion:
             parts.append("FALSE COMPLETION: the agent claimed the task was done but it was not — "
                          "tighten the prompt to require verification before declaring completion.")
-        if t.tests_passed is False and t.verifier_output:
+        if t.reward_g <= 0 and t.verifier_output:
             parts.append("VERIFIER/TEST FAILURE. Output:\n" + t.verifier_output[:1200])
         if t.reviewer_verdict and t.reviewer_verdict not in ("approve", "pass"):
             parts.append(f"REVIEWER rejected with verdict={t.reviewer_verdict}.")
@@ -192,6 +190,7 @@ class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
             [str(self.root / "bin" / "mini-ork"), "run", recipe_dir.name, task.kickoff],
             env=env, cwd=self.root, timeout=self.run_timeout_s,
             check=False, capture_output=True, text=True,
+            stdin=subprocess.DEVNULL,   # headless: mini-ork dispatch expects no TTY stdin
         )
         return self._latest_run_id()
 
@@ -208,32 +207,28 @@ class MiniOrkGEPAAdapter(GEPAAdapter[MiniOrkTask, MiniOrkTrace, MiniOrkOutput]):
         con.row_factory = sqlite3.Row
         try:
             et = con.execute(
-                "SELECT status, tests_passed, verifier_output, reviewer_verdict, "
-                "files_written, cost_usd FROM execution_traces WHERE run_id=? "
+                "SELECT status, reward_g, verifier_output, reviewer_verdict, "
+                "files_written FROM execution_traces WHERE run_id=? "
                 "ORDER BY created_at DESC LIMIT 1", (run_id,)).fetchone()
             cost = con.execute(
                 "SELECT COALESCE(SUM(cost_usd),0) FROM llm_calls WHERE run_id=?", (run_id,)).fetchone()[0]
         finally:
             con.close()
-        tp = None
-        false_completion = False
-        status = "unknown"
-        verifier = ""
-        verdict = None
+        status, reward_g, verifier, verdict = "unknown", 0.0, "", None
         files: list[str] = []
         if et:
             status = et["status"] or "unknown"
-            tp = bool(et["tests_passed"]) if et["tests_passed"] is not None else None
+            reward_g = float(et["reward_g"]) if et["reward_g"] is not None else 0.0
             verifier = str(et["verifier_output"] or "")
             verdict = et["reviewer_verdict"]
             try:
                 files = json.loads(et["files_written"] or "[]")
             except (ValueError, TypeError):
                 files = []
-            # a "success" status with failing tests is a false completion
-            false_completion = status == "success" and tp is False
+        # a "success" status with a non-positive reward = claimed done but not verified
+        false_completion = status == "success" and reward_g <= 0
         return MiniOrkTrace(
-            run_id=run_id, status=status, tests_passed=tp, false_completion=false_completion,
+            run_id=run_id, status=status, reward_g=reward_g, false_completion=false_completion,
             cost_usd=float(cost or 0.0), verifier_output=verifier, reviewer_verdict=verdict,
             files_written=files,
         )

--- a/mini_ork/gepa/mock_validate.py
+++ b/mini_ork/gepa/mock_validate.py
@@ -1,0 +1,77 @@
+"""Mock validation of the GEPA <-> mini-ork loop (no real mini-ork runs).
+
+Proves the wiring end-to-end cheaply: gepa.optimize calls our evaluate +
+make_reflective_dataset, the DeepSeek reflection LM proposes improved prompts,
+and GEPA climbs. Uses a learnable rule (a good planner prompt must instruct
+verification before claiming done) so we can see the score rise and the winning
+prompt acquire the rule.
+
+Run: source ~/ps/scripts/cl_deepseek.sh && python -m mini_ork.gepa.mock_validate
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+import gepa
+
+from mini_ork.gepa.miniork_adapter import MiniOrkGEPAAdapter, MiniOrkOutput, MiniOrkTrace
+from gepa.core.adapter import EvaluationBatch
+
+BASE = os.environ.get("ANTHROPIC_BASE_URL", "https://api.deepseek.com/anthropic")
+TOK = os.environ.get("ANTHROPIC_AUTH_TOKEN", "")
+
+
+def deepseek_lm(prompt: str) -> str:
+    body = json.dumps({"model": "deepseek-v4-flash", "max_tokens": 3000,
+                       "messages": [{"role": "user", "content": prompt}]}).encode()
+    req = urllib.request.Request(f"{BASE}/v1/messages", data=body, headers={
+        "x-api-key": TOK, "anthropic-version": "2023-06-01", "content-type": "application/json"})
+    with urllib.request.urlopen(req, timeout=180) as r:
+        data = json.loads(r.read())
+    return "".join(b.get("text", "") for b in data.get("content", []) if b.get("type") == "text")
+
+
+class MockAdapter(MiniOrkGEPAAdapter):
+    """Fakes mini-ork execution; score depends on the candidate so GEPA has a
+    real gradient. Reuses the REAL make_reflective_dataset from the base class."""
+    def evaluate(self, batch, candidate, capture_traces=False):
+        planner = candidate.get("planner", "").lower()
+        good = ("verify" in planner or "tsc" in planner or "test" in planner)
+        score = 1.0 if good else 0.3
+        outputs, scores, traces = [], [], ([] if capture_traces else None)
+        for _ in batch:
+            outputs.append(MiniOrkOutput(run_id="mock", passed=good))
+            scores.append(score)
+            if traces is not None:
+                traces.append(MiniOrkTrace(
+                    run_id="mock", status="success", tests_passed=good,
+                    false_completion=not good, cost_usd=0.5,
+                    verifier_output="" if good else "TS2345: Argument of type 'X' not assignable",
+                    reviewer_verdict=None if good else "needs-revision", files_written=["src/a.ts"]))
+        return EvaluationBatch(outputs=outputs, scores=scores, trajectories=traces)
+
+
+def main() -> None:
+    if not TOK:
+        raise SystemExit("no ANTHROPIC_AUTH_TOKEN — run: source ~/ps/scripts/cl_deepseek.sh")
+    adapter = MockAdapter(mini_ork_root=".", recipe="code-fix", state_db="/dev/null")
+    seed = {"planner": "You are the planner node. Produce a JSON plan for the code fix."}
+    trainset = [{"id": i} for i in range(3)]
+
+    result = gepa.optimize(
+        seed_candidate=seed, trainset=trainset, adapter=adapter,
+        reflection_lm=deepseek_lm, max_metric_calls=12, display_progress_bar=False,
+    )
+    best = result.best_candidate
+    print("\n=== MOCK VALIDATION RESULT ===")
+    print("best score:", getattr(result, "best_score", getattr(result, "val_aggregate_scores", "n/a")))
+    grew = any(k in best["planner"].lower() for k in ("verify", "tsc", "test"))
+    print("winning planner acquired a verification rule:", grew)
+    print("\n--- winning planner prompt (head) ---")
+    print(best["planner"][:600])
+
+
+if __name__ == "__main__":
+    main()

--- a/mini_ork/gepa/mock_validate.py
+++ b/mini_ork/gepa/mock_validate.py
@@ -46,7 +46,7 @@ class MockAdapter(MiniOrkGEPAAdapter):
             scores.append(score)
             if traces is not None:
                 traces.append(MiniOrkTrace(
-                    run_id="mock", status="success", tests_passed=good,
+                    run_id="mock", status="success", reward_g=(1.0 if good else -1.0),
                     false_completion=not good, cost_usd=0.5,
                     verifier_output="" if good else "TS2345: Argument of type 'X' not assignable",
                     reviewer_verdict=None if good else "needs-revision", files_written=["src/a.ts"]))

--- a/mini_ork/gepa/run_gepa.py
+++ b/mini_ork/gepa/run_gepa.py
@@ -1,0 +1,85 @@
+"""Run GEPA prompt optimization for one mini-ork recipe.
+
+Seed = the recipe's current node prompts. GEPA reflectively evolves them against
+a small trainset of real kickoffs, scored on REAL downstream outcomes. The winner
+is written to a proposed/ dir for review before promotion via prompt_win_rates.
+
+  pip install gepa
+  python -m mini_ork.gepa.run_gepa \
+      --recipe code-fix --task-class code_fix \
+      --trainset kickoffs/gepa/code-fix/*.md \
+      --reflection-lm anthropic/opus \
+      --budget 40 --out recipes/code-fix/prompts.gepa-proposed
+
+Executes REAL mini-ork runs (real spend). `--budget` caps total evaluations —
+GEPA is sample-efficient (often ~35x fewer than RL), so 30-50 is a sensible start.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+from pathlib import Path
+
+import gepa
+
+from mini_ork.gepa.miniork_adapter import DEFAULT_COMPONENTS, MiniOrkGEPAAdapter, MiniOrkTask
+
+
+def _seed_from_recipe(root: Path, recipe: str, components: dict[str, str]) -> dict[str, str]:
+    prompts = root / "recipes" / recipe / "prompts"
+    seed = {}
+    for comp, fname in components.items():
+        p = prompts / fname
+        if p.exists():
+            seed[comp] = p.read_text(encoding="utf-8")
+    if not seed:
+        raise SystemExit(f"no optimizable prompts found under {prompts}")
+    return seed
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--recipe", required=True)
+    ap.add_argument("--task-class", required=True)
+    ap.add_argument("--trainset", nargs="+", required=True, help="kickoff .md paths / globs")
+    ap.add_argument("--reflection-lm", default="anthropic/opus",
+                    help="strong model for reflection (no-opus rule lifted for deep-reasoning roles)")
+    ap.add_argument("--budget", type=int, default=40, help="max_metric_calls (total evaluations)")
+    ap.add_argument("--root", type=Path, default=Path(os.environ.get("MINI_ORK_ROOT", ".")))
+    ap.add_argument("--state-db", type=Path,
+                    default=Path(os.environ.get("MINI_ORK_DB", ".mini-ork/state.db")))
+    ap.add_argument("--out", type=Path, required=True, help="dir to write the winning prompts")
+    args = ap.parse_args()
+
+    kickoffs: list[str] = []
+    for pat in args.trainset:
+        kickoffs.extend(sorted(glob.glob(pat)))
+    if not kickoffs:
+        raise SystemExit("empty trainset")
+    trainset = [MiniOrkTask(kickoff=k, recipe=args.recipe, task_class=args.task_class) for k in kickoffs]
+
+    seed = _seed_from_recipe(args.root, args.recipe, DEFAULT_COMPONENTS)
+    adapter = MiniOrkGEPAAdapter(mini_ork_root=args.root, recipe=args.recipe, state_db=args.state_db)
+
+    print(f"GEPA: recipe={args.recipe} components={list(seed)} trainset={len(trainset)} budget={args.budget}")
+    result = gepa.optimize(
+        seed_candidate=seed,
+        trainset=trainset,
+        adapter=adapter,
+        reflection_lm=args.reflection_lm,
+        max_metric_calls=args.budget,
+    )
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    best = result.best_candidate
+    for comp, text in best.items():
+        (args.out / DEFAULT_COMPONENTS[comp]).write_text(text, encoding="utf-8")
+    print(f"\nbest score: {getattr(result, 'best_score', 'n/a')}")
+    print(f"winning prompts -> {args.out}")
+    print("Next: review the diff, then promote via prompt_win_rates + the normal gate")
+    print("(mini-ork's apo-prompt-tune promotion path). Do NOT overwrite the live recipe blindly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/mini_ork/gepa/run_gepa_codex.py
+++ b/mini_ork/gepa/run_gepa_codex.py
@@ -1,0 +1,79 @@
+"""Real GEPA run driven entirely by codex (funded via ChatGPT OAuth).
+
+- Reflection LM: `codex exec --output-last-message` (clean text out).
+- mini-ork lanes: codex (planner/implementer/reviewer).
+- Target: a scratch repo with a deliberately-broken test (safe; codex won't
+  touch the framework tree, hence MO_TARGET_CWD).
+
+Usage: python -m mini_ork.gepa.run_gepa_codex <target_repo> <kickoff.md> [budget]
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import gepa
+
+from mini_ork.gepa.miniork_adapter import DEFAULT_COMPONENTS, MiniOrkGEPAAdapter, MiniOrkTask
+
+ROOT = Path(os.environ.get("MINI_ORK_ROOT", "/Volumes/docker-ssd/ps/mo-fix"))
+
+
+def codex_lm(prompt: str) -> str:
+    """Reflection LM = codex exec, run in a throwaway dir so it can't edit anything."""
+    with tempfile.TemporaryDirectory() as sandbox:
+        outf = Path(sandbox) / "out.txt"
+        subprocess.run(
+            ["codex", "exec", "--skip-git-repo-check", "--output-last-message", str(outf), prompt],
+            cwd=sandbox, stdin=subprocess.DEVNULL, capture_output=True, text=True, timeout=300,
+        )
+        return outf.read_text(encoding="utf-8") if outf.exists() else ""
+
+
+def main() -> None:
+    target = str(Path(sys.argv[1]).resolve())
+    kickoff = str(Path(sys.argv[2]).resolve())
+    budget = int(sys.argv[3]) if len(sys.argv) > 3 else 3
+
+    # --- force everything onto codex + point verifiers at the scratch target ---
+    home = Path(tempfile.mkdtemp(prefix="gepa-codex-home-"))
+    (home / "config").mkdir(parents=True)
+    (home / "config" / "agents.yaml").write_text(
+        "lanes: {planner: codex, worker: codex, implementer: codex, reviewer: codex, "
+        "worker_default: codex, reviewer_default: codex}\n")
+    os.environ.update({
+        "MINI_ORK_HOME": str(home),
+        "MINI_ORK_DB": str(ROOT / ".mini-ork" / "state.db"),   # migrated schema
+        "MO_REFLECTION_LANE": "codex", "MO_MUTATION_LANE": "codex",
+        "MINI_ORK_NONINTERACTIVE": "1",
+        "MINI_ORK_TEST_CMD": "python3 -m pytest -q",
+        "MINI_ORK_TYPECHECK_CMD": "true",                       # scratch has no typechecker
+    })
+
+    adapter = MiniOrkGEPAAdapter(
+        mini_ork_root=ROOT, recipe="code-fix",
+        state_db=ROOT / ".mini-ork" / "state.db", target_cwd=target, run_timeout_s=1200)
+    seed = {c: (ROOT / "recipes" / "code-fix" / "prompts" / f).read_text(encoding="utf-8")
+            for c, f in DEFAULT_COMPONENTS.items()
+            if (ROOT / "recipes" / "code-fix" / "prompts" / f).exists()}
+    trainset = [MiniOrkTask(kickoff=kickoff, recipe="code-fix", task_class="code_fix")]
+
+    print(f"GEPA(codex): target={target} budget={budget} components={list(seed)}", flush=True)
+    result = gepa.optimize(
+        seed_candidate=seed, trainset=trainset, adapter=adapter,
+        reflection_lm=codex_lm, max_metric_calls=budget, display_progress_bar=False,
+        raise_on_exception=False,
+    )
+    out = ROOT / "recipes" / "code-fix" / "prompts.gepa-codex-proposed"
+    out.mkdir(parents=True, exist_ok=True)
+    for c, text in (result.best_candidate or seed).items():
+        (out / DEFAULT_COMPONENTS[c]).write_text(text, encoding="utf-8")
+    print(f"\nbest score: {getattr(result, 'best_score', 'n/a')}")
+    print(f"winning prompts -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mini_ork/ported/mini_ork_epics.py
+++ b/mini_ork/ported/mini_ork_epics.py
@@ -230,10 +230,31 @@ def _priority(epic_id: str, value, db: str) -> int:
     return _priority(epic_id, None, db)
 
 
+def _ensure_priority_column(db):
+    """Idempotent epics.priority migration (bash bin/mini-ork-epics:40-48). bash runs
+    this on EVERY invocation so list/priority/scheduler queries never crash on an older
+    epics schema; the port skipped it and _list's `SELECT ... priority` crashed. Only
+    alters when the table exists but lacks the column. Best-effort."""
+    if not db or not os.path.isfile(db):
+        return
+    try:
+        con = sqlite3.connect(db)
+        try:
+            cols = {r[1] for r in con.execute("PRAGMA table_info(epics)").fetchall()}
+            if cols and "priority" not in cols:
+                con.execute("ALTER TABLE epics ADD COLUMN priority INTEGER NOT NULL DEFAULT 0")
+                con.commit()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        pass
+
+
 def main(argv: list[str] | None = None, *, db: str | None = None, root: str | None = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     root = root or os.environ.get("MINI_ORK_ROOT") or os.getcwd()
     db = _resolve_db(db)
+    _ensure_priority_column(db)
     sub = argv[0] if argv else "help"
     rest = argv[1:]
     if sub == "ingest":

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -675,6 +675,11 @@ def main(argv=None, *, root=None, dispatch_fn=None) -> int:
         workflow = os.path.join(root, "recipes", os.environ["MINI_ORK_RECIPE"], "workflow.yaml")
     run_dir = os.path.dirname(plan_path) if plan_path else "."
 
+    # Pre-dispatch execute gate (bash :1136-1203): refuse to dispatch a
+    # needs_answers plan (exit 6, records the block). Before node building.
+    if _execute_gate_check(plan_path, run_dir, dry_run):
+        return 6
+
     # NODE_IDS: workflow.yaml source wins; else plan.json.decomposition.
     if workflow and os.path.isfile(workflow):
         node_source = "workflow.yaml"
@@ -1195,6 +1200,67 @@ def _envsubst(s):
     ${VAR}-in-path files, the OSS-leak-garbage class the bash guard prevents)."""
     return re.sub(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)',
                   lambda m: os.environ.get(m.group(1) or m.group(2), ''), s)
+
+
+def _execute_gate_check(plan_path, run_dir, dry_run):
+    """Port of bash execute pre-dispatch gate (:1142-1203). A plan with
+    plan_status=needs_answers AND real human_questions must NOT dispatch: print the
+    refusal, write blocked.json, mark the run failed/BLOCKED, emit an execute_blocked
+    run_event, and signal exit 6. Returns True when blocked. Opt out via
+    MINI_ORK_EXECUTE_GATE=0; skipped under dry-run."""
+    if os.environ.get("MINI_ORK_EXECUTE_GATE", "1") != "1" or dry_run:
+        return False
+    try:
+        p = json.load(open(plan_path))
+    except Exception:
+        return False
+    status = p.get("plan_status") or ""
+    questions = p.get("human_questions") or []
+    # A needs_answers plan with ZERO questions is a contradiction — do not block.
+    if status != "needs_answers" or not questions:
+        return False
+    gate_info = {"plan_status": status, "blocked_by": p.get("blocked_by") or "unknown",
+                 "human_questions": questions}
+    print("[blocked] plan_status=needs_answers — refusing to dispatch "
+          "(MINI_ORK_EXECUTE_GATE=0 to override)")
+    print(f"  blocked_by: {gate_info['blocked_by']}")
+    for q in questions:
+        print(f"  question: {q}")
+    try:
+        with open(os.path.join(run_dir, "blocked.json"), "w") as f:
+            f.write(json.dumps(gate_info) + "\n")
+    except OSError:
+        pass
+    # Resolve db with the same MINI_ORK_HOME/state.db fallback bash uses (:958) —
+    # callers set MINI_ORK_HOME but not always MINI_ORK_DB.
+    home = os.environ.get("MINI_ORK_HOME") or os.path.join(os.getcwd(), ".mini-ork")
+    db = os.environ.get("MINI_ORK_DB") or os.path.join(home, "state.db")
+    run_id = (os.environ.get("MINI_ORK_RUN_ID") or os.environ.get("MINI_ORK_TASK_RUN_ID")
+              or os.path.basename(run_dir))
+    if db and os.path.isfile(db) and run_id:
+        try:
+            now = int(time.time())
+            con = sqlite3.connect(db, timeout=5.0)
+            con.execute("PRAGMA busy_timeout = 5000")
+            try:
+                con.execute(
+                    "UPDATE task_runs SET status='failed', verdict=COALESCE(verdict,'BLOCKED'), "
+                    "updated_at=?, ended_at=COALESCE(ended_at,?), "
+                    "notes=COALESCE(notes || '; ','') || "
+                    "'execute gate: plan_status=needs_answers — nothing dispatched' "
+                    "WHERE id=? AND status NOT IN ('published','rolled_back','failed')",
+                    (now, now, run_id))
+                con.execute(
+                    "INSERT INTO run_events(event_id, run_id, event_type, payload_json, created_at) "
+                    "VALUES (?,?,?,?,?)",
+                    (f"evt-execute_blocked-{now}", run_id, "execute_blocked",
+                     json.dumps(gate_info), now))
+                con.commit()
+            finally:
+                con.close()
+        except sqlite3.Error:
+            pass
+    return True
 
 
 def _make_trace_fn(task_class, db, run_id):

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -646,6 +646,30 @@ def main(argv=None, *, root=None, dispatch_fn=None) -> int:
             else:
                 sys.stderr.write(f"Unexpected argument: {a}\n"); return 2
 
+    # Resolve plan path (bash :957-973): empty → newest plan.json in $MINI_ORK_HOME/runs,
+    # then REQUIRE it. A missing or nonexistent plan must exit 2 with a message, not a
+    # Python traceback (nodes_from_plan would open('') / a bad path). bash requires a
+    # plan even in workflow mode (it's used for run_dir / task_run_id / plan_content).
+    home = os.environ.get("MINI_ORK_HOME") or os.path.join(os.getcwd(), ".mini-ork")
+    if not plan_path:
+        newest, newest_mtime = "", -1.0
+        for dirpath, _dirs, files in os.walk(os.path.join(home, "runs")):
+            if "plan.json" in files:
+                p = os.path.join(dirpath, "plan.json")
+                try:
+                    m = os.path.getmtime(p)
+                except OSError:
+                    continue
+                if m > newest_mtime:
+                    newest, newest_mtime = p, m
+        plan_path = newest
+    if not plan_path:
+        sys.stderr.write("No plan.json found. Run: mini-ork plan <kickoff.md>\n")
+        return 2
+    if not os.path.isfile(plan_path):
+        sys.stderr.write(f"plan not found: {plan_path}\n")
+        return 2
+
     workflow = os.environ.get("MINI_ORK_WORKFLOW", "")
     if not workflow and os.environ.get("MINI_ORK_RECIPE"):
         workflow = os.path.join(root, "recipes", os.environ["MINI_ORK_RECIPE"], "workflow.yaml")

--- a/mini_ork/ported/mini_ork_lifetime.py
+++ b/mini_ork/ported/mini_ork_lifetime.py
@@ -423,7 +423,19 @@ def main(argv: list[str] | None = None) -> int:
     sub = argv[0] if argv else "summary"
     rest = argv[1:]
     if sub == "show":
-        out = show(*rest)
+        # Parse `show <recipe> [--task-class X]` — the flag must not be splatted as a
+        # positional arg (bash treats --task-class as a named filter, not a 2nd recipe).
+        recipe = ""
+        task_class = None
+        i = 0
+        while i < len(rest):
+            if rest[i] == "--task-class" and i + 1 < len(rest):
+                task_class = rest[i + 1]; i += 2
+            else:
+                if not recipe:
+                    recipe = rest[i]
+                i += 1
+        out = show(recipe, task_class)
         sys.stdout.write(out)
         return 0
     if sub == "conductor-history":

--- a/mini_ork/ported/mini_ork_self_improve.py
+++ b/mini_ork/ported/mini_ork_self_improve.py
@@ -297,7 +297,20 @@ def main(argv=None, *, root=None, dispatch=None) -> int:
             it = 0
 
     # Outer loop
+    kill_flag = os.path.join(home, "state", ".self-improve-kill")
     while True:
+        # Fix C (bash bin/mini-ork-self-improve:397-406): poll the UI kill-flag at each
+        # iteration boundary — the /kill endpoint touches it; halt the outer loop and
+        # CONSUME the flag. The port skipped this, so the runner ran through the kill.
+        if os.path.isfile(kill_flag):
+            print("==============================================================")
+            print(f"[kill-flag] {kill_flag} present — UI requested outer-loop halt")
+            print("==============================================================")
+            try:
+                os.remove(kill_flag)
+            except OSError:
+                pass
+            break
         now = int(time.time())
         if now >= hard_deadline:
             print(f"[hard-cap] reached after {seconds_to_hms(now - start)}")

--- a/mini_ork/ported/mini_ork_spawn.py
+++ b/mini_ork/ported/mini_ork_spawn.py
@@ -361,9 +361,15 @@ def spawn(
         "MINI_ORK_PARENT_RUN_ID": parent_run,
         "MINI_ORK_ALLOW_CHILD_SPAWN": str(allow_flag),
     }
-    cli_target = recipe if recipe else paths["child_kickoff"]
     cli = os.path.join(resolved_root, "bin", "mini-ork")
-    cli_argv = [cli, "run", cli_target] if recipe else [cli, "run", cli_target]
+    # bash bin/mini-ork-spawn:110-129 — WITH a recipe: `run <recipe> <kickoff>`;
+    # WITHOUT: `run <kickoff>`. The kickoff arg is mandatory in both; dropping it
+    # (the old `run <recipe>` with no kickoff) left the child run with nothing to
+    # plan → it failed and never wrote plan.json.
+    if recipe:
+        cli_argv = [cli, "run", recipe, paths["child_kickoff"]]
+    else:
+        cli_argv = [cli, "run", paths["child_kickoff"]]
     proc = subprocess.run(cli_argv, cwd=paths["child_workspace"], env=child_env,
                           capture_output=True, text=True)
     child_exit = proc.returncode


### PR DESCRIPTION
**The default-runtime flip is NOT ready — held.** Attempting it exposed, via CI, real divergences in ported flows the 4 confirm-panels never examined (spawn, recursive orchestration, run lifecycle, execute no-plan exit codes, telemetry gates: bash e2e/integration went red). Only the execute *dispatch engine* is deeply verified. So this PR keeps the default **bash** and lands only the two genuine bugs the attempt surfaced:

1. **Shim exec-on-source guard** — `mo_runtime_maybe_delegate` only delegates when the entrypoint is EXECUTED, not SOURCED (bash tests `source bin/mini-ork-*`; the exec was hijacking the source under python runtime).
2. **lifetime.show** — parse `--task-class` as a flag, not a positional (TypeError under python runtime).

Both are latent correctness fixes for when `MINI_ORK_RUNTIME=python` is used. Default-bash behavior is unchanged.