### PR TITLE
fix(learning-parity): context_assembler.sh emergent-read + execute hollow-guard (gaps main lacks)

### DIFF
--- a/lib/context_assembler.sh
+++ b/lib/context_assembler.sh
@@ -159,6 +159,43 @@ try:
 except Exception:
     pass
 
+# --- Verified emergent patterns (judge-gate approved) -------------------
+# Read-back of the reflection judge-gate: ONLY status='approved' rows (those
+# that cleared the evidence/strength floor in reflection_verify_patterns).
+# 'proposed' rows are self-diagnoses that never passed verification, so they
+# are deliberately excluded — the guard against memory confabulation (Dixit
+# 2026). Emitted as a sibling of known_failure_modes ("alongside"). Opt-out
+# MO_EMERGENT_INJECT=0. Cold-safe: empty/missing table → [].
+import os as _os_emg
+verified_emergent = []
+if _os_emg.environ.get("MO_EMERGENT_INJECT", "1") == "1":
+    try:
+        _emg_limit = int(_os_emg.environ.get("MO_EMERGENT_INJECT_LIMIT", "3"))
+    except ValueError:
+        _emg_limit = 3
+    try:
+        for r in con.execute("""
+            SELECT pattern_id, cluster_label, feature_set_json,
+                   strength_score, suggested_meta_adr
+            FROM emergent_patterns
+            WHERE status='approved'
+            ORDER BY strength_score DESC, detected_at DESC LIMIT ?
+        """, (_emg_limit,)).fetchall():
+            try:
+                _feats = json.loads(r["feature_set_json"]) if r["feature_set_json"] else []
+            except Exception:
+                _feats = []
+            verified_emergent.append({
+                "cite": f"emergent_patterns/{r['pattern_id']}",
+                "feature": _feats[0] if _feats else "emergent",
+                "cluster_label": r["cluster_label"],
+                "suggested_change": r["suggested_meta_adr"] or "",
+                "strength_score": r["strength_score"],
+                "scope": "emergent",
+            })
+    except Exception:
+        pass
+
 # --- Similarity-retrieved prior observations (Track A item 1) -----------
 # TF-IDF cosine over bug_reports + gradient_records + learning_record text
 # columns, scored against the incoming task_brief. Pulls in lessons that
@@ -321,6 +358,7 @@ pack = {
     "verifier_contract": {"content": verifier_contract, "cite": "artifact_contract"},
     "prior_similar_runs": prior_runs,
     "known_failure_modes": failure_modes,
+    "verified_emergent_patterns": verified_emergent,
     "similar_lessons": similar_lessons,
     "user_preferences": user_prefs,
     "constraints": constraints,
@@ -392,6 +430,41 @@ if rows:
         print(f"- [{target}] {signal.strip()}")
         print(f"  Fix applied going forward: {change.strip()}")
     print("--- /learned failure modes ---")
+
+# Verified emergent patterns (judge-gate approved) — read-back of the
+# reflection judge-gate into the prompt. ONLY status='approved' rows (cleared
+# the evidence/strength floor in reflection_verify_patterns); 'proposed'
+# self-diagnoses are excluded (memory-confabulation guard, Dixit 2026).
+# Opt-out MO_EMERGENT_INJECT=0. Cold-safe: empty/missing table → nothing.
+import os as _os_emg, json as _json_emg
+if _os_emg.environ.get("MO_EMERGENT_INJECT", "1") == "1":
+    try:
+        _emg_limit = int(_os_emg.environ.get("MO_EMERGENT_INJECT_LIMIT", "3"))
+    except ValueError:
+        _emg_limit = 3
+    con2 = sqlite3.connect(db)
+    con2.execute("PRAGMA busy_timeout=5000")
+    try:
+        emg = con2.execute("""
+            SELECT cluster_label, feature_set_json, strength_score
+            FROM emergent_patterns
+            WHERE status='approved'
+            ORDER BY strength_score DESC, detected_at DESC LIMIT ?
+        """, (_emg_limit,)).fetchall()
+    except sqlite3.OperationalError:
+        emg = []
+    finally:
+        con2.close()
+    if emg:
+        print("--- Verified emergent patterns (cross-run, judge-gate approved) ---")
+        for cluster_label, feature_set_json, strength in emg:
+            try:
+                feats = _json_emg.loads(feature_set_json) if feature_set_json else []
+            except Exception:
+                feats = []
+            feat = feats[0] if feats else "emergent"
+            print(f"- [{feat}] {(cluster_label or '').strip()}")
+        print("--- /verified emergent patterns ---")
 PY
 }
 

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -931,6 +931,35 @@ def _extract_verdict(root, review_file) -> str:
     return (r.stdout.strip() or "unknown") if r.returncode == 0 else "unknown"
 
 
