### PR TITLE
fix(plan): stop rejecting JSX/HTML tags as dry-run placeholders

### DIFF
--- a/mini_ork/ported/mini_ork_plan.py
+++ b/mini_ork/ported/mini_ork_plan.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -122,15 +123,52 @@ def _objects(s):
             return
 
 
+# A genuine unfilled stub carries a stub word (the dry-run placeholder reads
+# "<dry-run: not generated>"). A bare angle-bracketed identifier does NOT.
+_PLACEHOLDER_HINT = re.compile(
+    r"\b(dry[- ]?run|not[- ]generated|todo|tbd|fixme|fill[- ]?(me|in)?|xxx|placeholder)\b",
+    re.I,
+)
+
+
+def _is_stub_string(v) -> bool:
+    """True only for an UNFILLED template value — not for code that uses angle brackets."""
+    if not isinstance(v, str):
+        return False
+    s = v.strip()
+    if not (s.startswith("<") and s.endswith(">")):
+        return False
+    inner = s[1:-1].strip()
+    if not inner:
+        return True
+    # "<dry-run: not generated>", "<TODO>", "<fill me>" -> a real stub
+    # "<ContentNodeCreationModal>", "<div>", "<Foo />"   -> real code
+    return bool(_PLACEHOLDER_HINT.search(inner))
+
+
 def _contains_placeholder(v):
-    if isinstance(v, str):
-        stripped = v.strip()
-        return stripped.startswith("<") and stripped.endswith(">")
-    if isinstance(v, list):
-        return any(_contains_placeholder(x) for x in v)
+    """True when the PLAN ITSELF was never generated (i.e. it is the dry-run stub).
+
+    Scope matters. The old check recursed into EVERY nested string and flagged anything
+    shaped like `<...>`. That rejected two entirely legitimate things:
+
+      * JSX/HTML tags a plan naturally names — "<ContentNodeCreationModal>" — which made
+        mini-ork unable to plan work on ANY React/JSX codebase; and
+      * the planner's own step annotations — "<shell-only>", "<analysis-only — no edit>"
+        — meaning "this step edits no file".
+
+    A *placeholder plan* means the planner produced nothing: the dry-run stub, whose
+    objective is "<dry-run: not generated>" and whose decomposition is empty. Judge the
+    plan by its objective (and emptiness), not by every string inside it.
+    """
     if isinstance(v, dict):
-        return any(_contains_placeholder(x) for x in v.values())
-    return False
+        if _is_stub_string(v.get("objective")):
+            return True
+        # the dry-run stub is an empty shell: no objective, nothing to do
+        if not str(v.get("objective") or "").strip() and not (v.get("decomposition") or []):
+            return True
+        return False
+    return _is_stub_string(v)
 
 
 def _is_plan(obj):

--- a/tests/unit/test_mini_ork_plan_py.py
+++ b/tests/unit/test_mini_ork_plan_py.py
@@ -261,3 +261,39 @@ def test_mo_plan_deterministic_fallback_opt_in(tmp_path):
     assert rc == 0
     assert dispatch.calls["n"] == 1
     assert json.loads(Path(out).read_text())["objective"].startswith("Execute recipe ")
+
+
+
+def test_jsx_tags_are_not_placeholders():
+    """A plan for a React/JSX codebase names component tags. Those are CODE, not stubs.
+
+    Regression: the old check flagged ANY string shaped like `<...>`, anywhere in the plan.
+    A legitimate plan mentioning "<ContentNodeCreationModal>" was therefore rejected as a
+    dry-run placeholder -- which made mini-ork unable to plan work on any React/JSX repo.
+    """
+    jsx = {
+        **_VALID,
+        "objective": "Remove duplicate ContentNodeCreationModal mounts",
+        "decomposition": [
+            {"id": "s1", "node_type": "implementer", "depends_on": [],
+             "description": "HighlightableText renders <ContentNodeCreationModal /> directly; "
+                            "route it through the provider instead."},
+            # the planner annotates non-editing steps this way -- also angle-bracketed
+            {"id": "s2", "node_type": "verifier", "depends_on": ["s1"],
+             "description": "<shell-only>"},
+        ],
+    }
+    assert plan.validate_plan(json.dumps(jsx)) == "ok"
+
+
+def test_dry_run_stub_still_rejected():
+    """The thing the check actually exists for must still be caught."""
+    assert plan.validate_plan(plan._DRY_RUN_PLACEHOLDER) == "placeholder_plan"
+
+    # an objective that is an unfilled template value, with nothing to do
+    stub = {**_VALID, "objective": "<TODO>", "decomposition": []}
+    assert plan.validate_plan(json.dumps(stub)) == "placeholder_plan"
+
+    # an empty shell: no objective, no steps
+    empty = {**_VALID, "objective": "", "decomposition": []}
+    assert plan.validate_plan(json.dumps(empty)) == "placeholder_plan"


### PR DESCRIPTION
`validate_plan()` treated **any** string shaped like `<...>` — at any depth — as an unfilled dry-run placeholder.

A plan for a React codebase naturally names component tags. `"<ContentNodeCreationModal>"` in a step description was therefore read as a stub, and the whole plan was rejected `placeholder_plan`. **mini-ork could not plan work on any React/JSX repository.** It also mis-flagged the planner's own annotations for non-editing steps (`"<shell-only>"`).

### Root cause
`_contains_placeholder` recursed into every nested string and returned `s.startswith("<") and s.endswith(">")`. That predicate does not distinguish *an unfilled template value* from *code that happens to use angle brackets*.

### Fix
A placeholder plan means the planner produced **nothing** — the dry-run stub, whose `objective` is `"<dry-run: not generated>"` and whose `decomposition` is empty. Judge the plan by its objective and its emptiness, not by every string inside it. An angle-bracketed value counts as a stub only when it is empty or carries a stub word (`dry-run`/`TODO`/`TBD`/`FIXME`/`placeholder`/`fill-in`/`xxx`).

### Found live
A real `fix-duplicate-modals` run against a React repo died at plan validation with `placeholder_plan` while holding a perfectly good plan.

### Tests
`tests/unit/test_mini_ork_plan_py.py` — 14 pass (12 existing + 2 new):
- `test_jsx_tags_are_not_placeholders` — a plan naming `<ContentNodeCreationModal />` and `<shell-only>` validates `ok`
- `test_dry_run_stub_still_rejected` — the dry-run stub, `<TODO>`, and the empty shell are all still rejected