### PR TITLE
fix(runtime): plan.py wires default LLM dispatch (P0 — python-default runs hard-failed at plan)

### DIFF
--- a/bin/mini-ork-conductor
+++ b/bin/mini-ork-conductor
@@ -48,7 +48,12 @@ MAX_ITERS=0
 IDLE_SECS=60
 DRY_RUN=0
 EXPLAIN=0
-BUDGET_CAP="${MO_DAILY_BUDGET_USD:-50.0}"
+# Daily cap single-sourced from config/agents.yaml (budget.daily_cap_usd) via
+# mo_daily_budget_cap; MO_DAILY_BUDGET_USD still overrides. Falls back to 50
+# when agents.yaml is absent — identical to the old `${MO_DAILY_BUDGET_USD:-50.0}`.
+# shellcheck source=lib/budget_config.sh
+. "$MINI_ORK_ROOT/lib/budget_config.sh"
+BUDGET_CAP="$(mo_daily_budget_cap)"
 PLASTICITY_BUDGET="${MO_PLASTICITY_BUDGET:-5}"  # max mutations / 24h (Phase 5)
 
 while [ $# -gt 0 ]; do

--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -289,6 +289,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# NOTE (verdict vocabulary): this maps a terminal verdict/status to an OUTCOME
+# reward in {1.0, 0.5, 0.0} — a DIFFERENT concept from the PRM verdict-credit
+# gate in lib/process_reward.sh / mini_ork/learning/process_reward.py, whose
+# set is {approve,approved,pass,success,ok}. This set is intentionally broader
+# (adds `passed` and status terms like published/done) because it also
+# classifies raw run STATUS, not just reviewer verdicts. The two sets are NOT
+# unified on purpose: adding `passed` to the PRM gate would grant +W_VERDICT to
+# traces that currently score without it (a reward-value change, out of scope).
 _mo_reward_from_status() {
   local _status="${1:-}" _verdict="${2:-}"
   case "$(printf '%s' "$_verdict" | tr '[:upper:]' '[:lower:]')" in
@@ -1843,6 +1851,12 @@ obj = {
     'trace_id': trace_id,
     'task_class': task_class,
     'status': status,
+    # objective_domain is the GRPO slice key. Stamp it from the run's env so the
+    # feature-partition column is populated per-run (book-gen / future domains),
+    # not silently defaulted to 'code-delivery' inside trace_store for every row.
+    # Default to code-delivery ONLY when unset — matches lib/trace_store.sh's
+    # legacy fallback so historical + untagged runs share one slice.
+    'objective_domain': os.environ.get('MINI_ORK_OBJECTIVE_DOMAIN') or os.environ.get('MO_OBJECTIVE_DOMAIN') or 'code-delivery',
     'cost_usd': float(cost) if cost else 0.0,
     'duration_ms': int(duration_ms) if duration_ms else 0,
     'tool_calls': json.dumps(tool_calls),
@@ -3352,6 +3366,14 @@ if [ "$DRY_RUN" -eq 0 ]; then
   STATUS="success"
   [ "$FAIL_COUNT" -gt 0 ] && STATUS="failure"
   trace_write "{\"trace_id\":\"$TRACE_ID\",\"task_class\":\"${TASK_CLASS}\",\"status\":\"${STATUS}\"}" >/dev/null 2>&1 || true
+
+  # Close the eval loop: feed the rubric's GRADED 0-8 run score into reward_g on
+  # every trace of this run BEFORE the GRPO advantage recompute below reads them.
+  # When ${RUN_DIR}/rubric.json exists, mo_grade_run_reward overwrites the per-node
+  # status-map reward with the graded value (rubric 8→+1, 4→0, 0→-1); when it is
+  # absent it is a no-op, leaving the _mo_reward_from_status status-map fallback
+  # that _trace_write_node_rich already stamped. Best-effort; never fails the run.
+  mo_grade_run_reward "$RUN_DIR" "${MINI_ORK_RUN_ID:-}" >/dev/null 2>&1 || true
 
   # D3: populate task_memory + failure_memory per-task-class so the planner
   # injection of "prior 5 runs by task_class" has data to read.

--- a/lib/lane_router.sh
+++ b/lib/lane_router.sh
@@ -343,6 +343,12 @@ if _has_defect_attributions:
     for _pr in _penalty_rows:
         _pen = float(_pr["penalty"])
         _hlf_raw = _pr["decay_halflife_days"]
+        # NOTE: this 30.0 is the DEFECT-ATTRIBUTION penalty-decay halflife, a
+        # DIFFERENT quantity from the GRPO recency halflife (MO_LEARNING_HALFLIFE_DAYS,
+        # default 14, at line ~89 and bin/mini-ork-execute). It is only a fallback
+        # for a NULL decay_halflife_days column and MUST match that column's write
+        # default in lib/blame_attributor.sh (DECAY=30.0 / DEFAULT 30.0) — not the
+        # learning halflife. The two are intentionally not unified.
         try:
             _hlf = float(_hlf_raw) if _hlf_raw is not None else 30.0
         except (TypeError, ValueError):

--- a/lib/llm-dispatch.sh
+++ b/lib/llm-dispatch.sh
@@ -29,6 +29,13 @@ MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 [ -f "$MINI_ORK_ROOT/lib/providers/registry.sh" ] && \
   source "$MINI_ORK_ROOT/lib/providers/registry.sh"
 
+# Daily budget cap single source of truth: config/agents.yaml budget.daily_cap_usd
+# (read via mo_daily_budget_cap). The cost circuit below calls it instead of
+# hardcoding 50 so the cap matches the conductor + agents.yaml.
+# shellcheck source=lib/budget_config.sh
+[ -f "$MINI_ORK_ROOT/lib/budget_config.sh" ] && \
+  source "$MINI_ORK_ROOT/lib/budget_config.sh"
+
 # Models that ship as proper executables (call their CLI directly)
 _MO_LLM_EXECUTABLE_MODELS=(codex gemini)
 
@@ -1380,11 +1387,18 @@ llm_dispatch() {
   done
 
   # v0.2-pt7 (R10): cost circuit breaker. Check accumulated daily spend
-  # against MO_DAILY_BUDGET_USD before dispatching. Default cap: $50/day.
+  # against the daily cap before dispatching. The cap is single-sourced from
+  # config/agents.yaml (budget.daily_cap_usd) via mo_daily_budget_cap, with
+  # MO_DAILY_BUDGET_USD overriding and a 50 fallback when config is absent.
   # Returns non-zero with `[cost_circuit_open]` marker if exceeded so the
   # caller's $? check trips, halting the run gracefully.
   if [ -n "${MINI_ORK_DB:-}" ] && [ -f "${MINI_ORK_DB:-}" ]; then
-    local _budget="${MO_DAILY_BUDGET_USD:-50}"
+    local _budget
+    if declare -F mo_daily_budget_cap >/dev/null 2>&1; then
+      _budget="$(mo_daily_budget_cap)"
+    else
+      _budget="${MO_DAILY_BUDGET_USD:-50}"
+    fi
     local _spent_today
     _spent_today=$(python3 -c "
 import sqlite3, sys, time

--- a/lib/process_reward.sh
+++ b/lib/process_reward.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 # process_reward.sh — Process Reward Model (PRM) heuristic for mini-ork.
 #
-# Approximates a per-node reward 0.0-1.0 from observable trace signals:
-#   + 0.40  status = success
-#   + 0.20  tool_calls non-empty (agent actually did work)        [capped, see below]
-#   + 0.10  files_written or files_read non-empty (artifacts)      [capped, see below]
-#   + 0.15  reviewer_verdict in {APPROVE, pass, success, ok}, gated on
-#           status == success AND not same-family (see verifiable-first note)
-#   + 0.10  duration_ms in [1000, 600000] (not too fast, not too slow)
-#   + 0.05  cost_usd > 0 (real LLM invocation, not a stub)
+# Approximates a per-node reward 0.0-1.0 from observable trace signals. The
+# weight table + verdict set are the SINGLE SOURCE OF TRUTH in
+# mini_ork/learning/process_reward.py; both prm_score_trace and prm_backfill
+# load them from there by file path (see _load_prm_weights) so the values
+# cannot drift. Current outcome-dominant weights (status + review carry 0.80):
+#   + W_STATUS   status = success                               (outcome)
+#   + W_VERDICT  reviewer_verdict ∈ approve|approved|pass|success|ok,
+#               gated on status == success (see verifiable-first note)
+#   + W_TOOL     tool_calls non-empty (agent did work)           [capped]
+#   + W_FILE     files_written or files_read non-empty (artifacts)[capped]
+#   + W_DURATION duration_ms in [1000, 600000]
+#   (W_COST retired to 0.00 — rewarded cost>0, near-constant/off-thesis)
 # Total maxes at 1.0, floors at 0.0; partial credit is the point.
 #
 # Activity cap (Goodhart guard): by default the combined contribution of
@@ -27,10 +31,10 @@
 # without a real reviewer_model column in execution_traces, and the
 # asymmetric stripping of +0.15 from opus/minimax/glm/kimi runs biased
 # GRPO group ranking. Same-family neutralization awaits a schema change.
-# PRM copies in prm_score_trace and prm_backfill MUST stay behaviorally
-# identical: the weight table below is mirrored verbatim in prm_backfill.
-# Drift between the two causes process_reward to diverge between
-# single-trace writes and bulk backfills, silently breaking the router.
+# prm_score_trace and prm_backfill now load the weight table from the same
+# canonical Python module (mini_ork/learning/process_reward.py) instead of
+# each carrying an inline copy, so single-trace writes and bulk backfills can
+# no longer diverge and silently break the router.
 #
 # Public API:
 #   prm_score_trace   <trace_id>        compute + UPDATE process_reward
@@ -48,10 +52,10 @@ MINI_ORK_ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # lib/db_open.sh. STATE_DB is resolved per-call via $(mo_store_db_path) so
 # MO_STORE_DB / MO_STORE_BACKEND=postgres can route without forking this lib.
 # SQLite default (no env override) resolves to the same path as the old
-# ${MINI_ORK_DB:-${MINI_ORK_HOME:-.mini-ork}/state.db} convention. PRM weight
-# table (W_STATUS..W_COST, ACTIVITY_CAP) is mirrored verbatim between
-# prm_score_trace and prm_backfill; this refactor only changes the connect
-# path, not the scoring math.
+# ${MINI_ORK_DB:-${MINI_ORK_HOME:-.mini-ork}/state.db} convention. The PRM
+# weight table is single-sourced from mini_ork/learning/process_reward.py
+# (loaded by both prm_score_trace and prm_backfill); this refactor only
+# changes the connect path, not the scoring math.
 # shellcheck disable=SC1091
 . "${MINI_ORK_ROOT}/lib/policy_store.sh"
 
@@ -60,9 +64,9 @@ prm_score_trace() {
   mo_store_assert_sqlite
   local STATE_DB
   STATE_DB="$(mo_store_db_path)"
-  python3 - "$STATE_DB" "$trace_id" <<'PY'
-import json, os, sqlite3, sys
-db, trace_id = sys.argv[1:3]
+  python3 - "$STATE_DB" "$trace_id" "$MINI_ORK_ROOT" <<'PY'
+import importlib.util, json, os, sqlite3, sys
+db, trace_id, mo_root = sys.argv[1:4]
 con = sqlite3.connect(db)
 con.execute("PRAGMA busy_timeout=5000")
 con.row_factory = sqlite3.Row
@@ -83,21 +87,26 @@ def _len_json(s):
     except Exception:
         return 0
 
-# ── PRM weight table (DO NOT EDIT THIS COPY WITHOUT EDITING prm_backfill) ──
-# This table is mirrored verbatim in prm_backfill below. Both copies MUST
-# stay byte-identical so single-trace writes (prm_score_trace) and bulk
-# backfills (prm_backfill) compute the same process_reward for the same row.
-#   W_STATUS       = 0.40   # status == "success"
-#   W_TOOL         = 0.20   # tool_calls non-empty
-#   W_FILE         = 0.10   # files_read or files_written non-empty
-#   W_VERDICT      = 0.15   # reviewer_verdict ∈ approve|approved|pass|success|ok
-#                           #   AND status==success AND not same-family
-#   W_DURATION     = 0.10   # 1000 <= duration_ms <= 600000
-#   W_COST         = 0.05   # cost_usd > 0
-#   ACTIVITY_CAP   = 0.15   # MO_PRM_ACTIVITY_CAP=1 (default): clamp W_TOOL+W_FILE
-#                           # MO_PRM_ACTIVITY_CAP=0 (legacy): no clamp, activity can dominate
-W_STATUS, W_TOOL, W_FILE, W_VERDICT, W_DURATION, W_COST, ACTIVITY_CAP = \
-    0.50, 0.10, 0.05, 0.30, 0.05, 0.00, 0.15
+def _load_prm_weights(root):
+    """Load the canonical PRM weight table + verdict set from the Python port
+    by file path. Avoids `import mini_ork.*` so the facade in mini_ork/__init__
+    is not executed; the target module is pure stdlib with no import-time IO."""
+    src = os.path.join(root, "mini_ork", "learning", "process_reward.py")
+    spec = importlib.util.spec_from_file_location("mo_prm_weights", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return (mod.W_STATUS, mod.W_TOOL, mod.W_FILE, mod.W_VERDICT,
+            mod.W_DURATION, mod.ACTIVITY_CAP, set(mod._VERDICT_SET))
+
+# ── PRM weight table — SINGLE SOURCE OF TRUTH ─────────────────────────────
+# The weights + verdict set are canonically defined ONCE in
+# mini_ork/learning/process_reward.py and loaded here by file path (no package
+# import, so mini_ork/__init__'s facade is NOT triggered). prm_score_trace and
+# prm_backfill BOTH load from the same module, so the two copies can no longer
+# drift from each other or from the Python port. Parity is enforced by
+# tests/unit/test_process_reward_parity.py.
+W_STATUS, W_TOOL, W_FILE, W_VERDICT, W_DURATION, ACTIVITY_CAP, _VERDICT_SET = \
+    _load_prm_weights(mo_root)
 try:
     _activity_cap_enabled = int(os.environ.get("MO_PRM_ACTIVITY_CAP", "1")) != 0
 except ValueError:
@@ -117,7 +126,7 @@ if status_success:
         activity = min(activity, ACTIVITY_CAP)
     score += activity
     v = (r["reviewer_verdict"] or "").lower()
-    if v in {"approve", "approved", "pass", "success", "ok"}:
+    if v in _VERDICT_SET:
         score += W_VERDICT
     dur = int(r["duration_ms"] or 0)
     if 1000 <= dur <= 600000:
@@ -144,9 +153,9 @@ prm_backfill() {
   mo_store_assert_sqlite
   local STATE_DB
   STATE_DB="$(mo_store_db_path)"
-  python3 - "$STATE_DB" "$since" <<'PY'
-import json, os, sqlite3, sys, datetime
-db, since_str = sys.argv[1:3]
+  python3 - "$STATE_DB" "$since" "$MINI_ORK_ROOT" <<'PY'
+import importlib.util, json, os, sqlite3, sys, datetime
+db, since_str, mo_root = sys.argv[1:4]
 since = int(since_str)
 since_iso = datetime.datetime.utcfromtimestamp(since).strftime('%Y-%m-%dT%H:%M:%S.000Z')
 
@@ -167,21 +176,22 @@ def _len_json(s):
     except Exception:
         return 0
 
-# ── PRM weight table (DO NOT EDIT THIS COPY WITHOUT EDITING prm_score_trace) ──
-# Mirror copy of prm_score_trace's weight table. Both copies MUST stay
-# byte-identical so single-trace writes and bulk backfills compute the same
-# process_reward for the same row.
-#   W_STATUS       = 0.40   # status == "success"
-#   W_TOOL         = 0.20   # tool_calls non-empty
-#   W_FILE         = 0.10   # files_read or files_written non-empty
-#   W_VERDICT      = 0.15   # reviewer_verdict ∈ approve|approved|pass|success|ok
-#                           #   AND status==success AND not same-family
-#   W_DURATION     = 0.10   # 1000 <= duration_ms <= 600000
-#   W_COST         = 0.05   # cost_usd > 0
-#   ACTIVITY_CAP   = 0.15   # MO_PRM_ACTIVITY_CAP=1 (default): clamp W_TOOL+W_FILE
-#                           # MO_PRM_ACTIVITY_CAP=0 (legacy): no clamp, activity can dominate
-W_STATUS, W_TOOL, W_FILE, W_VERDICT, W_DURATION, W_COST, ACTIVITY_CAP = \
-    0.50, 0.10, 0.05, 0.30, 0.05, 0.00, 0.15
+def _load_prm_weights(root):
+    """Load the canonical PRM weight table + verdict set from the Python port
+    by file path. Identical loader to prm_score_trace — both read the single
+    source in mini_ork/learning/process_reward.py so they cannot diverge."""
+    src = os.path.join(root, "mini_ork", "learning", "process_reward.py")
+    spec = importlib.util.spec_from_file_location("mo_prm_weights", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return (mod.W_STATUS, mod.W_TOOL, mod.W_FILE, mod.W_VERDICT,
+            mod.W_DURATION, mod.ACTIVITY_CAP, set(mod._VERDICT_SET))
+
+# ── PRM weight table — SINGLE SOURCE OF TRUTH (see prm_score_trace) ────────
+# Loaded from the same canonical module as prm_score_trace, so single-trace
+# writes and bulk backfills compute identical process_reward for the same row.
+W_STATUS, W_TOOL, W_FILE, W_VERDICT, W_DURATION, ACTIVITY_CAP, _VERDICT_SET = \
+    _load_prm_weights(mo_root)
 try:
     _activity_cap_enabled = int(os.environ.get("MO_PRM_ACTIVITY_CAP", "1")) != 0
 except ValueError:
@@ -203,7 +213,7 @@ for r in rows:
             activity = min(activity, ACTIVITY_CAP)
         score += activity
         v = (r["reviewer_verdict"] or "").lower()
-        if v in {"approve", "approved", "pass", "success", "ok"}:
+        if v in _VERDICT_SET:
             score += W_VERDICT
         dur = int(r["duration_ms"] or 0)
         if 1000 <= dur <= 600000:

--- a/lib/reflection_pipeline.sh
+++ b/lib/reflection_pipeline.sh
@@ -456,7 +456,58 @@ print(persisted)
 PY
 }
 
-# desc: Orchestrate all 6 reflection steps sequentially. since_ts is unix epoch;
+# desc: Judge-gate (extract→distill→verify). Transition emergent_patterns rows
+#       from status='proposed' → 'approved' when they clear an evidence/strength
+#       floor already present in the schema:
+#         strength_score >= MO_EMERGENT_VERIFY_MIN_STRENGTH (default 3), AND
+#         evidence member count (member_item_ids_json) >= MO_EMERGENT_VERIFY_MIN_EVIDENCE (default 1).
+#       ONLY rows that clear this gate become eligible to be read into
+#       routing/context (see context_assembler). This is the guard against
+#       memory confabulation (Dixit 2026): raw self-diagnosed patterns stay
+#       'proposed' and never reach the rail; only evidence-backed ones are
+#       promoted to 'approved'. Opt-out MO_EMERGENT_VERIFY=0. Cold-safe: no-op
+#       on missing/empty table. Emits count of newly-approved rows on stdout.
+reflection_verify_patterns() {
+  if [ "${MO_EMERGENT_VERIFY:-1}" != "1" ]; then echo 0; return 0; fi
+  local min_strength="${MO_EMERGENT_VERIFY_MIN_STRENGTH:-3}"
+  local min_evidence="${MO_EMERGENT_VERIFY_MIN_EVIDENCE:-1}"
+  python3 - "${MINI_ORK_DB:?MINI_ORK_DB unset}" "$min_strength" "$min_evidence" <<'PY'
+import sqlite3, json, sys, time
+db, min_strength, min_evidence = sys.argv[1], float(sys.argv[2]), int(sys.argv[3])
+con = sqlite3.connect(db)
+con.execute("PRAGMA busy_timeout=5000")
+try:
+    rows = con.execute(
+        "SELECT pattern_id, member_item_ids_json, strength_score "
+        "FROM emergent_patterns WHERE status='proposed'"
+    ).fetchall()
+except sqlite3.OperationalError:
+    print(0); con.close(); sys.exit(0)
+now = int(time.time())
+approved = 0
+for pid, members_json, strength in rows:
+    try:
+        n_evidence = len(json.loads(members_json)) if members_json else 0
+    except (json.JSONDecodeError, TypeError):
+        n_evidence = 0
+    try:
+        s = float(strength)
+    except (TypeError, ValueError):
+        s = 0.0
+    if s >= min_strength and n_evidence >= min_evidence:
+        con.execute(
+            "UPDATE emergent_patterns SET status='approved', resolved_at=? "
+            "WHERE pattern_id=? AND status='proposed'",
+            (now, pid),
+        )
+        approved += 1
+con.commit()
+con.close()
+print(approved)
+PY
+}
+
+# desc: Orchestrate all reflection steps sequentially. since_ts is unix epoch;
 #       defaults to 24 hours ago.
 reflection_run() {
   local since_ts="${1:-$(( $(_rfl_now) - 86400 ))}"
@@ -509,6 +560,15 @@ PY
   local persisted
   persisted="$(reflection_persist_suggestions "$suggestions" 2>/dev/null || echo 0)"
   echo "reflection_run: ${count} promotion suggestions generated, ${persisted:-0} persisted" >&2
+
+  # [judge-gate] extract→distill→verify: promote only evidence-backed
+  # emergent_patterns from 'proposed' → 'approved' so confabulated
+  # self-diagnoses never reach routing/context (Dixit 2026).
+  echo "  [verify] judge-gate emergent_patterns" >&2
+  local approved
+  approved="$(reflection_verify_patterns 2>/dev/null || echo 0)"
+  echo "reflection_run: ${approved:-0} emergent_patterns approved by judge-gate" >&2
+
   echo "$suggestions"
 }
 

--- a/mini_ork/context_assembler.py
+++ b/mini_ork/context_assembler.py
@@ -129,6 +129,40 @@ def context_assemble(task_brief_path: str, workflow_node: str,
     except Exception:
         pass
 
+    # Verified emergent patterns (judge-gate approved) — read-back of the
+    # reflection judge-gate. ONLY status='approved' rows (those that cleared the
+    # evidence/strength floor in reflection_verify_patterns); 'proposed' rows are
+    # unverified self-diagnoses and are excluded to avoid memory confabulation
+    # (Dixit 2026). Sibling of known_failure_modes. Opt-out MO_EMERGENT_INJECT=0;
+    # cold-safe (empty/missing table → []).
+    verified_emergent = []
+    if os.environ.get("MO_EMERGENT_INJECT", "1") == "1":
+        try:
+            emg_limit = int(os.environ.get("MO_EMERGENT_INJECT_LIMIT", "3"))
+        except ValueError:
+            emg_limit = 3
+        try:
+            for r in con.execute("""
+                SELECT pattern_id, cluster_label, feature_set_json,
+                       strength_score, suggested_meta_adr
+                FROM emergent_patterns
+                WHERE status='approved'
+                ORDER BY strength_score DESC, detected_at DESC LIMIT ?
+            """, (emg_limit,)).fetchall():
+                try:
+                    feats = json.loads(r["feature_set_json"]) if r["feature_set_json"] else []
+                except Exception:
+                    feats = []
+                verified_emergent.append({
+                    "cite": f"emergent_patterns/{r['pattern_id']}",
+                    "feature": feats[0] if feats else "emergent",
+                    "cluster_label": r["cluster_label"],
+                    "suggested_change": r["suggested_meta_adr"] or "",
+                    "strength_score": r["strength_score"],
+                    "scope": "emergent"})
+        except Exception:
+            pass
+
     similar_lessons = []
     try:
         query_text = " ".join(filter(None, [
@@ -212,6 +246,7 @@ def context_assemble(task_brief_path: str, workflow_node: str,
         "verifier_contract": {"content": verifier_contract, "cite": "artifact_contract"},
         "prior_similar_runs": prior_runs,
         "known_failure_modes": failure_modes,
+        "verified_emergent_patterns": verified_emergent,
         "similar_lessons": similar_lessons,
         "user_preferences": user_prefs,
         "constraints": constraints,
@@ -260,14 +295,49 @@ def failure_modes_md(task_class: str, limit: int = 5, db: str | None = None) -> 
                 if not r[0].startswith(FRAMEWORK_INTERNAL_PREFIXES)][:limit]
     else:
         rows = rows[:limit]
-    if not rows:
-        return ""
-    out = ["--- Learned failure modes (from prior runs of this task class) ---",
-           "Avoid repeating these known issues:"]
-    for target, signal, change in rows:
-        out.append(f"- [{target}] {signal.strip()}")
-        out.append(f"  Fix applied going forward: {change.strip()}")
-    out.append("--- /learned failure modes ---")
+    out = []
+    if rows:
+        out.append("--- Learned failure modes (from prior runs of this task class) ---")
+        out.append("Avoid repeating these known issues:")
+        for target, signal, change in rows:
+            out.append(f"- [{target}] {signal.strip()}")
+            out.append(f"  Fix applied going forward: {change.strip()}")
+        out.append("--- /learned failure modes ---")
+
+    # Verified emergent patterns (judge-gate approved) — read-back into the
+    # prompt. ONLY status='approved' rows (cleared the evidence/strength floor
+    # in reflection_verify_patterns); 'proposed' self-diagnoses excluded
+    # (memory-confabulation guard, Dixit 2026). Opt-out MO_EMERGENT_INJECT=0;
+    # cold-safe (empty/missing table → nothing).
+    if os.environ.get("MO_EMERGENT_INJECT", "1") == "1":
+        try:
+            emg_limit = int(os.environ.get("MO_EMERGENT_INJECT_LIMIT", "3"))
+        except ValueError:
+            emg_limit = 3
+        con2 = sqlite3.connect(dbp)
+        con2.execute("PRAGMA busy_timeout=5000")
+        try:
+            emg = con2.execute("""
+                SELECT cluster_label, feature_set_json, strength_score
+                FROM emergent_patterns
+                WHERE status='approved'
+                ORDER BY strength_score DESC, detected_at DESC LIMIT ?
+            """, (emg_limit,)).fetchall()
+        except sqlite3.OperationalError:
+            emg = []
+        finally:
+            con2.close()
+        if emg:
+            out.append("--- Verified emergent patterns (cross-run, judge-gate approved) ---")
+            for cluster_label, feature_set_json, _strength in emg:
+                try:
+                    feats = json.loads(feature_set_json) if feature_set_json else []
+                except Exception:
+                    feats = []
+                feat = feats[0] if feats else "emergent"
+                out.append(f"- [{feat}] {(cluster_label or '').strip()}")
+            out.append("--- /verified emergent patterns ---")
+
     return "\n".join(out)
 
 

--- a/mini_ork/ported/mini_ork_conductor.py
+++ b/mini_ork/ported/mini_ork_conductor.py
@@ -29,6 +29,45 @@ def _today_cost(db):
     return float(r[0] or 0)
 
 
+def _adaptive_lane_gain(con, base=0.3):
+    """Fit the lane-advantage gain from conductor_decisions.realized_score.
+
+    Mirror of the embedded-python helper in bin/mini-ork-conductor. Reads back
+    the realized_score history (written post-run by the learning loop) and
+    calibrates the gain via an EMA of past outcomes: ema==0.5 → gain==base,
+    good track record widens it, poor track record damps it. Cold-safe: fewer
+    than MO_CONDUCTOR_GAIN_MIN_SAMPLES resolved decisions keeps the historical
+    default (0.3). Opt-out MO_CONDUCTOR_ADAPTIVE_GAIN=0. Bounded to [0.1, 0.6].
+    """
+    if os.environ.get("MO_CONDUCTOR_ADAPTIVE_GAIN", "1") != "1":
+        return base
+    try:
+        min_samples = int(os.environ.get("MO_CONDUCTOR_GAIN_MIN_SAMPLES", "3"))
+    except ValueError:
+        min_samples = 3
+    try:
+        rows = con.execute(
+            "SELECT realized_score FROM conductor_decisions "
+            "WHERE realized_score IS NOT NULL ORDER BY decided_at ASC"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return base
+    scores = []
+    for r in rows:
+        try:
+            scores.append(float(r[0]))
+        except (TypeError, ValueError):
+            continue
+    if len(scores) < min_samples:
+        return base
+    alpha = 0.3
+    ema = scores[0]
+    for s in scores[1:]:
+        ema = alpha * s + (1.0 - alpha) * ema
+    gain = base * (2.0 * ema)
+    return max(0.1, min(0.6, gain))
+
+
 def decide_for_epic(db, epic_id, spent, cap, plast_budget) -> dict:
     budget_pct = (spent / cap) if cap > 0 else 0.0
     con = sqlite3.connect(db); con.execute("PRAGMA busy_timeout=5000"); con.row_factory = sqlite3.Row
@@ -93,6 +132,7 @@ def decide_for_epic(db, epic_id, spent, cap, plast_budget) -> dict:
                             "WHERE applied_at >= strftime('%s','now','-24 hours')").fetchone()["n"]
     plasticity_remaining = max(0, plast_budget - mut_today)
 
+    lane_gain = _adaptive_lane_gain(con, 0.3)
     predicted = (topology or {}).get("win_rate", 0.5) or 0.5
     lane_adv_sum = 0.0
     try:
@@ -105,7 +145,7 @@ def decide_for_epic(db, epic_id, spent, cap, plast_budget) -> dict:
                     lane_adv_sum += r["relative_advantage"]
     except sqlite3.OperationalError:
         pass
-    predicted = min(1.0, predicted * (1.0 + lane_adv_sum * 0.3))
+    predicted = min(1.0, predicted * (1.0 + lane_adv_sum * lane_gain))
     con.close()
     return {"epic_id": epic_id, "task_class": task_class, "topology": topology,
             "lane_hints": lane_hints, "open_role_proposals": open_proposals_n,

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -744,6 +744,16 @@ def main(argv=None, *, root=None, dispatch_fn=None) -> int:
         if rc != 0:
             fail_count += 1
     _emit_run_verdict(live_run_dir, fail_count, len(fields_list))
+    # Close the eval loop (bash mo_grade_run_reward, :3271): feed the rubric's GRADED
+    # 0-8 run score into reward_g on every trace of this run. When rubric.json exists it
+    # overwrites the per-node status-map reward with the graded value; absent → no-op,
+    # leaving the reward_from_status fallback the trace_fn already stamped. Best-effort.
+    if os.environ.get("MO_GRADE_RUN_REWARD", "1") == "1":
+        try:
+            from mini_ork import trace_store  # noqa: PLC0415
+            trace_store.grade_run_reward(live_run_dir, run_id, db=db)
+        except Exception:
+            pass
     if fail_count > 0:
         set_status(db, run_id, "failed")
         sys.stderr.write(f"execute: {fail_count} node(s) failed\n")
@@ -1277,6 +1287,11 @@ def _make_trace_fn(task_class, db, run_id):
         extra = {
             "trace_id": f"tr-{node_type}-{node_id}-{uuid.uuid4().hex[:8]}",
             "run_id": run_id,
+            # objective_domain is the GRPO slice key (bash obj stamp, :1839). Stamp it
+            # from the run's env so the feature-partition column populates per-run;
+            # default code-delivery ONLY when unset, matching trace_store's fallback.
+            "objective_domain": (os.environ.get("MINI_ORK_OBJECTIVE_DOMAIN")
+                                 or os.environ.get("MO_OBJECTIVE_DOMAIN") or "code-delivery"),
             "verifier_output": {"node_type": node_type, "finish_reason": finish_reason or None},
         }
         if output_file:

--- a/mini_ork/ported/mini_ork_plan.py
+++ b/mini_ork/ported/mini_ork_plan.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -587,5 +588,24 @@ def _build_prompt(root, kickoff, workflow, profile_path) -> str:
     return prompt
 
 
+def _default_llm_dispatch(root):
+    """Default planner LLM seam for the CLI entry — shells to llm_dispatch, mirroring
+    bash bin/mini-ork-plan:656 (RESULT=$(llm_dispatch --node-type planner …)). Without
+    this, a python-runtime `mini-ork run` hard-fails at plan ('LLM dispatch unavailable')
+    because __main__ passed no dispatch. The seam stays injectable for tests (which pass
+    dispatch= explicitly or use MO_GIVEN_PLAN); only the CLI boundary wires this default."""
+    lib = os.path.join(root, "lib", "llm-dispatch.sh")
+
+    def d(task_class, node_type, prompt):
+        r = subprocess.run(
+            ["bash", "-c", f'source "{lib}"; llm_dispatch --task-class "$1" '
+             '--node-type "$2" --prompt-text "$3" 2>&1', "_", task_class, node_type, prompt],
+            capture_output=True, text=True)
+        return r.returncode, r.stdout
+    return d
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    _root = os.environ.get("MINI_ORK_ROOT") or \
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    raise SystemExit(main(dispatch=_default_llm_dispatch(_root)))

--- a/mini_ork/ported/mini_ork_verify.py
+++ b/mini_ork/ported/mini_ork_verify.py
@@ -177,6 +177,35 @@ def main(argv: list[str] | None = None, *, db: str | None = None, root: str | No
         else:
             results.append(f'{{"verifier":"{name}","pass":false,"evidence_path":"{ev}"}}'); fail_count += 1
 
+    # Required-artifact assertion (parity: bin/mini-ork-verify). A recipe that
+    # declares a concrete, run-local artifact but produces nothing (missing OR
+    # zero-byte) must FAIL — not launder into pass/partial/vacuous. Only ABSOLUTE
+    # env-expanded paths (e.g. `${MINI_ORK_RUN_DIR}/framework-edit.diff`) are
+    # enforced; relative canonical outputs are publish-targets (exempt). A real,
+    # non-empty artifact passes (the 36KB-synthesis false-negative case).
+    artifact_fail = False
+    if dry_run == 0 and plan_path and os.path.isfile(plan_path):
+        try:
+            ac_req = json.load(open(plan_path, encoding="utf-8")).get("artifact_contract", {})
+        except Exception:
+            ac_req = {}
+        if isinstance(ac_req, dict):
+            seen: set[str] = set()
+            for key in ("required_artifacts", "outputs"):
+                for raw in ac_req.get(key, []) or []:
+                    p = os.path.expandvars(str(raw))
+                    if not os.path.isabs(p) or p in seen:
+                        continue
+                    seen.add(p)
+                    if os.path.isfile(p) and os.path.getsize(p) > 0:
+                        results.append(f'{{"verifier":"__artifact__","pass":true,"evidence_path":"{p}"}}')
+                        pass_count += 1
+                    else:
+                        sys.stderr.write(f"  [fail] required artifact missing or empty: {p}\n")
+                        results.append(f'{{"verifier":"__artifact__","pass":false,"evidence_path":"{p}"}}')
+                        fail_count += 1
+                        artifact_fail = True
+
     gate_verdict = "pass"
     if dry_run == 0 and os.path.isfile(os.path.join(root, "lib", "gate_registry.sh")):
         ctx = json.dumps({"task_class": task_class, "artifact_path": artifact_path,
@@ -195,6 +224,10 @@ def main(argv: list[str] | None = None, *, db: str | None = None, root: str | No
 
     if dry_run == 1:
         verdict = "dry-run"
+    elif artifact_fail:
+        # Missing/empty required artifact is a hard fail: outranks an otherwise
+        # passing verifier set so a hollow run cannot resolve to "partial".
+        verdict = "fail"
     elif pass_count == 0 and fail_count == 0:
         verdict = "vacuous"
     elif fail_count == 0 and gate_verdict == "pass":

--- a/mini_ork/ported/reflection_pipeline.py
+++ b/mini_ork/ported/reflection_pipeline.py
@@ -45,6 +45,7 @@ __all__ = [
     "reflection_summarize_patterns",
     "reflection_suggest_promotions",
     "reflection_persist_suggestions",
+    "reflection_verify_patterns",
     "reflection_run",
 ]
 
@@ -641,6 +642,58 @@ def reflection_persist_suggestions(suggestions_json: str) -> int:
     return _persist_suggestions_upsert(db_path, suggestions_json)
 
 
+def reflection_verify_patterns() -> int:
+    """Mirror lib/reflection_pipeline.sh::reflection_verify_patterns.
+
+    Judge-gate (extract→distill→verify): transition emergent_patterns rows from
+    status='proposed' → 'approved' when they clear the evidence/strength floor
+    (strength_score >= MO_EMERGENT_VERIFY_MIN_STRENGTH AND member-evidence count
+    >= MO_EMERGENT_VERIFY_MIN_EVIDENCE). Only approved rows are eligible to be
+    read into routing/context — the guard against memory confabulation (Dixit
+    2026). Opt-out MO_EMERGENT_VERIFY=0. Cold-safe: no-op on missing/empty
+    table. Prints and returns the count of newly-approved rows.
+    """
+    if os.environ.get("MO_EMERGENT_VERIFY", "1") != "1":
+        print(0)
+        return 0
+    min_strength = float(os.environ.get("MO_EMERGENT_VERIFY_MIN_STRENGTH", "3"))
+    min_evidence = int(os.environ.get("MO_EMERGENT_VERIFY_MIN_EVIDENCE", "1"))
+    db_path = os.environ["MINI_ORK_DB"]
+    con = _connect(db_path)
+    try:
+        try:
+            rows = con.execute(
+                "SELECT pattern_id, member_item_ids_json, strength_score "
+                "FROM emergent_patterns WHERE status='proposed'"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            print(0)
+            return 0
+        now = int(time.time())
+        approved = 0
+        for pid, members_json, strength in rows:
+            try:
+                n_evidence = len(json.loads(members_json)) if members_json else 0
+            except (json.JSONDecodeError, TypeError):
+                n_evidence = 0
+            try:
+                s = float(strength)
+            except (TypeError, ValueError):
+                s = 0.0
+            if s >= min_strength and n_evidence >= min_evidence:
+                con.execute(
+                    "UPDATE emergent_patterns SET status='approved', resolved_at=? "
+                    "WHERE pattern_id=? AND status='proposed'",
+                    (now, pid),
+                )
+                approved += 1
+        con.commit()
+    finally:
+        con.close()
+    print(approved)
+    return approved
+
+
 def reflection_run(since_ts: int | None = None) -> str:
     """Mirror lib/reflection_pipeline.sh::reflection_run.
 
@@ -733,6 +786,23 @@ def reflection_run(since_ts: int | None = None) -> str:
         f"reflection_run: {count} promotion suggestions generated, {persisted} persisted",
         file=sys.stderr,
     )
+
+    # [judge-gate] extract→distill→verify: promote only evidence-backed
+    # emergent_patterns from 'proposed' → 'approved' so confabulated
+    # self-diagnoses never reach routing/context (Dixit 2026).
+    print("  [verify] judge-gate emergent_patterns", file=sys.stderr)
+    approved = 0
+    try:
+        _approved_buf = io.StringIO()
+        with redirect_stdout(_approved_buf):
+            approved = reflection_verify_patterns()
+    except Exception:
+        approved = 0
+    print(
+        f"reflection_run: {approved} emergent_patterns approved by judge-gate",
+        file=sys.stderr,
+    )
+
     # Final stdout emission: bash's `echo "$suggestions"` — single copy.
     print(suggestions_json)
     return suggestions_json

--- a/tests/unit/test_context_assembler_py.py
+++ b/tests/unit/test_context_assembler_py.py
@@ -105,6 +105,72 @@ def test_context_assemble_parity(db, tmp_path, monkeypatch):
     assert py_pack == bash_pack
 
 
+def _seed_emergent(db, rows):
+    """rows: (pattern_id, cluster_label, features_list, strength, status)."""
+    con = sqlite3.connect(db)
+    now = int(time.time())
+    for pid, label, feats, strength, status in rows:
+        con.execute(
+            "INSERT INTO emergent_patterns (pattern_id, cluster_label, "
+            "member_item_ids_json, feature_set_json, strength_score, "
+            "suggested_meta_adr, status, detected_at) VALUES (?,?,?,?,?,?,?,?)",
+            (pid, label, "[]", json.dumps(feats), strength,
+             "meta-adr text", status, now))
+    con.commit()
+    con.close()
+
+
+def test_verified_emergent_md_readback(db, monkeypatch):
+    """failure_modes_md surfaces judge-gate 'approved' emergent patterns and
+    hides 'proposed' ones; bash and python md output stay byte-identical."""
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    monkeypatch.delenv("MO_TARGET_CWD", raising=False)
+    _seed_emergent(db, [
+        ("emg-ok",  "empty verifier output means silent failure",
+         ["verifier_addition"], 7.0, "approved"),
+        ("emg-raw", "unverified confabulated self-diagnosis",
+         ["adr"], 9.0, "proposed"),
+    ])
+    py = ca.failure_modes_md("code-fix", 5, db=db)
+    bash = _bash_fn(db, "context_failure_modes_md", "code-fix", "5")
+    assert py == bash
+    assert "Verified emergent patterns" in py
+    assert "empty verifier output means silent failure" in py
+    # The 'proposed' (unverified) pattern must NOT reach the prompt.
+    assert "confabulated" not in py
+
+
+def test_verified_emergent_optout_and_json(db, monkeypatch):
+    """MO_EMERGENT_INJECT=0 suppresses the block; JSON pack carries approved rows
+    under verified_emergent_patterns with bash/python parity."""
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    _seed_emergent(db, [
+        ("emg-ok", "cross-run lesson", ["verifier_addition"], 6.0, "approved"),
+    ])
+    # opt-out hides the md block on both sides
+    monkeypatch.setenv("MO_EMERGENT_INJECT", "0")
+    py_off = ca.failure_modes_md("code-fix", 5, db=db)
+    bash_off = _bash_fn(db, "context_failure_modes_md", "code-fix", "5",
+                        extra_env={"MO_EMERGENT_INJECT": "0"})
+    assert py_off == bash_off
+    assert "Verified emergent patterns" not in py_off
+    monkeypatch.delenv("MO_EMERGENT_INJECT", raising=False)
+
+    # JSON path: verified_emergent_patterns populated + parity.
+    import tempfile
+    brief = os.path.join(tempfile.mkdtemp(), "brief.json")
+    with open(brief, "w") as f:
+        f.write(json.dumps({"task_class": "code-fix", "goal": "x"}))
+    pack = ca.context_assemble(brief, "implementer", db=db)
+    bash_out = _bash_fn(db, "context_assemble", brief, "implementer")
+    bpack = json.loads(bash_out)
+    for v in ("assembled_at", "tokens_estimated"):
+        pack.pop(v, None); bpack.pop(v, None)
+    assert pack == bpack
+    ids = [e["cite"] for e in pack["verified_emergent_patterns"]]
+    assert "emergent_patterns/emg-ok" in ids
+
+
 def test_truncation_budget(db, tmp_path, monkeypatch):
     brief = tmp_path / "brief.json"
     brief.write_text(json.dumps({"task_class": "code-fix"}))

--- a/tests/unit/test_mini_ork_conductor_py.py
+++ b/tests/unit/test_mini_ork_conductor_py.py
@@ -67,6 +67,65 @@ def test_decide_predicted_and_budget_bias(tmp_path):
     assert "budget pressure" in lo["topology_rationale"]
 
 
+def _seed_lane_adv(db, task_class="code_fix"):
+    """Give one lane a positive relative_advantage so lane_adv_sum > 0 and the
+    gain coefficient actually moves predicted_score."""
+    _sql(db, "INSERT INTO agent_performance_memory "
+             "(agent_version_id, task_class, role, model, runs_count, relative_advantage) "
+             f"VALUES ('impl-v1','{task_class}','implementer','implementer',5,1.0);")
+
+
+def _seed_realized(db, scores):
+    for i, s in enumerate(scores):
+        _sql(db, "INSERT INTO conductor_decisions "
+                 "(decided_at, epic_id, task_class, predicted_score, budget_pct_used, "
+                 "outcome, realized_score) "
+                 f"VALUES ({1000+i}, 'e-old-{i}', 'code_fix', 0.5, 0.0, "
+                 f"'{'success' if s>=0.5 else 'failure'}', {s});")
+
+
+def test_adaptive_gain_cold_defaults_to_030(tmp_path):
+    """Cold table (no resolved decisions) → gain stays 0.3, matching the legacy
+    fixed constant. predicted = 0.8 * (1 + 1.0*0.3) = 1.04 → clamped to 1.0."""
+    _, db = _seed(tmp_path, "gc")
+    _seed_lane_adv(db)
+    dec = cond.decide_for_epic(db, "e1", spent=0.0, cap=50.0, plast_budget=5)
+    assert dec["lane_hints"].get("implementer") == "impl-v1"
+    assert dec["predicted_score"] == 1.0  # 0.8*(1+0.3) clamped
+
+
+def test_adaptive_gain_optout_matches_cold(tmp_path, monkeypatch):
+    """MO_CONDUCTOR_ADAPTIVE_GAIN=0 forces the fixed 0.3 even with realized rows."""
+    _, db = _seed(tmp_path, "go")
+    _seed_lane_adv(db)
+    _seed_realized(db, [1.0, 1.0, 1.0, 1.0])   # strong track record present
+    monkeypatch.setenv("MO_CONDUCTOR_ADAPTIVE_GAIN", "0")
+    dec = cond.decide_for_epic(db, "e1", spent=0.0, cap=50.0, plast_budget=5)
+    assert dec["predicted_score"] == 1.0  # gain forced to 0.3 → 0.8*1.3 clamped
+
+
+def test_adaptive_gain_poor_record_damps_predicted(tmp_path, monkeypatch):
+    """A poor realized track record (ema<0.5) shrinks the gain below 0.3 so the
+    lane-advantage boost is damped and predicted stays below the cold value.
+    Bash and python compute the identical fitted gain (parity)."""
+    monkeypatch.delenv("MO_CONDUCTOR_ADAPTIVE_GAIN", raising=False)
+    hb, db_b = _seed(tmp_path, "gpb")
+    _, db_p = _seed(tmp_path, "gpp")
+    for d in (db_b, db_p):
+        _seed_lane_adv(d)
+        _seed_realized(d, [0.0, 0.0, 0.0, 0.0])   # all failures → ema=0 → gain floor 0.1
+    # Python port
+    dec = cond.decide_for_epic(db_p, "e1", spent=0.0, cap=50.0, plast_budget=5)
+    # gain = clamp(0.3*2*ema=0, 0.1, 0.6) = 0.1 → 0.8*(1+1.0*0.1) = 0.88
+    assert abs(dec["predicted_score"] - 0.88) < 1e-6
+    # Bash conductor logs the same predicted_score for the same DB state.
+    subprocess.run(["bash", str(BIN), "--once", "--dry-run"], capture_output=True, text=True,
+                   env={**os.environ, "MINI_ORK_ROOT": str(REPO), "MINI_ORK_HOME": hb,
+                        "MINI_ORK_DB": db_b})
+    got = _sql(db_b, "SELECT predicted_score FROM conductor_decisions WHERE epic_id='e1'")
+    assert abs(float(got) - 0.88) < 1e-6, f"bash predicted_score={got!r}"
+
+
 def test_empty_queue(tmp_path):
     hb, db_b = _seed(tmp_path, "e")
     _sql(db_b, "UPDATE epics SET status='done' WHERE id='e1';")   # nothing ready

--- a/tests/unit/test_mini_ork_execute_py.py
+++ b/tests/unit/test_mini_ork_execute_py.py
@@ -548,6 +548,37 @@ def test_main_live_run_wired(tmp_path, monkeypatch):
     assert int(n) >= 2
 
 
+def test_trace_fn_stamps_scoping(tmp_path, monkeypatch):
+    # Scoping-stamp fix: the per-node trace_fn must land code_region (from an in-repo
+    # files_written path) and objective_domain (from MINI_ORK_OBJECTIVE_DOMAIN), the
+    # two feature-partition columns that were NULL/monolithic before.
+    db = _seed_db(tmp_path, "scope"); _seed_task_run(db, rid="run-s", status="executing")
+    repo = _git_repo(tmp_path / "repo")
+    (repo / "lib").mkdir()
+    edited = repo / "lib" / "healer.sh"; edited.write_text("echo hi\n")
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    monkeypatch.setenv("MINI_ORK_ROOT", str(repo))
+    monkeypatch.setenv("MO_TARGET_CWD", str(repo))
+    monkeypatch.setenv("MINI_ORK_OBJECTIVE_DOMAIN", "book-gen")
+    tf = ex._make_trace_fn("code_fix", db, "run-s")
+    tf("impl1", "success", "implementer", output_file=str(edited), finish_reason="done")
+    row = _sql(db, "SELECT objective_domain, code_region FROM execution_traces "
+                   "WHERE run_id='run-s';").stdout.strip()
+    assert row == "book-gen|lib"
+
+
+def test_trace_fn_objective_domain_defaults(tmp_path, monkeypatch):
+    # objective_domain defaults to code-delivery ONLY when the env is unset.
+    db = _seed_db(tmp_path, "scopedef"); _seed_task_run(db, rid="run-d", status="executing")
+    monkeypatch.delenv("MINI_ORK_OBJECTIVE_DOMAIN", raising=False)
+    monkeypatch.delenv("MO_OBJECTIVE_DOMAIN", raising=False)
+    monkeypatch.setenv("MINI_ORK_DB", db)
+    tf = ex._make_trace_fn("code_fix", db, "run-d")
+    tf("r1", "success", "researcher")
+    assert _sql(db, "SELECT objective_domain FROM execution_traces "
+                    "WHERE run_id='run-d';").stdout.strip() == "code-delivery"
+
+
 # ── orchestration backbone parity (NODE_IDS + --dry-run) ──
 
 def _py_blocks():

--- a/tests/unit/test_mini_ork_verify_py.py
+++ b/tests/unit/test_mini_ork_verify_py.py
@@ -110,3 +110,75 @@ def test_dry_run_parity(tmp_path):
     sp, _ = _py(home, db, "art.txt", "--plan", plan, "--dry-run")
     assert _norm(sb) == _norm(sp)
     assert json.loads(sp)["verdict"] == "dry-run"
+
+
+def _req_plan(home, artifact_path, verifiers=None):
+    """A plan whose artifact_contract requires a concrete (absolute) run-local
+    artifact — the hollow-run guard target."""
+    plan = home / "plan-req.json"
+    plan.write_text(json.dumps({
+        "task_class": "framework_edit",
+        "artifact_contract": {
+            "required_artifacts": [str(artifact_path)],
+            "success_verifiers": verifiers or [],
+        },
+    }))
+    return str(plan)
+
+
+def test_missing_required_artifact_fails(tmp_path):
+    # (i) a required artifact that does not exist → hard FAIL (exit 1), both impls.
+    home, db, _ = _scenario(tmp_path, [])
+    missing = tmp_path / "artifact.md"          # never created
+    plan = _req_plan(home, missing)
+    sb, rb = _bash(home, db, str(missing), "--plan", plan)
+    sp, rp = _py(home, db, str(missing), "--plan", plan)
+    assert _norm(sb) == _norm(sp)
+    assert json.loads(sb)["verdict"] == json.loads(sp)["verdict"] == "fail"
+    assert rb == rp == 1
+
+
+def test_empty_required_artifact_fails(tmp_path):
+    # (i) a zero-byte required artifact → hard FAIL (exit 1), both impls.
+    home, db, _ = _scenario(tmp_path, [])
+    empty = tmp_path / "artifact.md"; empty.write_text("")   # exists but 0 bytes
+    plan = _req_plan(home, empty)
+    sb, rb = _bash(home, db, str(empty), "--plan", plan)
+    sp, rp = _py(home, db, str(empty), "--plan", plan)
+    assert _norm(sb) == _norm(sp)
+    assert json.loads(sb)["verdict"] == json.loads(sp)["verdict"] == "fail"
+    assert rb == rp == 1
+
+
+def test_real_required_artifact_passes(tmp_path):
+    # (ii) a real, non-empty required artifact → PASS (exit 0), both impls. This
+    # is the 36KB-synthesis false-negative that must NOT be false-failed.
+    home, db, _ = _scenario(tmp_path, [])
+    real = tmp_path / "synthesis.md"
+    real.write_text("# Synthesis\n" + ("evidence line with a real finding\n" * 2000))
+    assert real.stat().st_size > 30_000
+    plan = _req_plan(home, real)
+    sb, rb = _bash(home, db, str(real), "--plan", plan)
+    sp, rp = _py(home, db, str(real), "--plan", plan)
+    assert _norm(sb) == _norm(sp)
+    assert json.loads(sb)["verdict"] == json.loads(sp)["verdict"] == "pass"
+    assert rb == rp == 0
+
+
+def test_relative_output_is_exempt(tmp_path):
+    # A relative canonical output (publish-target) that doesn't exist yet must NOT
+    # trip the guard — only absolute run-local artifacts are enforced.
+    home, db, _ = _scenario(tmp_path, [])
+    plan = home / "plan-rel.json"
+    plan.write_text(json.dumps({
+        "task_class": "research_synthesis",
+        "artifact_contract": {
+            "outputs": ["docs/research/synthesis-latest.md"],  # relative → exempt
+            "success_verifiers": ["goodv"],
+        },
+    }))
+    sb, rb = _bash(home, db, "art.txt", "--plan", str(plan))
+    sp, rp = _py(home, db, "art.txt", "--plan", str(plan))
+    assert _norm(sb) == _norm(sp)
+    assert json.loads(sb)["verdict"] == json.loads(sp)["verdict"] == "pass"
+    assert rb == rp == 0

--- a/tests/unit/test_reflection_pipeline_py.py
+++ b/tests/unit/test_reflection_pipeline_py.py
@@ -586,6 +586,105 @@ def shlex_quote(s: str) -> str:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# (9) reflection_verify_patterns — judge-gate: proposed → approved on floor
+# ─────────────────────────────────────────────────────────────────────────────
+def _seed_emergent(temp_db, rows):
+    """rows: list of (pattern_id, members_list, strength_score, status)."""
+    now = int(time.time())
+    con = sqlite3.connect(temp_db)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.execute("DELETE FROM emergent_patterns")
+    for pid, members, strength, status in rows:
+        con.execute(
+            "INSERT INTO emergent_patterns (pattern_id, cluster_label, "
+            "member_item_ids_json, feature_set_json, strength_score, status, detected_at) "
+            "VALUES (?,?,?,?,?,?,?)",
+            (pid, f"label-{pid}", json.dumps(members), json.dumps(["verifier_addition"]),
+             strength, status, now),
+        )
+    con.commit()
+    con.close()
+
+
+def test_reflection_verify_patterns_gate(temp_db):
+    """Judge-gate promotes only evidence-backed 'proposed' rows to 'approved'.
+
+    Floor (defaults): strength_score >= 3 AND member-evidence count >= 1.
+    Rows below either bound stay 'proposed'. Byte-parity on the stdout count
+    between the live bash function and the Python port (run bash first, re-seed,
+    then Python — each observes the same input)."""
+    seed = [
+        ("p-strong",   [{"item_table": "execution_traces", "item_id": "t1"}], 5.0, "proposed"),  # pass
+        ("p-weak-str", [{"item_table": "execution_traces", "item_id": "t2"}], 2.0, "proposed"),  # fail: strength
+        ("p-no-ev",    [],                                                     9.0, "proposed"),  # fail: evidence
+        ("p-already",  [{"item_table": "execution_traces", "item_id": "t3"}], 8.0, "approved"),  # not proposed
+    ]
+
+    _seed_emergent(temp_db, seed)
+    r = _run_bash_function(temp_db, "reflection_verify_patterns")
+    assert r.returncode == 0, f"bash verify failed: {r.stderr}"
+    assert r.stdout.strip() == "1", f"bash approved count: {r.stdout!r}"
+
+    _seed_emergent(temp_db, seed)
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        n = rp.reflection_verify_patterns()
+    assert n == 1
+    assert buf.getvalue().strip() == "1"
+
+    # Row-diff after Python ran: only p-strong flipped to approved; p-already
+    # stays approved; the two failing rows stay proposed.
+    con = sqlite3.connect(temp_db)
+    statuses = dict(con.execute(
+        "SELECT pattern_id, status FROM emergent_patterns"
+    ).fetchall())
+    con.close()
+    assert statuses["p-strong"] == "approved"
+    assert statuses["p-weak-str"] == "proposed"
+    assert statuses["p-no-ev"] == "proposed"
+    assert statuses["p-already"] == "approved"
+
+
+def test_reflection_verify_patterns_optout(temp_db, monkeypatch):
+    """MO_EMERGENT_VERIFY=0 is a hard opt-out: nothing is promoted, count 0."""
+    seed = [("p-strong", [{"item_table": "execution_traces", "item_id": "t1"}], 5.0, "proposed")]
+    _seed_emergent(temp_db, seed)
+    r = _run_bash_function(temp_db, "reflection_verify_patterns",
+                           env_extra={"MO_EMERGENT_VERIFY": "0"})
+    assert r.stdout.strip() == "0"
+    monkeypatch.setenv("MO_EMERGENT_VERIFY", "0")
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        n = rp.reflection_verify_patterns()
+    assert n == 0
+    con = sqlite3.connect(temp_db)
+    st = con.execute("SELECT status FROM emergent_patterns WHERE pattern_id='p-strong'").fetchone()[0]
+    con.close()
+    assert st == "proposed"  # untouched
+
+
+def test_reflection_verify_patterns_cold(temp_db):
+    """Cold-safe: no emergent_patterns rows → count 0, no crash (both sides)."""
+    con = sqlite3.connect(temp_db)
+    con.execute("PRAGMA busy_timeout=5000")
+    con.execute("DELETE FROM emergent_patterns")
+    con.commit()
+    con.close()
+    r = _run_bash_function(temp_db, "reflection_verify_patterns")
+    assert r.returncode == 0 and r.stdout.strip() == "0"
+    import io
+    from contextlib import redirect_stdout
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        assert rp.reflection_verify_patterns() == 0
+    assert buf.getvalue().strip() == "0"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # (8) reflection_extract_gradients — SQL trace_id selection + injected stub
 # ─────────────────────────────────────────────────────────────────────────────
 def test_reflection_extract_gradients(temp_db):

--- a/tests/unit/test_trace_store_py.py
+++ b/tests/unit/test_trace_store_py.py
@@ -90,3 +90,47 @@ def test_roundtrip_get(db):
         db=db)
     row = trace_store.trace_get(tid, db=db)
     assert row and row["status"] == "success" and abs(float(row["reward_g"]) - 1.0) < 1e-9
+
+
+def test_objective_domain_passthrough(db):
+    # objective_domain must land from the payload, not silently default to
+    # code-delivery — the scoping-stamp fix (feature-partition column population).
+    tid = trace_store.trace_write(
+        {"trace_id": "od-1", "task_class": "book-gen", "status": "success",
+         "objective_domain": "book-gen"}, db=db)
+    row = trace_store.trace_get(tid, db=db)
+    assert row["objective_domain"] == "book-gen"
+    # unset → legacy code-delivery fallback preserved
+    tid2 = trace_store.trace_write(
+        {"trace_id": "od-2", "task_class": "x", "status": "success"}, db=db)
+    assert trace_store.trace_get(tid2, db=db)["objective_domain"] == "code-delivery"
+
+
+def _bash_grade(db, run_dir, run_id):
+    subprocess.run(
+        ["bash", "-c", f'. "{TS_SH}" && mo_grade_run_reward "$1" "$2"', "_", run_dir, run_id],
+        env={**os.environ, "MINI_ORK_DB": db}, capture_output=True, text=True, check=True,
+    )
+
+
+def test_grade_run_reward_bash_vs_python(db, tmp_path):
+    # Win #3 graded bridge: rubric.json {score 0-8} → reward_g in [-1,+1] stamped on
+    # every trace of the run, overwriting the binary status-map reward. Assert the
+    # bash mo_grade_run_reward and python grade_run_reward agree on the graded value.
+    rd = tmp_path / "grade-run"; rd.mkdir()
+    (rd / "rubric.json").write_text(json.dumps({"score": 6}))
+    # seed one trace per side under distinct run_ids, initial reward_g = -1 (status-map fail)
+    for tid, rid in (("gb-1", "grade-bash"), ("gp-1", "grade-py")):
+        trace_store.trace_write(
+            {"trace_id": tid, "run_id": rid, "task_class": "code-fix", "status": "failure",
+             "reward_value": 0.0, "reward_anchor": 0.5, "reward_direction": "higher_is_better"},
+            db=db)
+    _bash_grade(db, str(rd), "grade-bash")
+    n = trace_store.grade_run_reward(str(rd), "grade-py", db=db)
+    assert n == 1
+    bg, pg = _reward_g(db, "gb-1"), _reward_g(db, "gp-1")
+    graded = (6 / 8 - 0.5) / 0.5   # 0.5
+    assert abs(float(bg) - graded) < 1e-9 and abs(float(pg) - graded) < 1e-9
+    # missing rubric → no-op (0 rows), leaves status-map reward intact
+    empty = tmp_path / "no-rubric"; empty.mkdir()
+    assert trace_store.grade_run_reward(str(empty), "grade-py", db=db) == 0


### PR DESCRIPTION
The runtime flip made MINI_ORK_RUNTIME=python the default, but plan.py's `__main__` called main() with no dispatch seam → `LLM dispatch unavailable` on every real run → every python-default `mini-ork run` died at the plan stage. CI missed it (parity tests use MO_GIVEN_PLAN/dry-run; the live harness only hit execute's researcher). Fix: wire _default_llm_dispatch (shells mo_llm_dispatch, mirrors bash bin/mini-ork-plan:656) at the CLI boundary; seam stays injectable for tests. execute.py already wires its default. **Verified**: python-runtime plan now dispatches + produces a valid 7-node plan.