### PR TITLE
fix(runtime): conductor tolerates fresh/empty db (python-default crasher sweep)

### DIFF
--- a/mini_ork/ported/epic_graph.py
+++ b/mini_ork/ported/epic_graph.py
@@ -67,6 +67,10 @@ def ready_now(db: str | None = None) -> list[str]:
                          AND d.resolved_at IS NULL)
              ORDER BY e.created_at ASC""").fetchall()
         return [r[0] for r in rows]
+    except sqlite3.Error:
+        # Fresh db without the epics/epic_dependencies tables → no ready epics,
+        # matching bash's tolerant `sqlite3 … 2>/dev/null` (crash-free empty result).
+        return []
     finally:
         con.close()
 

--- a/mini_ork/ported/mini_ork_conductor.py
+++ b/mini_ork/ported/mini_ork_conductor.py
@@ -22,11 +22,16 @@ from . import epic_graph
 
 
 def _today_cost(db):
-    c = sqlite3.connect(db)
-    r = c.execute("SELECT COALESCE(SUM(cost_usd),0) FROM task_runs "
-                  "WHERE created_at >= strftime('%s','now','-24 hours')").fetchone()
-    c.close()
-    return float(r[0] or 0)
+    # bash: `sqlite3 … 2>/dev/null || echo 0` — tolerate a missing task_runs table /
+    # empty or absent db (a fresh .mini-ork), returning 0 instead of crashing the loop.
+    try:
+        c = sqlite3.connect(db)
+        r = c.execute("SELECT COALESCE(SUM(cost_usd),0) FROM task_runs "
+                      "WHERE created_at >= strftime('%s','now','-24 hours')").fetchone()
+        c.close()
+        return float(r[0] or 0)
+    except sqlite3.Error:
+        return 0.0
 
 
 def _adaptive_lane_gain(con, base=0.3):


### PR DESCRIPTION
Swept all 32 delegated entrypoints under MINI_ORK_RUNTIME=python (now the default). One crasher: mini-ork-conductor raised OperationalError('no such table: task_runs'/'epics') on a fresh db — _today_cost + epic_graph.ready_now were unguarded where bash tolerates via `2>/dev/null`. Guarded both (also hardens scheduler). Verified: conductor --once runs clean on a fresh db; 10 tests pass; other 31 entrypoints clean.