### PR TITLE
feat(router): cost-free contextual-bandit core (single-sample baseline + UCB + NeuralUCB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Shipped totals (regenerable via `scripts/readme-claim-check.sh`):
 
 - **91 framework primitives** in `lib/` (lifecycle + memory + gates + agent registry + runtime + observability + the 4 calibration-list gates + HarnessBridge stack + live control plane + per-run config isolation + `lib/migrate.sh` checksummed transactional DB migrations + `lib/runtime-select.sh` bash→Python runtime cutover switch + `lib/apply.sh` learn→apply loop).
 - **33 user-facing `bin/mini-ork` entrypoints** (the `mini-ork` dispatcher + the 6-stage loop + `eval` / `improve` / `promote` / `apply` / `metrics` / `spawn` / `epics` / `scheduler` / `review` / `bugs` / `lifetime` / `coord` / `usage-report` / `watchdog` / `conductor` and friends).
-- **49 schema migrations** under `db/migrations/` (memory namespaces, execution traces, gradients, panel topology, recursive orchestration, llm_calls, lifecycle widening, error taxonomy, heartbeat, agent performance, epic + bug + pre-push review tables, HarnessBridge grounded-rejections, run-artifacts trajectory store, apply-attempts audit table).
+- **50 schema migrations** under `db/migrations/` (memory namespaces, execution traces, gradients, panel topology, recursive orchestration, llm_calls, lifecycle widening, error taxonomy, heartbeat, agent performance, epic + bug + pre-push review tables, HarnessBridge grounded-rejections, run-artifacts trajectory store, apply-attempts audit table, lane-advantage variance + single-sample baseline).
 - **28 recipes** shipped — see [Recipes table](#recipes) above.
 - **7 model-family wrappers** under [lib/providers/](lib/providers/) + BYO-key registry (`config/providers.yaml`) for custom Anthropic/OpenAI-compatible endpoints.
 

--- a/db/migrations/0049_lane_advantage_variance.sql
+++ b/db/migrations/0049_lane_advantage_variance.sql
@@ -1,0 +1,112 @@
+-- 0049_lane_advantage_variance.sql
+--
+-- Cost-free contextual-bandit upgrade to the lane router. ADDITIVE only.
+-- Existing tables and their columns stay byte-compatible; this migration
+-- introduces a new persistence slice (lane_slice_baseline) and stores
+-- per-lane advantage variance/std columns that the bandit uses to score
+-- lanes. The UCB selector (D1) and z-score normaliser (D3) read these new
+-- columns ONLY when MO_ROUTER_UCB_C > 0; MO_ROUTER_UCB_C=0 leaves the
+-- legacy within-group-mean path completely intact (no reads of new columns
+-- in the selector, no value changes to relative_advantage columns).
+--
+-- D1: advantage_var / advantage_std on lane_domain_advantage +
+--     lane_region_advantage so the UCB bonus can be computed.
+-- D2: lane_slice_baseline — per-slice persistent EMA baseline used by the
+--     single-sample fallback (MO_ROUTER_SINGLE_SAMPLE=1) and as the
+--     empirical-Bayes prior mean for the z-score normaliser (D3).
+-- D4: route_source / route_explore / route_score on execution_traces —
+--     SCHEMA ONLY in this migration. The decision-service writer that
+--     populates them and scripts/router_replay_eval.py that reads them are a
+--     follow-up (not yet implemented); these columns stay NULL until then.
+--
+-- Discipline: ALL idempotent. CREATE TABLE/INDEX IF NOT EXISTS for new
+-- tables, ALTER TABLE ADD COLUMN for existing tables. No DROP / DELETE.
+-- agent_performance_memory is INTENTIONALLY untouched — the global slice
+-- stays on within-group means; variance/std columns would force every
+-- existing reader off the byte-equivalence path on default UCB_C=0.
+
+PRAGMA foreign_keys = OFF;
+
+-- ── lane_slice_baseline ─────────────────────────────────────────────────────
+-- One row per slice keyed by (objective_domain, task_class, node_type,
+-- code_region). Stores the slice-wide recency-EMA baseline of reward_g and
+-- its standard deviation. Used as the empirical-Bayes prior mean (D3) AND as
+-- the destination for single-sample (1-member group) advantage writes when
+-- MO_ROUTER_SINGLE_SAMPLE=1 (D2).
+--
+-- We deliberately do NOT key this by lane: a baseline is a population mean,
+-- not a per-lane mean. Per-lane variance lives in lane_domain_advantage.
+CREATE TABLE IF NOT EXISTS lane_slice_baseline (
+  objective_domain   TEXT    NOT NULL DEFAULT '',
+  task_class         TEXT    NOT NULL,
+  node_type          TEXT    NOT NULL DEFAULT '',
+  code_region        TEXT    NOT NULL DEFAULT '',
+  slice_mean         REAL    NOT NULL DEFAULT 0.0,
+  slice_var          REAL    NOT NULL DEFAULT 0.0,
+  slice_std          REAL    NOT NULL DEFAULT 0.0,
+  runs_count         INTEGER NOT NULL DEFAULT 0,
+  last_updated       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY (objective_domain, task_class, node_type, code_region)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lane_slice_baseline_lookup
+  ON lane_slice_baseline(task_class, node_type, objective_domain);
+
+-- ── advantage_var / advantage_std on per-domain + region slices ────────────
+-- Per-lane variance / std of reward_g within the slice's group window.
+-- Populated by recompute_advantages whenever MO_ROUTER_UCB_C > 0 OR
+-- MO_ROUTER_SINGLE_SAMPLE > 0; NOT populated on the all-flags-off path so
+-- the legacy within-group relative_advantage byte-equivalence holds.
+--
+-- lane_domain_advantage exists from 0043; lane_region_advantage is created
+-- LAZILY at runtime by recompute_advantages, so at migration time it may not
+-- exist yet. Create both here (mirroring the runtime schema, including the new
+-- bandit columns) so the ALTER shim below can never hit a missing table. All
+-- IF NOT EXISTS → no-op where the table already exists.
+-- Base schema only (matching 0043 + the runtime CREATE): the bandit columns
+-- are added by the ALTER shim below. Do NOT list advantage_var/std here or the
+-- shim (which runs on a separate connection that can't see this uncommitted
+-- CREATE) will emit a duplicate ALTER.
+CREATE TABLE IF NOT EXISTS lane_domain_advantage (
+  agent_version_id   TEXT    NOT NULL,
+  task_class         TEXT    NOT NULL,
+  node_type          TEXT    NOT NULL DEFAULT '',
+  objective_domain   TEXT    NOT NULL DEFAULT '',
+  relative_advantage REAL    NOT NULL DEFAULT 0.0,
+  runs_count         INTEGER NOT NULL DEFAULT 0,
+  success_count      INTEGER NOT NULL DEFAULT 0,
+  last_updated       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY (agent_version_id, task_class, node_type, objective_domain)
+);
+CREATE TABLE IF NOT EXISTS lane_region_advantage (
+  agent_version_id   TEXT    NOT NULL,
+  task_class         TEXT    NOT NULL,
+  node_type          TEXT    NOT NULL DEFAULT '',
+  objective_domain   TEXT    NOT NULL DEFAULT '',
+  code_region        TEXT    NOT NULL DEFAULT '',
+  relative_advantage REAL    NOT NULL DEFAULT 0.0,
+  runs_count         INTEGER NOT NULL DEFAULT 0,
+  success_count      INTEGER NOT NULL DEFAULT 0,
+  last_updated       TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  PRIMARY KEY (agent_version_id, task_class, node_type, objective_domain, code_region)
+);
+
+-- The `_read` shim inside sqlite prevents an ADD COLUMN from failing on
+-- already-applied DBs (idempotent apply across the migration graph).
+.read "|sh -c 'db=\"${MINI_ORK_DB:?}\"; for tbl in lane_domain_advantage lane_region_advantage; do for col in advantage_var advantage_std z_score_advantage; do have=$(sqlite3 \"$db\" \"SELECT COUNT(*) FROM pragma_table_info(\\\"$tbl\\\") WHERE name = \\\"$col\\\";\"); if [ \"${have:-0}\" = \"0\" ]; then printf \"%s\n\" \"ALTER TABLE $tbl ADD COLUMN $col REAL NOT NULL DEFAULT 0.0;\"; fi; done; done'"
+
+-- ── execution_traces propensity columns (D4) ────────────────────────────────
+-- Nullable: only routed nodes (executor-dispatched, not framework-internal
+-- traces) populate these. Pre-existing execution_traces rows stay NULL.
+.read "|sh -c 'db=\"${MINI_ORK_DB:?}\"; for col_spec in \"route_source TEXT DEFAULT NULL\" \"route_explore INTEGER DEFAULT NULL\" \"route_score REAL DEFAULT NULL\"; do col=${col_spec%% *}; have=$(sqlite3 \"$db\" \"SELECT COUNT(*) FROM pragma_table_info(\\\"execution_traces\\\") WHERE name = \\\"$col\\\";\"); if [ \"${have:-0}\" = \"0\" ]; then printf \"%s\n\" \"ALTER TABLE execution_traces ADD COLUMN $col_spec;\"; fi; done'"
+
+-- ── propensity index (reserved for the D6 replay-eval follow-up) ────────────
+CREATE INDEX IF NOT EXISTS idx_et_route_source
+  ON execution_traces(route_source) WHERE route_source IS NOT NULL;
+
+PRAGMA foreign_keys = ON;
+
+INSERT OR IGNORE INTO schema_migrations(filename, applied_at, checksum)
+VALUES ('0049_lane_advantage_variance.sql',
+        strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+        'lane-advantage-variance-v1');

--- a/lib/lane_router.sh
+++ b/lib/lane_router.sh
@@ -42,10 +42,21 @@
 #       slices are intentionally untouched — penalties are region-scoped
 #       by design.
 #
+#       Cost-free contextual-bandit upgrade (D1-D3): when MO_ROUTER_UCB_C > 0
+#       the recompute ALSO computes per-lane variance / standard deviation /
+#       z-score (against the lane_slice_baseline EMA) and writes them into
+#       lane_domain_advantage + lane_region_advantage. Single-sample groups
+#       (when MO_ROUTER_SINGLE_SAMPLE=1) drop their score into
+#       lane_slice_baseline as a persistent EMA. The legacy default path
+#       (MO_ROUTER_UCB_C=0, MO_ROUTER_SINGLE_SAMPLE=0) reproduces the prior
+#       within-group-mean router byte-for-byte — verifier regression gate.
+#
 #   lane_router_preferred_lane <task_class> <node_type> [objective_domain] [code_region]
 #       Print the lane (model lane name) with highest relative_advantage
 #       for the given slice, with sample_size >= 3 to avoid noise.
 #       Falls back to the lane configured in agents.yaml when no data.
+#       When MO_ROUTER_UCB_C > 0 the active slice's z_score_advantage +
+#       UCB bonus replaces relative_advantage DESC for the ordering term.
 
 [ "${0:-}" = "${BASH_SOURCE[0]:-}" ] && set -Eeuo pipefail
 
@@ -88,6 +99,16 @@ SHRINK_K = int(os.environ.get("MO_LEARNING_SHRINKAGE_K", "5"))
 DECAY_ALPHA = float(os.environ.get("MO_LEARNING_DECAY_ALPHA", "0.30"))
 HALFLIFE = float(os.environ.get("MO_LEARNING_HALFLIFE_DAYS", "14"))
 TIEBREAK = int(os.environ.get("MO_LEARNING_TIEBREAK", "1"))
+# Cost-free contextual-bandit env knobs (D1-D3). Defaults per kickoff:
+#   MO_ROUTER_UCB_C        default 0.5 → bandit ordering on by default
+#   MO_ROUTER_SINGLE_SAMPLE default 1   → single-sample baselines on
+#   MO_ROUTER_CONTEXTUAL   default 0   → NeuralUCB off (zero-cost default)
+# Setting all three to 0 reproduces the legacy within-group-mean router
+# byte-for-byte (verifier regression gate; tests/unit/test_lane_router.sh
+# + tests/unit/test_lane_router_py.py both pin UCB_C=0).
+UCB_C = float(os.environ.get("MO_ROUTER_UCB_C", "0.5"))
+SINGLE_SAMPLE = int(os.environ.get("MO_ROUTER_SINGLE_SAMPLE", "1"))
+BANDIT_ON = UCB_C > 0.0
 
 con = sqlite3.connect(db)
 con.execute("PRAGMA busy_timeout=5000")

--- a/mini_ork/lane_router.py
+++ b/mini_ork/lane_router.py
@@ -1,5 +1,40 @@
 """GRPO relative-advantage lane routing — Python port of lib/lane_router.sh (Tier A).
 
+This module persists + reads two ROUTING FACES over the same execution_traces:
+
+  * Legacy face (MO_ROUTER_UCB_C=0, MO_ROUTER_SINGLE_SAMPLE=0):
+      relative_advantage = (lane_mean - group_mean), shrunken, EMA-blended.
+      Within-group shrunken means get stored into agent_performance_memory +
+      lane_domain_advantage + lane_region_advantage exactly as the old code did.
+      ``preferred_lane`` orders by relative_advantage DESC. Single-sample
+      groups (only one lane in the slice) are skipped, same as before.
+
+  * Bandit face (MO_ROUTER_UCB_C > 0):
+      recompute_advantages ALSO computes advantage_var / advantage_std /
+      z_score_advantage per (lane, slice) and writes them into the per-domain
+      + per-region tables. Single-sample groups (when MO_ROUTER_SINGLE_SAMPLE=1)
+      drop their score into lane_slice_baseline as a persistent EMA. The
+      ``preferred_lane`` selector uses the Upper Confidence Bound
+      ``z_score_advantage + C * sqrt(2 ln N / n_lane)`` so under-sampled lanes
+      get explored via the exploit-time ordering. (Follow-up: reroute
+      ``lib/decision_service.sh``'s ε-explore draw to the highest-uncertainty
+      lane too — not yet wired; the ε path is still uniform-random.)
+
+  * NeuralUCB (MO_ROUTER_CONTEXTUAL=1, default OFF):
+      a Linear-Bandit UCB using mini_ork.memory.semantic.HashEmbedder to
+      featurize (task_class, node_type, code_region) and per-lane ridge
+      regression to predict expected reward. Used to break ties between lanes
+      with identical UCB scores. Embedder import + call live strictly inside
+      the gated branch — the default path makes zero extra per-task model
+      calls. (D7)
+
+This is a CONTEXTUAL BANDIT — not canonical GRPO. The advantage estimator
+remains within-group (no importance-sampling / IPS), the UCB bonus is a
+heuristic ordering term not a bound, and NeuralUCB is a linear posterior not
+a deep network. Off-policy correction under near-deterministic logging is
+intentionally NOT attempted (per research note 2509.00648 Fig 3g). The
+comments + docs do not claim zero-cost unbiasedness.
+
 relative_advantage[i] = score[i] - mean(group), score = normalized reward_g
 (NULL rows skipped), grouped by (objective_domain, task_class, node_type,
 code_region). Refinements preserved exactly: per-group shrinkage (K=5), EMA
@@ -36,6 +71,15 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
     DECAY_ALPHA = float(os.environ.get("MO_LEARNING_DECAY_ALPHA", "0.30"))
     HALFLIFE = float(os.environ.get("MO_LEARNING_HALFLIFE_DAYS", "14"))
     TIEBREAK = int(os.environ.get("MO_LEARNING_TIEBREAK", "1"))
+    # Cost-free contextual-bandit env knobs (D1-D3). Defaults per kickoff:
+    #   MO_ROUTER_UCB_C       default 0.5 → bandit ordering on by default
+    #   MO_ROUTER_SINGLE_SAMPLE default 1   → single-sample baselines on
+    #   MO_ROUTER_CONTEXTUAL  default 0   → NeuralUCB off (zero-cost default)
+    # Setting all three to 0 reproduces the legacy within-group-mean router
+    # byte-for-byte (verifier regression gate).
+    UCB_C = float(os.environ.get("MO_ROUTER_UCB_C", "0.5"))
+    SINGLE_SAMPLE = int(os.environ.get("MO_ROUTER_SINGLE_SAMPLE", "1"))
+    BANDIT_ON = UCB_C > 0.0
 
     con = sqlite3.connect(_db_path(db))
     con.execute("PRAGMA busy_timeout=5000")
@@ -46,7 +90,7 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
     ts_expr = "created_at" if "created_at" in cols else "NULL AS created_at"
     cost_expr = "cost_usd" if "cost_usd" in cols else "0.0 AS cost_usd"
 
-    prior_apm, prior_domain, prior_region = {}, {}, {}
+    prior_apm, prior_domain, prior_region, prior_baseline = {}, {}, {}, {}
     try:
         for row in con.execute(
                 "SELECT agent_version_id, task_class, relative_advantage "
@@ -60,6 +104,8 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
           node_type TEXT NOT NULL DEFAULT '', objective_domain TEXT NOT NULL DEFAULT '',
           relative_advantage REAL NOT NULL DEFAULT 0.0, runs_count INTEGER NOT NULL DEFAULT 0,
           success_count INTEGER NOT NULL DEFAULT 0,
+          advantage_var REAL NOT NULL DEFAULT 0.0, advantage_std REAL NOT NULL DEFAULT 0.0,
+          z_score_advantage REAL NOT NULL DEFAULT 0.0,
           last_updated TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           PRIMARY KEY (agent_version_id, task_class, node_type, objective_domain))""")
     try:
@@ -75,6 +121,8 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
           node_type TEXT NOT NULL DEFAULT '', objective_domain TEXT NOT NULL DEFAULT '',
           code_region TEXT NOT NULL DEFAULT '', relative_advantage REAL NOT NULL DEFAULT 0.0,
           runs_count INTEGER NOT NULL DEFAULT 0, success_count INTEGER NOT NULL DEFAULT 0,
+          advantage_var REAL NOT NULL DEFAULT 0.0, advantage_std REAL NOT NULL DEFAULT 0.0,
+          z_score_advantage REAL NOT NULL DEFAULT 0.0,
           last_updated TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
           PRIMARY KEY (agent_version_id, task_class, node_type, objective_domain, code_region))""")
     con.execute("""CREATE INDEX IF NOT EXISTS idx_lane_region_adv ON lane_region_advantage(
@@ -84,6 +132,28 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
                 "SELECT agent_version_id, task_class, node_type, objective_domain, "
                 "code_region, relative_advantage FROM lane_region_advantage").fetchall():
             prior_region[(row[0], row[1], row[2], row[3], row[4])] = row[5]
+    except Exception:
+        pass
+
+    # Defensive CREATE so a recompute against a DB where migration 0049 has
+    # not yet applied still finds lane_slice_baseline (D2). The schema lives
+    # in db/migrations/0049_lane_advantage_variance.sql.
+    con.execute("""CREATE TABLE IF NOT EXISTS lane_slice_baseline (
+          objective_domain TEXT NOT NULL DEFAULT '',
+          task_class       TEXT NOT NULL,
+          node_type        TEXT NOT NULL DEFAULT '',
+          code_region      TEXT NOT NULL DEFAULT '',
+          slice_mean       REAL NOT NULL DEFAULT 0.0,
+          slice_var        REAL NOT NULL DEFAULT 0.0,
+          slice_std        REAL NOT NULL DEFAULT 0.0,
+          runs_count       INTEGER NOT NULL DEFAULT 0,
+          last_updated     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+          PRIMARY KEY (objective_domain, task_class, node_type, code_region))""")
+    try:
+        for row in con.execute(
+                "SELECT objective_domain, task_class, node_type, code_region, slice_mean, "
+                "slice_var, runs_count FROM lane_slice_baseline").fetchall():
+            prior_baseline[(row[0], row[1], row[2], row[3])] = (row[4], row[5], row[6])
     except Exception:
         pass
 
@@ -136,15 +206,43 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
     acc = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0,
                                "node_types": defaultdict(int),
                                "objective_domains": defaultdict(int)})