+def _required_artifacts_ok(plan_path) -> bool:
+    """Hollow-run guard for the verifier node (parity: bash _mo_required_artifacts_ok).
+    A recipe that declares a concrete, run-local artifact (an ABSOLUTE, env-expanded
+    artifact_contract path such as ``${MINI_ORK_RUN_DIR}/framework-edit.diff``) but
+    produces nothing — missing OR zero-byte — fails. Relative canonical outputs are
+    publish-targets (exempt), so a genuine artifact is never false-failed. Returns
+    True when all required artifacts exist + are non-empty (or none apply)."""
+    if not plan_path or not os.path.isfile(plan_path):
+        return True
+    try:
+        ac = json.load(open(plan_path, encoding="utf-8")).get("artifact_contract", {})
+    except Exception:
+        return True
+    if not isinstance(ac, dict):
+        return True
+    ok = True
+    seen: set[str] = set()
+    for key in ("required_artifacts", "outputs"):
+        for raw in ac.get(key, []) or []:
+            p = os.path.expandvars(str(raw))
+            if not os.path.isabs(p) or p in seen:
+                continue
+            seen.add(p)
+            if not (os.path.isfile(p) and os.path.getsize(p) > 0):
+                sys.stderr.write(f"  [fail] required artifact missing or empty: {p}\n")
+                ok = False
+    return ok
+
+
 def _run_verifier_ref(script, evidence_path, *, plan_path="", artifact_path="", cwd=None):
     """Port of _run_verifier_ref (minus the mo_runtime_exec seam): run the
     verifier script, capture evidence, and treat {"pass": true} as success."""
@@ -1798,6 +1827,12 @@ def dispatch_node(fields, *, root, run_dir, plan_path, task_class, db, run_id,
         return 1, fr
 
     if node_type == "verifier":
+        # Hollow-run guard: fail before any verifier runs if the recipe declares a
+        # concrete run-local artifact (absolute contract path) that is missing or
+        # zero-byte. Covers the verifier_ref branch (which bypasses mini-ork-verify).
+        if not _required_artifacts_ok(plan_path):
+            print("  [fail] verifier node: required artifact(s) missing or empty", file=sys.stderr)
+            return 1, "error"
         artifact = ""
         try:
             ac = (json.load(open(plan_path)).get("artifact_contract") or {}) if plan_path else {}

--- a/tests/unit/test_mini_ork_execute_py.py
+++ b/tests/unit/test_mini_ork_execute_py.py
@@ -389,10 +389,35 @@ def test_live_reviewer_verdict_gate(tmp_path):
     rc_rev, fr_rev = ex.dispatch_node(_fields("rev3", "reviewer", "opus"),
                                       dispatch_fn=_fake('{"verdict": "needs_revision"}'), **common)
     assert rc_rev == 1 and fr_rev == "verdict_revise"
+    # unknown/unparseable verdict on a gating (non-synth) node → FAIL, not neutral.
+    rc_unk, fr_unk = ex.dispatch_node(_fields("rev4", "reviewer", "opus"),
+                                      dispatch_fn=_fake("I think this looks fine overall."), **common)
+    assert rc_unk == 1 and fr_unk == "verdict_fail"
     # a synth reviewer never gates → always success
     rc_synth, _ = ex.dispatch_node(_fields("synth_node", "reviewer", "opus"),
                                    dispatch_fn=_fake("# Synthesis\ntop findings..."), **common)
     assert rc_synth == 0
+
+
+def test_live_verifier_hollow_artifact_fails(tmp_path):
+    # Hollow-run guard: a plan that requires a concrete absolute run-local artifact
+    # which is missing → the verifier node fails before any verifier runs. A real,
+    # non-empty artifact at that path passes the guard.
+    db = _seed_db(tmp_path, "vh"); _seed_task_run(db)
+    rd = tmp_path / "run"; rd.mkdir()
+    art = rd / "framework-edit.diff"
+    plan = tmp_path / "plan-req.json"
+    plan.write_text(json.dumps({"objective": "o",
+                                "artifact_contract": {"required_artifacts": [str(art)]}}))
+    common = dict(root=str(REPO), run_dir=str(rd), plan_path=str(plan),
+                  task_class="framework_edit", db=db, run_id="r1", dispatch_fn=_fake(""))
+    rc_missing, fr_missing = ex.dispatch_node(_fields("verify1", "verifier"), **common)
+    assert rc_missing == 1 and fr_missing == "error"
+    # Now materialise a real, non-empty artifact → guard passes (no outputs → the
+    # node returns 0 with an informational finish_reason, bash parity).
+    art.write_text("diff --git a/x b/x\n+real change\n")
+    rc_ok, _ = ex.dispatch_node(_fields("verify2", "verifier"), **common)
+    assert rc_ok == 0
 
 
 def test_run_verifier_ref(tmp_path):


### PR DESCRIPTION
An agent-team self-audit re-derived the reward/reflection/verify fixes, but **main already has them** (landed via #157 GEPA). The cherry-pick kept only the genuine non-redundant delta: (1) `lib/context_assembler.sh` now reads approved emergent patterns — a latent py/sh parity gap (the .py does, the .sh didn't); (2) an execute-side `_required_artifacts_ok` hollow-run guard + test main lacked. gpg-scoped tests pass.