### PR TITLE
fix(router): stop learning_governed collapsing recipe-pinned panels (monoculture)

### DIFF
--- a/bin/mini-ork-execute
+++ b/bin/mini-ork-execute
@@ -2017,7 +2017,16 @@ _mo_policy_route_lane() {
     static_hybrid)
       _mo_learning_static_lane "$node_type" "$current_lane" ;;
     learning_governed)
-      _mo_learning_governed_lane "$node_type" "$(_mo_learning_static_lane "$node_type" "$current_lane")" ;;
+      # Router-monoculture fix: respect a recipe-pinned lane (current_lane != node_type)
+      # — deliberate cross-family panel diversity or a model-strength pin. The governed
+      # router must NOT override it with the single global-slice winner (that collapses 4
+      # same-node-type panel researchers onto one lane). Learning governs only UNPINNED
+      # nodes; pinned nodes keep their lane (matches _mo_learning_static_lane).
+      if [ "$current_lane" != "$node_type" ]; then
+        printf '%s\n' "$current_lane"
+      else
+        _mo_learning_governed_lane "$node_type" "$(_mo_learning_static_lane "$node_type" "$current_lane")"
+      fi ;;
     trace_governed)
       # Cheap-first execution with expensive review/recovery. FAIL_COUNT is
       # the executor's prefix-trace signal: verifier/reviewer failures before

--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -140,6 +140,15 @@ def policy_route_lane(node_type: str, current_lane: str, *, dry_run=False, root=
     if policy == "static_hybrid":
         return learning_static_lane(node_type, current_lane)
     if policy == "learning_governed":
+        # Router-monoculture fix: a recipe-pinned lane (current_lane != node_type) is a
+        # deliberate author choice — cross-family panel diversity (glm/kimi/codex/opus
+        # lenses) or a model-strength pin. The governed router must NOT override it with
+        # the single global-slice winner: that collapses every same-node-type panel node
+        # (4 researchers) onto ONE lane, destroying the diversity the recipe designed.
+        # Learning governs only UNPINNED nodes (current_lane == node_type); pinned nodes
+        # keep their lane — consistent with learning_static_lane's pin-preservation.
+        if current_lane != node_type:
+            return current_lane
         return learning_governed_lane(node_type, learning_static_lane(node_type, current_lane), root=root)
     if policy == "trace_governed":
         fail_count = int(os.environ.get("FAIL_COUNT", "0") or "0")

--- a/tests/unit/test_mini_ork_execute_py.py
+++ b/tests/unit/test_mini_ork_execute_py.py
@@ -67,6 +67,18 @@ def test_dispatch_chain_parity():
         assert rb == rp, f"({nt},{lead}): bash={rb!r} py={rp!r}"
 
 
+def test_router_respects_pins_no_monoculture():
+    # Router-monoculture fix (bash + py parity): under learning_governed (the default),
+    # recipe-pinned panel lenses keep their DISTINCT lanes instead of the governed router
+    # collapsing all 4 same-node-type researchers onto one global-slice winner.
+    env = {"MO_ROUTING_POLICY": "learning_governed", "DRY_RUN": "0"}
+    for lens in ("glm_lens", "kimi_lens", "codex_lens", "opus_lens"):
+        rb = _call("_mo_policy_route_lane", "researcher", lens, env=env)
+        rp = ex.policy_route_lane("researcher", lens)
+        assert rb == lens and rp == lens, \
+            f"pinned {lens} must be preserved: bash={rb!r} py={rp!r} — monoculture NOT fixed"
+
+
 def test_learning_static_lane_parity():
     env = {"MO_FRONTIER_LANE": "opus_lens", "MO_CHEAP_LANE": "kimi_lens"}
     for nt, lane in [("reviewer", "reviewer"), ("researcher", "researcher"),


### PR DESCRIPTION
The default `learning_governed` policy overrode even a recipe-**pinned** lane (`model_lane: glm_lens`) with the single global-slice winner, so a 4-lens cross-family panel collapsed onto ONE lane — destroying designed diversity. **Observed live**: a research-synthesis dogfood routed opus/glm/kimi lenses all to codex_lens; I had to disable the router to keep the panel. Fix (bash+py parity): respect pinned lanes (deliberate author choice), govern only unpinned nodes — matching learning_static_lane's own pin-preservation that learning_governed was contradicting. Unpinned code-fix nodes unaffected. Test: 4 pinned lenses stay distinct, bash==py.