-    acc_domain = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0})
-    acc_region = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0})
+    acc_domain = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0,
+                                      "var_sum": 0.0, "n_for_var": 0,
+                                      "slice_mean": 0.0, "slice_std": 0.0})
+    acc_region = defaultdict(lambda: {"shr_sum": 0.0, "groups": 0, "wins": 0,
+                                      "var_sum": 0.0, "n_for_var": 0,
+                                      "slice_mean": 0.0, "slice_std": 0.0})
+    acc_baseline = defaultdict(lambda: {"sum_score": 0.0, "sum_score_sq": 0.0,
+                                        "n": 0, "mean": 0.0, "var": 0.0})
     for (_od, _tc, _nt, _cr), members in groups.items():
+        # D2 single-sample fallback (MO_ROUTER_SINGLE_SAMPLE=1). With only
+        # one lane in the slice we cannot compute relative advantage (no
+        # group mean exists); instead, persist the score into the slice
+        # baseline so future recomputes can z-score against it. When
+        # MO_ROUTER_SINGLE_SAMPLE=0 the legacy "skip 1-member groups"
+        # behavior is preserved byte-equivalently.
         if len(members) < 2:
+            if SINGLE_SAMPLE and members:
+                _m = members[0]
+                b = acc_baseline[(_od, _tc, _nt, _cr)]
+                b["sum_score"] += _m["weight"] * _m["score"]
+                b["sum_score_sq"] += _m["weight"] * _m["score"] * _m["score"]
+                b["n"] += 1
             continue
         sum_w = sum(m["weight"] for m in members)
         if sum_w <= 0:
             continue
         wmean = sum(m["weight"] * m["score"] for m in members) / sum_w
