### PR TITLE
feat(evals): held-out compounding-curve eval harness (budget-matched)

### DIFF
--- a/evals/heldout/manifest.json
+++ b/evals/heldout/manifest.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "t1",
+    "dir": "t1",
+    "gold_test_cmd": "pytest evals/heldout/tasks/t1/test_t1.py -q",
+    "note": "word_count: counts only ASCII spaces; off-by-one on empty string"
+  },
+  {
+    "id": "t2",
+    "dir": "t2",
+    "gold_test_cmd": "pytest evals/heldout/tasks/t2/test_t2.py -q",
+    "note": "flatten: only flattens one level; nested lists past depth one survive"
+  },
+  {
+    "id": "t3",
+    "dir": "t3",
+    "gold_test_cmd": "pytest evals/heldout/tasks/t3/test_t3.py -q",
+    "note": "fizzbuzz: returns only Fizz for multiples of 15; should be FizzBuzz"
+  }
+]

--- a/evals/heldout/tasks/t1/solution.py
+++ b/evals/heldout/tasks/t1/solution.py
@@ -1,0 +1,12 @@
+"""Word-count helper shipped with a known bug for held-out eval.
+
+The shipped implementation counts only ASCII spaces and applies an
+off-by-one correction for the empty case. The gold test exposes both
+flaws; the obvious fix splits on whitespace and returns 0 for "".
+"""
+
+
+def count_words(s: str) -> int:
+    if not s:
+        return 1
+    return len(s) - s.count(" ") + 1

--- a/evals/heldout/tasks/t1/test_t1.py
+++ b/evals/heldout/tasks/t1/test_t1.py
@@ -1,0 +1,17 @@
+from solution import count_words
+
+
+def test_counts_words_split_by_whitespace():
+    assert count_words("hello world") == 2
+
+
+def test_handles_tabs_and_newlines():
+    assert count_words("hello\tworld\nfoo") == 3
+
+
+def test_empty_string_is_zero():
+    assert count_words("") == 0
+
+
+def test_multiple_internal_spaces():
+    assert count_words("a   b") == 2

--- a/evals/heldout/tasks/t2/solution.py
+++ b/evals/heldout/tasks/t2/solution.py
@@ -1,0 +1,16 @@
+"""Flatten helper shipped with a known bug for held-out eval.
+
+The shipped implementation only flattens one level; nested lists past
+depth one survive. The gold test exercises a 3-deep nested case; the
+obvious fix recurses on items that are still lists.
+"""
+
+
+def flatten(lst):
+    out = []
+    for item in lst:
+        if isinstance(item, list):
+            out.extend(item)
+        else:
+            out.append(item)
+    return out

--- a/evals/heldout/tasks/t2/test_t2.py
+++ b/evals/heldout/tasks/t2/test_t2.py
@@ -1,0 +1,17 @@
+from solution import flatten
+
+
+def test_flattens_already_flat():
+    assert flatten([1, 2, 3]) == [1, 2, 3]
+
+
+def test_flattens_one_level():
+    assert flatten([1, [2, 3], 4]) == [1, 2, 3, 4]
+
+
+def test_flattens_deeply_nested():
+    assert flatten([[1, [2, [3, 4]]], 5]) == [1, 2, 3, 4, 5]
+
+
+def test_empty_list():
+    assert flatten([]) == []

--- a/evals/heldout/tasks/t3/solution.py
+++ b/evals/heldout/tasks/t3/solution.py
@@ -1,0 +1,14 @@
+"""FizzBuzz helper shipped with a known bug for held-out eval.
+
+The shipped implementation returns only "Fizz" for multiples of 15.
+The gold test asserts the canonical "FizzBuzz" label for n in {15, 30};
+the obvious fix checks the joint divisibility first.
+"""
+
+
+def fizzbuzz(n: int) -> str:
+    if n % 3 == 0:
+        return "Fizz"
+    if n % 5 == 0:
+        return "Buzz"
+    return str(n)

--- a/evals/heldout/tasks/t3/test_t3.py
+++ b/evals/heldout/tasks/t3/test_t3.py
@@ -1,0 +1,21 @@
+from solution import fizzbuzz
+
+
+def test_multiples_of_three():
+    assert fizzbuzz(3) == "Fizz"
+    assert fizzbuzz(9) == "Fizz"
+
+
+def test_multiples_of_five():
+    assert fizzbuzz(5) == "Buzz"
+    assert fizzbuzz(25) == "Buzz"
+
+
+def test_multiples_of_fifteen_are_fizzbuzz():
+    assert fizzbuzz(15) == "FizzBuzz"
+    assert fizzbuzz(30) == "FizzBuzz"
+
+
+def test_other_numbers_pass_through():
+    assert fizzbuzz(1) == "1"
+    assert fizzbuzz(7) == "7"