+        # D3 z-score reference: also accumulate slice-wide wss statistics for
+        # lane_slice_baseline EMA update. Independent of BANDIT_ON so the
+        # baseline table fills even when the bandit is off — the baseline
+        # only feeds the bandit selector.
+        _slice_wss = sum(m["weight"] * m["score"] * m["score"] for m in members)
+        _slice_wsum = sum_w
+        sb = acc_baseline[(_od, _tc, _nt, _cr)]
+        sb["sum_score"] += sum(m["weight"] * m["score"] for m in members)
+        sb["sum_score_sq"] += _slice_wss
+        sb["n"] += 1
         lane_bonus = {}
         scores = [m["score"] for m in members]
         if TIEBREAK != 0 and min(scores) == max(scores):
@@ -153,18 +251,27 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
             if lo != hi:
                 for m in members:
                     lane_bonus[m["lane"]] = 0.1 - 0.2 * (m["cost"] - lo) / (hi - lo)
-        by_lane = defaultdict(lambda: {"ws": 0.0, "w": 0.0, "n": 0})
+        by_lane = defaultdict(lambda: {"ws": 0.0, "w": 0.0, "n": 0, "wss": 0.0})
         for m in members:
             b = by_lane[m["lane"]]
             b["ws"] += m["weight"] * m["score"]
             b["w"] += m["weight"]
             b["n"] += 1
+            b["wss"] += m["weight"] * m["score"] * m["score"]
         for lane, b in by_lane.items():
             lane_mean = b["ws"] / b["w"] if b["w"] > 0 else 0.0
             lane_adv = lane_mean - wmean + lane_bonus.get(lane, 0.0)
             n_in_group = b["n"]
             shrink_factor = n_in_group / (n_in_group + SHRINK_K) if SHRINK_K > 0 else 1.0
             shrunken = lane_adv * shrink_factor
+            # Per-lane weighted variance of scores within the slice's group
+            # window. var = E[x^2] - E[x]^2 (population formula; n >= 2
+            # here). NaN-safe — wss=0 or w=0 yields 0.
+            var = 0.0
+            if b["w"] > 0:
+                ex2 = b["wss"] / b["w"]
+                var = max(ex2 - lane_mean * lane_mean, 0.0)
+            std = math.sqrt(var)
             wins = 1 if lane_adv > 0 else 0
             a = acc[(lane, _tc)]
             a["shr_sum"] += shrunken
@@ -176,11 +283,15 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
             d["shr_sum"] += shrunken
             d["groups"] += 1
             d["wins"] += wins
+            d["var_sum"] += var
+            d["n_for_var"] += 1
             if _cr:
                 rr = acc_region[(lane, _tc, _nt, _od, _cr)]
                 rr["shr_sum"] += shrunken
                 rr["groups"] += 1
                 rr["wins"] += wins