--- a/scripts/heldout_eval.py
+++ b/scripts/heldout_eval.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Pure JSON-driven held-out eval scorer.
+
+Reads a manifest and a per-task results JSON, walks tasks in manifest order,
+computes resolve_rate and resolve_per_dollar with an optional budget cap, and
+emits a single JSON line on stdout (and to --out when provided).
+
+No network. No subprocess. No state. Deterministic by manifest order.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="heldout_eval",
+        description="JSON-driven held-out eval scorer (no LLM, no subprocess).",
+    )
+    p.add_argument("--manifest", required=True, type=Path,
+                   help="Path to manifest.json (list of {id, dir, gold_test_cmd, note}).")
+    p.add_argument("--results", required=True, type=Path,
+                   help="Path to results.json ({task_id: {passed: bool, cost_usd: float}}).")
+    p.add_argument("--out", type=Path, default=None,
+                   help="Optional output path; JSON line is also printed to stdout.")
+    p.add_argument("--arm", required=True, choices=["on", "off"],
+                   help="Arm label passed through to the output line.")
+    p.add_argument("--epoch", required=True, type=int,
+                   help="Epoch index passed through to the output line.")
+    p.add_argument("--budget-usd", type=float, default=None,
+                   help="Optional cap on cumulative cost; tasks whose inclusion "
+                        "would exceed the cap are skipped.")
+    return p.parse_args(argv)
+
+
+def score(
+    manifest: Any,
+    results: Any,
+    *,
+    arm: str,
+    epoch: int,
+    budget_usd: float | None,
+) -> dict[str, Any]:
+    if not isinstance(manifest, list):
+        raise ValueError("manifest must be a JSON list")
+    if not isinstance(results, dict):
+        raise ValueError("results must be a JSON object keyed by task id")
+    tasks_scored = 0
+    passed = 0
+    cost_usd = 0.0
+    for entry in manifest:
+        if not isinstance(entry, dict):
+            raise ValueError("each manifest entry must be an object")
+        tid = entry.get("id")
+        if not isinstance(tid, str):
+            raise ValueError("manifest entry missing string 'id'")
+        row = results.get(tid)
+        if row is None:
+            continue
+        try:
+            task_cost = float(row.get("cost_usd", 0.0) or 0.0)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"results[{tid!r}].cost_usd is not numeric") from exc
+        if budget_usd is not None and (cost_usd + task_cost) > budget_usd:
+            break
+        cost_usd += task_cost
+        tasks_scored += 1
+        if bool(row.get("passed", False)):
+            passed += 1
+    resolve_rate = (passed / tasks_scored) if tasks_scored else 0.0
+    if cost_usd == 0:
+        resolve_per_dollar = 0.0
+    else:
+        resolve_per_dollar = resolve_rate / cost_usd
+    return {
+        "arm": arm,
+        "epoch": epoch,
+        "resolve_rate": resolve_rate,
+        "cost_usd": cost_usd,
+        "resolve_per_dollar": resolve_per_dollar,
+        "tasks_scored": tasks_scored,
+        "budget_usd": budget_usd,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    manifest = json.loads(args.manifest.read_text())
+    results = json.loads(args.results.read_text())
+    out = score(
+        manifest,
+        results,
+        arm=args.arm,
+        epoch=args.epoch,
+        budget_usd=args.budget_usd,
+    )
+    line = json.dumps(out)
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(line + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_heldout_eval_py.py
+++ b/tests/unit/test_heldout_eval_py.py
@@ -1,0 +1,129 @@
+"""Unit tests for scripts/heldout_eval.py — the pure JSON-driven scorer.
+
+Covers: resolve_per_dollar math on a known fixture, --budget-usd caps
+tasks_scored deterministically in manifest order, zero-cost yields
+resolve_per_dollar=0.0, and arm/epoch passthrough.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "heldout_eval.py"
+MANIFEST = REPO / "evals" / "heldout" / "manifest.json"
+
+
+def _run_cli(results: dict, *, arm: str = "off", epoch: int = 0, budget_usd: float | None = None,
+             out_path: Path | None = None) -> dict:
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(results, f)
+        results_path = Path(f.name)
+    try:
+        cmd = [
+            sys.executable, str(SCRIPT),
+            "--manifest", str(MANIFEST),
+            "--results", str(results_path),
+            "--arm", arm,
+            "--epoch", str(epoch),
+        ]
+        if budget_usd is not None:
+            cmd += ["--budget-usd", str(budget_usd)]
+        if out_path is not None:
+            cmd += ["--out", str(out_path)]
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(proc.stdout.strip())
+    finally:
+        results_path.unlink(missing_ok=True)
+
+
+def test_resolve_per_dollar_math_on_known_fixture():
+    out = _run_cli({
+        "t1": {"passed": True, "cost_usd": 0.5},
+        "t2": {"passed": False, "cost_usd": 0.3},
+        "t3": {"passed": True, "cost_usd": 0.2},
+    })
+    assert out["arm"] == "off"
+    assert out["epoch"] == 0
+    assert out["tasks_scored"] == 3
+    assert out["resolve_rate"] == pytest.approx(2 / 3)
+    assert out["cost_usd"] == pytest.approx(1.0)
+    assert out["resolve_per_dollar"] == pytest.approx(2 / 3)
+    assert out["budget_usd"] is None
+
+
+def test_budget_cap_deterministic():
+    # Manifest order is [t1, t2, t3] with costs 0.5/0.3/0.2.
+    # budget=0.7 → t1 fits (0.5), t2 would push to 0.8 > 0.7 → stop.
+    out = _run_cli({
+        "t1": {"passed": True, "cost_usd": 0.5},
+        "t2": {"passed": True, "cost_usd": 0.3},
+        "t3": {"passed": True, "cost_usd": 0.2},
+    }, budget_usd=0.7)
+    assert out["tasks_scored"] == 1
+    assert out["cost_usd"] == pytest.approx(0.5)
+    assert out["resolve_rate"] == pytest.approx(1.0)
+    assert out["resolve_per_dollar"] == pytest.approx(2.0)
+
+
+def test_zero_cost_yields_zero_per_dollar():
+    out = _run_cli({
+        "t1": {"passed": True, "cost_usd": 0.0},
+    })
+    assert out["cost_usd"] == 0.0
+    assert out["resolve_per_dollar"] == 0.0
+    assert out["resolve_rate"] == pytest.approx(1.0)
+    assert out["tasks_scored"] == 1
+
+
+def test_arm_and_epoch_passthrough():
+    out = _run_cli({"t1": {"passed": True, "cost_usd": 0.5}}, arm="on", epoch=7)
+    assert out["arm"] == "on"
+    assert out["epoch"] == 7
+
+
+def test_cli_writes_out_file_when_provided():
+    with tempfile.TemporaryDirectory() as td:
+        out_path = Path(td) / "line.jsonl"
+        line = _run_cli(
+            {"t1": {"passed": True, "cost_usd": 0.5}},
+            out_path=out_path,
+        )
+        text = out_path.read_text()
+        assert text.endswith("\n")
+        assert json.loads(text) == line
+
+
+def test_cli_smoke_matches_documented_contract():
+    # Reproduces the cli_smoke contract from the verifier plan verbatim.
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump({
+            "t1": {"passed": True, "cost_usd": 0.5},
+            "t2": {"passed": False, "cost_usd": 0.3},
+            "t3": {"passed": True, "cost_usd": 0.2},
+        }, f)
+        results_path = Path(f.name)
+    try:
+        proc = subprocess.run(
+            [
+                sys.executable, str(SCRIPT),
+                "--manifest", str(MANIFEST),
+                "--results", str(results_path),
+                "--arm", "off",
+                "--epoch", "0",
+            ],
+            capture_output=True, text=True, check=True,
+        )
+        out = json.loads(proc.stdout.strip())
+        assert out["arm"] == "off"
+        assert out["epoch"] == 0
+        assert out["resolve_rate"] == pytest.approx(2 / 3)
+        assert out["cost_usd"] == pytest.approx(1.0)
+        assert out["resolve_per_dollar"] == pytest.approx(2 / 3)
+    finally:
+        results_path.unlink(missing_ok=True)


### PR DESCRIPTION
## What (Workstream A foundation — the fundability artifact)
The measurement foundation for the **compounding curve** (resolve-rate-per-$ climbing run-over-run vs a compute-matched stateless baseline). With the scientific controls baked in.

- `evals/heldout/` — fixed, held-out benchmark: 3 red-by-design code-fix tasks (word_count off-by-one, one-level flatten, missing FizzBuzz), gold pytest fails on the bug, passes when fixed. Never fed to the loop (rules out overfitting, arXiv `2604.18951`).
- `scripts/heldout_eval.py` — pure deterministic scorer: `resolve_rate`, `resolve_per_dollar` (div-by-zero guarded), `--budget-usd` cap that stops in manifest order so **ON vs OFF arms compare at equal compute** (the control arXiv `2509.21882` requires). `--arm/--epoch` passthrough.
- 6 test assertions (metric math, budget cap, div-by-zero, labels).

Rests on the execution-anchored reward (#168) → the metric measures a **verified** signal. The loop-driver / ON-vs-OFF runner is a deliberate follow-on.

## Verification (mine)
`python -m pytest tests/unit/test_heldout_eval_py.py -q` → **6 passed**; each seed gold test confirmed red-by-design (fails on shipped bug).

## Note
Known minor nit: the 3 tasks share a `solution` module name, so `pytest evals/heldout/tasks/` (all at once) collides; the manifest runs them one-file-at-a-time via `gold_test_cmd` (the intended path), which is unaffected. Follow-on can add per-task isolation.

## Provenance
Produced by **mini-ork dogfooding itself** — framework-edit `run-1783860043-49163`. Gated on real smoke; the run's `fail` verdict was the known empty-diff-capture false-negative (files were written to disk, verified directly).