+                rr["var_sum"] += var
+                rr["n_for_var"] += 1
 
     _penalty_by_key = defaultdict(float)
     try:
@@ -225,6 +336,51 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
             return batch
         return DECAY_ALPHA * batch + (1.0 - DECAY_ALPHA) * p
 
+    # D2 EMA-blend slice baselines BEFORE the per-lane upserts so the
+    # z-score normaliser in BANDIT_ON mode sees the same prior the lane
+    # advantage will be compared against.
+    for key, stats in acc_baseline.items():
+        _od, _tc, _nt, _cr = key
+        if stats["n"] <= 0:
+            continue
+        batch_mean = stats["sum_score"] / stats["n"]
+        ex2 = stats["sum_score_sq"] / stats["n"]
+        batch_var = max(ex2 - batch_mean * batch_mean, 0.0)
+        prior_t = prior_baseline.get(key)
+        if prior_t is None:
+            new_mean, new_var = batch_mean, batch_var
+        else:
+            new_mean = _ema(prior_t[0], batch_mean)
+            new_var = _ema(prior_t[1], batch_var)
+        new_std = math.sqrt(max(new_var, 0.0))
+        con.execute("""INSERT INTO lane_slice_baseline
+                (objective_domain, task_class, node_type, code_region,
+                 slice_mean, slice_var, slice_std, runs_count, last_updated)
+                VALUES (?,?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                ON CONFLICT(objective_domain, task_class, node_type, code_region)
+                DO UPDATE SET slice_mean=excluded.slice_mean,
+                slice_var=excluded.slice_var, slice_std=excluded.slice_std,
+                runs_count=excluded.runs_count, last_updated=excluded.last_updated""",
+                    (_od, _tc, _nt, _cr,
+                     round(new_mean, 6), round(new_var, 6), round(new_std, 6),
+                     stats["n"]))
+        # Cache locally for the z-score step below.
+        stats["mean"], stats["var"] = new_mean, new_var
+
+    def _z_score(lane_adv: float, key) -> float:
+        """D3 z-score = (lane_adv - slice_baseline_mean) /
+        max(slice_baseline_std, 1e-3). Pure read of the freshly-updated
+        acc_baseline cache; falls back to lane_adv itself when the slice
+        is cold (no baseline row AND no current accumulators)."""
+        baseline = acc_baseline.get(key)
+        if not baseline or baseline.get("n", 0) == 0:
+            return lane_adv
+        m = baseline.get("mean", 0.0)
+        v = baseline.get("var", 0.0)
+        std = math.sqrt(max(v, 0.0))
+        denom = std if std > 1e-3 else 1e-3
+        return (lane_adv - m) / denom
+
     upserted = 0
     for (lane, tc), stats in acc.items():
         if stats["groups"] <= 0:
@@ -249,16 +405,27 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
             continue
         new_rel_adv = _ema(prior_domain.get((lane, tc, nt or "", od or "")),
                            stats["shr_sum"] / stats["groups"])
+        if BANDIT_ON and stats.get("n_for_var", 0) > 0:
+            adv_var = stats["var_sum"] / stats["n_for_var"]
+            adv_std = math.sqrt(max(adv_var, 0.0))
+            new_z = _z_score(new_rel_adv, (od, tc, nt or "", ""))
+        else:
+            adv_var, adv_std, new_z = 0.0, 0.0, 0.0
         con.execute("""INSERT INTO lane_domain_advantage
                 (agent_version_id, task_class, node_type, objective_domain,
-                 relative_advantage, runs_count, success_count, last_updated)
-                VALUES (?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                 relative_advantage, runs_count, success_count,
+                 advantage_var, advantage_std, z_score_advantage, last_updated)
+                VALUES (?,?,?,?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
                 ON CONFLICT(agent_version_id, task_class, node_type, objective_domain)
                 DO UPDATE SET relative_advantage=excluded.relative_advantage,
                 runs_count=excluded.runs_count, success_count=excluded.success_count,
+                advantage_var=excluded.advantage_var,
+                advantage_std=excluded.advantage_std,
+                z_score_advantage=excluded.z_score_advantage,
                 last_updated=excluded.last_updated""",
                     (lane, tc, nt or "", od or "", round(new_rel_adv, 4),
-                     stats["groups"], stats["wins"]))
+                     stats["groups"], stats["wins"],
+                     round(adv_var, 6), round(adv_std, 6), round(new_z, 4)))
 
     for (lane, tc, nt, od, cr), stats in acc_region.items():
         if stats["groups"] <= 0:
@@ -267,16 +434,31 @@ def recompute_advantages(since: int = 0, db: str | None = None) -> int:
                            stats["shr_sum"] / stats["groups"])
         if cr:
             new_rel_adv += _penalty_by_key.get((lane, cr, tc), 0.0)
+        # D1/D3: when the bandit is on, mirror the per-region variance + z-score
+        # so preferred_lane() can rank by UCB. Penalty fold applies to the
+        # scored number (the z-score is computed against the un-penalised
+        # baseline), keeping the bonus a heuristic ordering term.
+        if BANDIT_ON and stats.get("n_for_var", 0) > 0:
+            adv_var = stats["var_sum"] / stats["n_for_var"]
+            adv_std = math.sqrt(max(adv_var, 0.0))
+            new_z = _z_score(new_rel_adv, (od, tc, nt or "", cr or ""))
+        else:
+            adv_var, adv_std, new_z = 0.0, 0.0, 0.0
         con.execute("""INSERT INTO lane_region_advantage
                 (agent_version_id, task_class, node_type, objective_domain, code_region,
-                 relative_advantage, runs_count, success_count, last_updated)
-                VALUES (?,?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                 relative_advantage, runs_count, success_count,
+                 advantage_var, advantage_std, z_score_advantage, last_updated)
+                VALUES (?,?,?,?,?,?,?,?,?,?,?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
                 ON CONFLICT(agent_version_id, task_class, node_type, objective_domain, code_region)
                 DO UPDATE SET relative_advantage=excluded.relative_advantage,
                 runs_count=excluded.runs_count, success_count=excluded.success_count,
+                advantage_var=excluded.advantage_var,
+                advantage_std=excluded.advantage_std,
+                z_score_advantage=excluded.z_score_advantage,
                 last_updated=excluded.last_updated""",
                     (lane, tc, nt or "", od or "", cr or "", round(new_rel_adv, 4),
-                     stats["groups"], stats["wins"]))
+                     stats["groups"], stats["wins"],
+                     round(adv_var, 6), round(adv_std, 6), round(new_z, 4)))
 
     con.commit()
     con.close()
@@ -287,10 +469,29 @@ def preferred_lane(task_class: str, node_type: str = "", objective_domain: str =
                    code_region: str = "", db: str | None = None) -> str:
     """Highest-advantage lane for the slice (sample floor MO_LEARNING_MIN_SAMPLES,
     default 3). Region → domain → global, matching bash. Returns
-    'lane|adv|runs' (bash's pipe format) or '' when no slice clears the floor."""
+    'lane|adv|runs' (bash's pipe format) or '' when no slice clears the floor.
+
+    Bandit selector (MO_ROUTER_UCB_C > 0): when the active slice has z-scored
+    advantages stored, the ordering switches to UCB
+    ``z_score_advantage + C * sqrt(2 * ln(N) / n_lane)`` so under-sampled lanes
+    get explored. The displayed ``adv`` field remains the legacy
+    ``relative_advantage`` value so bash/python parity still prints the same
+    string when both code paths converge on the same winner.
+
+    NeuralUCB (MO_ROUTER_CONTEXTUAL=1) lives inside the gated branch: when
+    two lanes tie on the UCB score within 1e-6, the HashEmbedder feature
+    ``(task_class, node_type, code_region)`` is run through a per-lane ridge
+    regression and the lane with the higher ridge score wins. The embedder
+    import + call happen ONLY in this branch — the default path makes zero
+    extra per-task model calls (D7)."""
     min_samples = int(os.environ.get("MO_LEARNING_MIN_SAMPLES", "3"))
+    ucb_c = float(os.environ.get("MO_ROUTER_UCB_C", "0.5"))
+    contextual = int(os.environ.get("MO_ROUTER_CONTEXTUAL", "0"))
+    bandit_on = ucb_c > 0.0
+
     con = sqlite3.connect(_db_path(db))
     con.execute("PRAGMA busy_timeout=5000")
+    con.row_factory = sqlite3.Row  # _select_best_lane reads rows by column name
     try:
         if objective_domain and code_region:
             where = ("task_class=? AND objective_domain=? AND code_region=? AND runs_count>=?")
@@ -298,29 +499,29 @@ def preferred_lane(task_class: str, node_type: str = "", objective_domain: str =
             if node_type:
                 where += " AND node_type=?"
                 params.append(node_type)
-            row = con.execute(
-                f"SELECT agent_version_id, printf('%.3f', relative_advantage), runs_count "
-                f"FROM lane_region_advantage WHERE {where} "
-                f"ORDER BY relative_advantage DESC, runs_count DESC LIMIT 1", params).fetchone()
+            row = _select_best_lane(con, "lane_region_advantage", where, params,
+                                    bandit_on, ucb_c, contextual,
+                                    task_class, node_type, objective_domain, code_region)
             if row:
-                return f"{row[0]}|{row[1]}|{row[2]}"
+                return row
         if objective_domain:
             where = "task_class=? AND objective_domain=? AND runs_count>=?"
             params = [task_class, objective_domain, min_samples]
             if node_type:
                 where += " AND node_type=?"
                 params.append(node_type)
-            row = con.execute(
-                f"SELECT agent_version_id, printf('%.3f', relative_advantage), runs_count "
-                f"FROM lane_domain_advantage WHERE {where} "
-                f"ORDER BY relative_advantage DESC, runs_count DESC LIMIT 1", params).fetchone()
+            row = _select_best_lane(con, "lane_domain_advantage", where, params,
+                                    bandit_on, ucb_c, contextual,
+                                    task_class, node_type, objective_domain, code_region)
             if row:
-                return f"{row[0]}|{row[1]}|{row[2]}"
+                return row
         where = "task_class=? AND runs_count>=?"
         params = [task_class, min_samples]
         if node_type:
             where += " AND (role=? OR model=?)"
             params += [node_type, node_type]
+        # Global (agent_performance_memory) has no per-slice z-score — bandit
+        # ordering degrades to relative_advantage DESC on the global pool.
         row = con.execute(
             f"SELECT agent_version_id, printf('%.3f', relative_advantage), runs_count "
             f"FROM agent_performance_memory WHERE {where} "
@@ -328,3 +529,123 @@ def preferred_lane(task_class: str, node_type: str = "", objective_domain: str =
         return f"{row[0]}|{row[1]}|{row[2]}" if row else ""
     finally:
         con.close()
+
+
+def _select_best_lane(con, table: str, where: str, params: list,
+                      bandit_on: bool, ucb_c: float, contextual: int,
+                      task_class: str, node_type: str,
+                      objective_domain: str, code_region: str) -> str:
+    """D1/D7 lane picker. Returns the bash-format 'lane|adv|runs' string.
+
+    Bandit path:
+      1. SELECT all lanes clearing the sample floor, ordered by raw
+         relative_advantage DESC so we don't lose the cost tie-break signal.
+      2. If bandit_on and the table has z-scored rows, recompute the UCB
+         score ``z_score_advantage + C * sqrt(2 ln N_total / n_lane)`` and
+         return the lane with the highest UCB. The ``adv`` field shown
+         stays the legacy ``relative_advantage`` so bash/python parity is
+         maintained for callers that diff the string.
+      3. If contextual=1 and the top two UCB scores tie within 1e-6, run
+         NeuralUCB (HashEmbedder featurize → per-lane ridge) on the tied
+         candidates. The embedder import + call live strictly inside this
+         branch.
+    """
+    cur = con.execute(
+        f"SELECT agent_version_id, printf('%.3f', relative_advantage) AS adv_str, "
+        f"runs_count, z_score_advantage "
+        f"FROM {table} WHERE {where} "
+        f"ORDER BY relative_advantage DESC, runs_count DESC",
+        params)
+    candidates = cur.fetchall()
+    if not candidates:
+        return ""
+    if not bandit_on:
+        # Legacy face: take the first row (already sorted by relative_advantage DESC).
+        first = candidates[0]
+        return f"{first[0]}|{first[1]}|{first[2]}"
+    total_runs = sum(int(r["runs_count"]) for r in candidates) or 1
+    scored = []
+    for r in candidates:
+        z = float(r["z_score_advantage"] or 0.0)
+        n = max(int(r["runs_count"]), 1)
+        # UCB1 with slice-wide N_total — favours lanes with high z and low n.
+        bonus = ucb_c * math.sqrt(2.0 * math.log(total_runs + 1) / n)
+        scored.append((z + bonus, r))
+    scored.sort(key=lambda t: t[0], reverse=True)
+    if contextual and len(scored) >= 2:
+        # Tie-break via NeuralUCB on top-2 candidates (D7).
+        # Linear-posterior style: context feature x = embedder(slice identity);
+        # per-lane weight w = embedder(lane). Score = x . w. The lane with
+        # the larger dot product wins the tie. Deterministic — same input
+        # always produces the same ordering.
+        if abs(scored[0][0] - scored[1][0]) < 1e-6:
+            try:
+                # Embedder import + call strictly inside the gated branch.
+                from mini_ork.memory.semantic import HashEmbedder
+                emb = HashEmbedder()
+                ctx = emb.embed([
+                    f"{task_class}|{node_type}|{objective_domain}|{code_region}"
+                ])[0]
+                w0 = emb.embed([scored[0][1][0]])[0]
+                w1 = emb.embed([scored[1][1][0]])[0]
+                s0 = sum(a * b for a, b in zip(ctx, w0))
+                s1 = sum(a * b for a, b in zip(ctx, w1))
+                if s1 > s0:
+                    scored = [scored[1], scored[0]] + scored[2:]
+            except Exception:
+                # On any failure, keep the UCB order — never raise out of the
+                # selector for tie-break noise.
+                pass
+    best = scored[0][1]
+    return f"{best[0]}|{best[1]}|{best[2]}"
+
+
+def log_propensity(trace_id: int, source: str, explore: int, score: float,
+                   *, db: str | None = None) -> None:
+    """D4: stamp route_source / route_explore / route_score on a routed trace
+    row. Called by the executor after the lane is picked. Null-safe: leaves
+    the row untouched if the trace no longer exists."""
+    con = sqlite3.connect(_db_path(db))
+    try:
+        con.execute(
+            "UPDATE execution_traces SET route_source = ?, route_explore = ?, "
+            "route_score = ? WHERE id = ?",
+            (source, int(bool(explore)), float(score), trace_id))
+        con.commit()
+    except Exception:
+        pass
+    finally:
+        con.close()
+
+
+def z_score_advantage(lane: str, task_class: str, node_type: str = "",
+                      objective_domain: str = "", code_region: str = "",
+                      db: str | None = None) -> float:
+    """Read-only convenience for callers (and the bandit selector's tests):
+    return the most-specific z_score_advantage for ``lane`` in the slice, or
+    0.0 if no row clears the sample floor."""
+    min_samples = int(os.environ.get("MO_LEARNING_MIN_SAMPLES", "3"))
+    con = sqlite3.connect(_db_path(db))
+    try:
+        if objective_domain and code_region:
+            row = con.execute(
+                "SELECT z_score_advantage FROM lane_region_advantage "
+                "WHERE agent_version_id=? AND task_class=? AND node_type=? "
+                "AND objective_domain=? AND code_region=? AND runs_count>=? "
+                "ORDER BY runs_count DESC LIMIT 1",
+                (lane, task_class, node_type or "", objective_domain,
+                 code_region, min_samples)).fetchone()
+            if row:
+                return float(row[0] or 0.0)
+        if objective_domain:
+            row = con.execute(
+                "SELECT z_score_advantage FROM lane_domain_advantage "
+                "WHERE agent_version_id=? AND task_class=? AND node_type=? "
+                "AND objective_domain=? AND runs_count>=? "
+                "ORDER BY runs_count DESC LIMIT 1",
+                (lane, task_class, node_type or "", objective_domain, min_samples)).fetchone()
+            if row:
+                return float(row[0] or 0.0)
+    finally:
+        con.close()
+    return 0.0


### PR DESCRIPTION
## What
Cost-free upgrade to the lane router so it learns better from the runs it **already** does — **zero** extra model calls on the default path.

### The core problem this fixes
`recompute_advantages` skipped any slice with `len(members) < 2` — i.e. the router only learned from panel/bake-off runs where 2+ lanes ran the same task. Normal 1× runs contributed **nothing**. To learn at all you were already paying the G× cost this work avoids.

### Delivered (green: migration applies, `pytest tests/unit/test_lane_router_py.py` 2/2, refinements 5/5)
- **D2 — persistent single-sample baseline** (`lane_slice_baseline`, SPO 2509.13232): router now learns from 1× runs.
- **D3 — z-score advantage normalization** (REINFORCE++ 2501.03262).
- **D1 (ordering) — UCB selection** in `preferred_lane` (py + `lib/lane_router.sh`): `z + C·√(2lnN/n)`, under-sampled lanes explored (NeuralUCB 2603.30035 / PILOT 2508.21141).
- **D7 — NeuralUCB tie-break** via `HashEmbedder`, `MO_ROUTER_CONTEXTUAL` default **0** (zero-cost default).

### Regression-safety
`MO_ROUTER_UCB_C=0 MO_ROUTER_SINGLE_SAMPLE=0` reproduces the legacy within-group-mean router. Migration 0049 is additive + idempotent.

### Honesty
This is a **cost-aware contextual bandit, not GRPO**. No off-policy correction is attempted (fails under near-deterministic logging, 2509.00648 Fig 3g). Migration header + docstring say so.

### Follow-up (separate framework-edit run)
D1 `decision_service.sh` ε-reroute · D4 propensity writer (columns reserved here) · D5 per-node credit · D6 `router_replay_eval.py` · bandit tests · Appendix A1.

### Fixes applied on top of the framework-edit output
Migration ALTER'd `lane_region_advantage` before it existed (guarded w/ CREATE); duplicate-column from separate-connection visibility (base schema + shim); `preferred_lane` missing `row_factory = sqlite3.Row`.