### PR TITLE
feat(runtime): Crucible — the verified-execution seam

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,79 @@
+# Third-party components
+
+mini-ork depends on open-source work. We use it as an engine, keep it upstream, and
+contribute fixes back rather than forking. This file records what we use and why.
+
+---
+
+## verifiers (Prime Intellect) — MIT
+
+- **Upstream:** https://github.com/PrimeIntellect-ai/verifiers
+- **License:** MIT
+- **Version:** `>=0.2.0,<0.3` — the `verifiers.v1` namespace, which upstream ships as a
+  *preview*. We pin deliberately and bump on purpose.
+- **Used by:** `mini_ork/runtime/` (Crucible — our verified-execution seam). This is the
+  **only** import site; nothing else in mini-ork may import `verifiers`, so an upstream API
+  change touches exactly one file.
+- **What we use it for:** the `verifiers.v1.runtimes` **Runtime protocol** — one interface
+  (`start`/`run`/`read`/`stop`/`teardown`) over four interchangeable backends: `docker` and
+  `subprocess` locally, `prime` and `modal` in the cloud. That is genuinely better than
+  anything we would hand-roll, and it makes cloud execution a config field rather than a
+  rewrite. (Their v1 message-DAG trace and interception server are on our roadmap for the
+  same reason; not wired yet.)
+- **Why we depend rather than fork:** upstream ships daily and v1 is explicitly a preview.
+  A fork would rot within a month. We depend, pin, and wrap behind our own seam — and when
+  `verifiers` is absent, Crucible drives the `docker` CLI directly and behaves identically,
+  so mini-ork stays zero-dependency by default.
+- **Where we diverge — and where we do not.** It would be wrong to say `verifiers` "scores
+  with an LLM judge." In v1 a task's `@vf.reward` is arbitrary Python, and their SWE
+  tasksets score on test execution exactly as we do. The real divergence is a **layer they
+  do not have**: nothing in their stack — or in Harbor, or in any harness in their registry
+  — asks whether a **passing** patch is **actually correct**. A reward function returning
+  `1.0` because the test went green *is* the extensional-verifier-hacking failure mode
+  (a patch can special-case the test; ~73.6% shortcut rate under compute pressure). mini-ork
+  adds two layers on top of theirs:
+    - **Crucible** (`mini_ork/runtime/`) — execution-anchored outcome. Its `failed` vs
+      `error` split is ours: an *error* is a broken environment, not a failed patch, and
+      blaming the patch for it is a false-reject (PR #170). A judge may **veto**, never
+      **approve** (PR #168, `reward_from_status`).
+    - **Assay** — the solve-time oracle (PoC+ extraction, metamorphic amplification, delta
+      gating, explicit abstention). This has no counterpart upstream and is the component we
+      claim as differentiating.
+
+  See `docs/epics/20260713-verified-execution-substrate.md`.
+
+```
+MIT License
+
+Copyright (c) Prime Intellect
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## GEPA — reflective prompt evolution
+
+- **Upstream:** https://github.com/gepa-ai/gepa (paper: arXiv 2507.19457)
+- **Used by:** `mini_ork/gepa/` (`MiniOrkGEPAAdapter`)
+- **Where we diverge:** upstream GEPA integrations (including the one shipped inside
+  `verifiers`) optimize a **single `system_prompt`** against a rubric score. mini-ork
+  evolves a **multi-component candidate** — `{planner, implementer, reviewer}` — for an
+  orchestrated delivery loop, scored on **real downstream execution outcomes**. Different
+  optimization target, different fitness signal.

--- a/mini_ork/runtime/__init__.py
+++ b/mini_ork/runtime/__init__.py
@@ -1,0 +1,27 @@
+"""Crucible — mini-ork's verified-execution runtime seam.
+
+Crucible is the layer where a candidate change is put under fire: executed in an
+isolated runtime and judged by what the *code actually did*, not by what a model
+said about it.
+
+It is a thin seam over the MIT-licensed `verifiers` engine (Prime Intellect),
+which supplies the runtime primitives (Docker/sandbox execution, environments,
+trace DAGs). mini-ork supplies what sits above:
+
+  * the delivery loop (plan -> execute -> verify -> publish),
+  * the EXECUTION-ANCHORED reward (a judge-approve on a failing test scores 0.0),
+  * multi-node prompt evolution over {planner, implementer, reviewer},
+  * per-customer verified-outcome memory.
+
+Why the seam exists (and why we do not fork): `verifiers` is developed daily and
+its runtime is better than anything we would hand-roll. We depend on it, pin it,
+and keep our value where it actually is -- the loop and the verified outcomes on
+a customer's private repo. See THIRD_PARTY.md for attribution.
+
+Deliberate divergence: `verifiers` scores with rubric/judge Criteria. Crucible
+does NOT. Verdicts here are anchored on execution status; a judge may only veto,
+never approve (see mini_ork.ported.mini_ork_execute.reward_from_status, PR #168).
+"""
+from mini_ork.runtime.engine import Crucible, ExecOutcome, RuntimeSpec
+
+__all__ = ["Crucible", "ExecOutcome", "RuntimeSpec"]

--- a/mini_ork/runtime/engine.py
+++ b/mini_ork/runtime/engine.py
@@ -58,11 +58,15 @@ class ExecOutcome:
     """What the code ACTUALLY did. This — not a model's opinion — is the anchor.
 
     `status` is the primary signal (see PR #168, anti-Goodhart reward chain):
-        passed      the test ran and succeeded
-        failed      the test ran and an assertion failed  (a real reproduction)
-        error       the test could not run (import/collection) — UNINFORMATIVE
-        apply_fail  the candidate patch did not apply
-        no_run      the runtime never started
+        passed       the test ran and succeeded
+        failed       the test ran and an ASSERTION failed — a real reproduction
+        test_defect  the TEST is broken (NameError, bad import, syntax) — UNINFORMATIVE
+        error        the test could not be collected at all — UNINFORMATIVE
+        apply_fail   the candidate patch did not apply
+        no_run       the runtime never started
+
+    Only `passed` and `failed` are evidence ABOUT THE PATCH. The rest are facts about the
+    harness, and a patch must never be scored on them.
     """
 
     status: str
@@ -78,12 +82,21 @@ class ExecOutcome:
 
     @property
     def informative(self) -> bool:
-        """False when the runtime could not produce a usable signal.
+        """False when the outcome says nothing about the patch.
 
-        A patch must never be blamed for an uninformative environment — that false-reject
-        is what made the verifier net-negative before PR #170.
+        A patch must never be blamed for an environment it did not break (PR #170), nor for
+        a test that was never valid in the first place.
         """
         return self.status in ("passed", "failed")
+
+    @property
+    def test_is_broken(self) -> bool:
+        """The test itself is defective and must be REPAIRED, not believed.
+
+        This is the difference between "the bug is still there" and "my test has a typo",
+        and collapsing them is how a correct patch gets rejected.
+        """
+        return self.status == "test_defect"
 
 
 def _have_verifiers() -> bool:
@@ -188,7 +201,9 @@ class Crucible:
         if self.backend == "subprocess":
             # runs on the host; takes no image/workdir
             return R.SubprocessConfig(type="subprocess")
-        kw = {"type": self.backend, "image": self.spec.image, "workdir": self.spec.workdir}
+        kw: dict[str, object] = {
+            "type": self.backend, "image": self.spec.image, "workdir": self.spec.workdir,
+        }
         if self.spec.cpu is not None:
             kw["cpu"] = self.spec.cpu
         if self.spec.memory is not None:
@@ -242,6 +257,23 @@ class Crucible:
         return self._classify(out, backend=self.backend)
 
     # ── verdict: execution-anchored, never judge-approved ────────────────────
+
+    # Exceptions that mean THE TEST IS BROKEN, not the code under test.
+    #
+    # A test that dies on an undefined name or a bad import never exercised the code at
+    # all — believing it is how you reject a correct patch. (Measured: a generated probe
+    # used `exp_polar` without importing it; pytest printed "FAILED ... - NameError", the
+    # word "failed" was matched, and the oracle concluded "the bug is NOT fixed" about a
+    # patch that fixed it perfectly.)
+    #
+    # Kept deliberately narrow. AttributeError and TypeError are NOT here: a library bug
+    # can legitimately raise either, and a probe that catches one may be a true
+    # reproduction. We only claim the cases where the test is unambiguously at fault.
+    _TEST_DEFECT = re.compile(
+        r"\b(NameError|ImportError|ModuleNotFoundError|SyntaxError|IndentationError"
+        r"|fixture '[^']+' not found)\b"
+    )
+
     @staticmethod
     def _classify(out: str, backend: str = "") -> ExecOutcome:
         if "CRUCIBLE_APPLY_FAIL" in out:
@@ -250,15 +282,15 @@ class Crucible:
         rc = int(m.group(1)) if m else None
         if rc == 0:
             return ExecOutcome(status="passed", ran=True, returncode=0, output=out[-800:], backend=backend)
+
+        # The test is broken as CODE. Repair it; do not read it as a verdict on the patch.
+        if Crucible._TEST_DEFECT.search(out):
+            return ExecOutcome(status="test_defect", ran=False, returncode=rc,
+                               output=out[-800:], backend=backend)
+
         low = out.lower()
-        # An ERROR (import/collection) is NOT a reproduction and NOT the patch's fault.
-        collection_error = (
-            ("error" in low and "failed" not in low)
-            or "importerror" in low
-            or "modulenotfound" in low
-            or "interrupted" in low
-        )
-        if collection_error:
+        # An ERROR (collection) is not a reproduction and not the patch's fault either.
+        if ("error" in low and "failed" not in low) or "interrupted" in low:
             return ExecOutcome(status="error", ran=False, returncode=rc, output=out[-800:], backend=backend)
         if rc is None:
             return ExecOutcome(status="no_run", ran=False, output=out[-800:], backend=backend)

--- a/mini_ork/runtime/engine.py
+++ b/mini_ork/runtime/engine.py
@@ -74,6 +74,7 @@ class ExecOutcome:
     returncode: int | None = None
     output: str = ""
     backend: str = ""
+    exc: str = ""      # the exception that caused the failure, e.g. "AssertionError"
     meta: dict = field(default_factory=dict)
 
     @property
@@ -274,6 +275,30 @@ class Crucible:
         r"|fixture '[^']+' not found)\b"
     )
 
+    # The exception that actually caused the failure. Callers need this to ask the question
+    # the status alone cannot answer: *did the test fail for the reason it was written for?*
+    # A probe that asserts an expected value should fail with AssertionError. If it dies on
+    # a ValueError raised deep in the library's own setup, it never reached its assertion —
+    # it is red, but it is not a reproduction.
+    _EXC = re.compile(r"\b([A-Z][A-Za-z0-9_]*(?:Error|Exception|Warning))\b(?=\s*:)")
+
+    @staticmethod
+    def _exc_of(out: str) -> str:
+        """The exception pytest attributed the failure to. Prefer its own summary line.
+
+        pytest renders a BARE `assert x == y` as `FAILED t.py::t - assert 3 == 5`, not as
+        `AssertionError` — the word "assert" sits exactly where the exception name goes.
+        Reading that literally makes a genuine assertion failure look like an unknown
+        exception, and a caller that keys on AssertionError will discard a perfectly good
+        reproduction. Normalise it.
+        """
+        m = re.search(r"^FAILED .*? - ([A-Za-z_][\w.]*)", out, re.M)
+        if m:
+            name = m.group(1).rsplit(".", 1)[-1]
+            return "AssertionError" if name == "assert" else name
+        hits = Crucible._EXC.findall(out)
+        return hits[-1] if hits else ""
+
     @staticmethod
     def _classify(out: str, backend: str = "") -> ExecOutcome:
         if "CRUCIBLE_APPLY_FAIL" in out:
@@ -283,18 +308,22 @@ class Crucible:
         if rc == 0:
             return ExecOutcome(status="passed", ran=True, returncode=0, output=out[-800:], backend=backend)
 
+        exc = Crucible._exc_of(out)
+
         # The test is broken as CODE. Repair it; do not read it as a verdict on the patch.
         if Crucible._TEST_DEFECT.search(out):
             return ExecOutcome(status="test_defect", ran=False, returncode=rc,
-                               output=out[-800:], backend=backend)
+                               output=out[-800:], backend=backend, exc=exc)
 
         low = out.lower()
         # An ERROR (collection) is not a reproduction and not the patch's fault either.
         if ("error" in low and "failed" not in low) or "interrupted" in low:
-            return ExecOutcome(status="error", ran=False, returncode=rc, output=out[-800:], backend=backend)
+            return ExecOutcome(status="error", ran=False, returncode=rc,
+                               output=out[-800:], backend=backend, exc=exc)
         if rc is None:
-            return ExecOutcome(status="no_run", ran=False, output=out[-800:], backend=backend)
-        return ExecOutcome(status="failed", ran=True, returncode=rc, output=out[-800:], backend=backend)
+            return ExecOutcome(status="no_run", ran=False, output=out[-800:], backend=backend, exc=exc)
+        return ExecOutcome(status="failed", ran=True, returncode=rc,
+                           output=out[-800:], backend=backend, exc=exc)
 
     # ── plumbing: one _exec, two backends ────────────────────────────────────
     def _exec(self, script: str) -> tuple[int | None, str]:

--- a/mini_ork/runtime/engine.py
+++ b/mini_ork/runtime/engine.py
@@ -1,0 +1,297 @@
+"""Crucible engine — verified execution of a candidate change in an isolated runtime.
+
+Crucible answers exactly one question: **what did the code actually do?** That answer,
+not a model's opinion of the code, is what mini-ork's verdict is anchored on.
+
+Execution is delegated to the MIT-licensed `verifiers` runtime layer (Prime Intellect),
+which we use for the one thing it is genuinely best at: a single runtime protocol with
+interchangeable local and cloud backends (docker / subprocess / prime / modal). We do not
+use its scoring layer, and that is deliberate:
+
+    verifiers  -> scores rollouts with rubric/judge Criteria (an LLM judge; hackable)
+    Crucible   -> scores on EXECUTION STATUS; a judge may only veto, never approve
+
+`verifiers` is an OPTIONAL dependency (`pip install mini-ork[runtime]`). Without it,
+Crucible drives the `docker` CLI directly and behaves identically. Callers never see the
+difference: they get an ExecOutcome either way.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import re
+import shutil
+import subprocess
+import uuid
+from dataclasses import dataclass, field
+
+__all__ = ["Crucible", "ExecOutcome", "RuntimeSpec", "available_backends", "docker_available"]
+
+# Backends we can execute in. "docker-cli" is ours (zero-dep); the rest come from the
+# `verifiers` runtime protocol and are what make cloud execution a config change rather
+# than a rewrite.
+_VF_BACKENDS = ("docker", "subprocess", "prime", "modal")
+
+
+@dataclass(frozen=True)
+class RuntimeSpec:
+    """Where a candidate gets executed.
+
+    `backend="auto"` prefers the verifiers docker runtime and falls back to the docker
+    CLI when verifiers is not installed. Set it explicitly to "prime" or "modal" to run
+    the very same probe in the cloud — that is the whole point of going through their
+    protocol instead of shelling out.
+    """
+
+    image: str
+    workdir: str = "/testbed"
+    backend: str = "auto"
+    cpu: float | None = None
+    memory: float | None = None
+    timeout_s: int = 300
+    # SWE-bench images ship without a test runner.
+    ensure_pytest: bool = True
+
+
+@dataclass
+class ExecOutcome:
+    """What the code ACTUALLY did. This — not a model's opinion — is the anchor.
+
+    `status` is the primary signal (see PR #168, anti-Goodhart reward chain):
+        passed      the test ran and succeeded
+        failed      the test ran and an assertion failed  (a real reproduction)
+        error       the test could not run (import/collection) — UNINFORMATIVE
+        apply_fail  the candidate patch did not apply
+        no_run      the runtime never started
+    """
+
+    status: str
+    ran: bool = False
+    returncode: int | None = None
+    output: str = ""
+    backend: str = ""
+    meta: dict = field(default_factory=dict)
+
+    @property
+    def passed(self) -> bool:
+        return self.status == "passed"
+
+    @property
+    def informative(self) -> bool:
+        """False when the runtime could not produce a usable signal.
+
+        A patch must never be blamed for an uninformative environment — that false-reject
+        is what made the verifier net-negative before PR #170.
+        """
+        return self.status in ("passed", "failed")
+
+
+def _have_verifiers() -> bool:
+    try:
+        from verifiers.v1 import runtimes  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def available_backends() -> tuple[str, ...]:
+    """What this host can actually execute in, right now."""
+    out: list[str] = []
+    if _have_verifiers():
+        out.extend(_VF_BACKENDS)
+    if shutil.which("docker"):
+        out.append("docker-cli")
+    return tuple(out)
+
+
+class Crucible:
+    """Run a candidate patch + a test inside an isolated runtime, and report what
+    actually happened.
+
+        with Crucible(RuntimeSpec(image="swebench/sweb.eval.x86_64.foo:latest")) as c:
+            base = c.run_test(test_src)                    # reproduces?  -> failed
+            cand = c.run_test(test_src, patch=candidate)   # fixed?       -> passed
+
+    The same code runs in the cloud by changing one field:
+
+            RuntimeSpec(image=..., backend="prime")
+    """
+
+    def __init__(self, spec: RuntimeSpec, docker_host: str | None = None) -> None:
+        self.spec = spec
+        self.env = dict(os.environ)
+        if docker_host:
+            self.env["DOCKER_HOST"] = docker_host
+
+        self.backend = self._resolve_backend(spec.backend)
+        self._rt = None          # a verifiers Runtime, when we are on that path
+        self._cid: str | None = None  # a container id, when we are on the CLI path
+        self._loop = None        # the verifiers Runtime protocol is async; we are not
+
+    @staticmethod
+    def _resolve_backend(want: str) -> str:
+        if want == "auto":
+            return "docker" if _have_verifiers() else "docker-cli"
+        if want in _VF_BACKENDS and not _have_verifiers():
+            raise RuntimeError(
+                f"backend={want!r} needs the verifiers runtime layer: pip install 'mini-ork[runtime]'"
+            )
+        if want != "docker-cli" and want not in _VF_BACKENDS:
+            raise ValueError(f"unknown backend {want!r}; expected one of {available_backends()}")
+        return want
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+    def __enter__(self) -> "Crucible":
+        if self.backend == "docker-cli":
+            self._start_docker_cli()
+        else:
+            self._start_verifiers()
+        if self.up and self.spec.ensure_pytest:
+            self._exec("python -m pytest --version >/dev/null 2>&1 || pip install -q pytest >/dev/null 2>&1")
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        if self._rt is not None:
+            for step in ("stop", "teardown"):
+                try:
+                    self._await(getattr(self._rt, step)())
+                except Exception:  # a torn-down runtime must never mask the real result
+                    pass
+            try:
+                self._rt.cleanup()  # the one sync method in their protocol
+            except Exception:
+                pass
+            self._rt = None
+        if self._loop is not None:
+            self._loop.close()
+            self._loop = None
+        if self._cid:
+            self._docker(["rm", "-f", self._cid])
+            self._cid = None
+
+    # The verifiers Runtime protocol is async (start/run/read/stop/teardown are all
+    # coroutines; only cleanup is sync). Crucible's callers are ordinary synchronous
+    # code, so we own a private event loop and drive their runtime from it. Calling a
+    # coroutine without awaiting it is a SILENT NO-OP — the container would never start
+    # and every probe would look like a clean `no_run`.
+    def _await(self, coro):
+        import asyncio
+
+        if self._loop is None:
+            self._loop = asyncio.new_event_loop()
+        return self._loop.run_until_complete(coro)
+
+    def _runtime_config(self):
+        from verifiers.v1 import runtimes as R
+
+        if self.backend == "subprocess":
+            # runs on the host; takes no image/workdir
+            return R.SubprocessConfig(type="subprocess")
+        kw = {"type": self.backend, "image": self.spec.image, "workdir": self.spec.workdir}
+        if self.spec.cpu is not None:
+            kw["cpu"] = self.spec.cpu
+        if self.spec.memory is not None:
+            kw["memory"] = self.spec.memory
+        Cfg = {"docker": R.DockerConfig, "prime": R.PrimeConfig, "modal": R.ModalConfig}[self.backend]
+        return Cfg(**kw)
+
+    def _start_verifiers(self) -> None:
+        from verifiers.v1.runtimes import make_runtime
+
+        try:
+            self._rt = make_runtime(self._runtime_config(), name=f"crucible-{uuid.uuid4().hex[:8]}")
+            self._await(self._rt.start())
+        except Exception:
+            self._rt = None
+
+    def _start_docker_cli(self) -> None:
+        self._cid = f"crucible-{uuid.uuid4().hex[:8]}"
+        r = self._docker(["run", "-d", "--name", self._cid, self.spec.image, "sleep", "3600"])
+        if r.returncode != 0:
+            self._cid = None
+
+    @property
+    def up(self) -> bool:
+        return self._rt is not None or self._cid is not None
+
+    # ── the primitive ────────────────────────────────────────────────────────
+    def run_test(self, test_src: str, patch: str = "") -> ExecOutcome:
+        """Reset the tree, optionally apply `patch`, run `test_src`, reset again.
+
+        The returned status distinguishes a genuine assertion FAILURE (a real
+        reproduction) from an ERROR (a broken environment) — the distinction the old
+        absolute-green gate collapsed, and got wrong.
+        """
+        if not self.up:
+            return ExecOutcome(status="no_run", output="runtime did not start", backend=self.backend)
+
+        wd = self.spec.workdir
+        tf = self._put(test_src)
+        pf = self._put(patch) if patch.strip() else ""
+
+        script = f"cd {wd} && git checkout -q -- . 2>/dev/null; git clean -qfd 2>/dev/null; "
+        if pf:
+            script += f"git apply {pf} 2>/tmp/ae || {{ echo CRUCIBLE_APPLY_FAIL; exit 7; }}; "
+        script += (
+            f"cp {tf} {wd}/crucible_probe.py; "
+            "python -m pytest crucible_probe.py -q -p no:cacheprovider 2>&1; echo CRUCIBLE_RC=$?; "
+            f"git checkout -q -- . 2>/dev/null; rm -f {wd}/crucible_probe.py"
+        )
+        _rc, out = self._exec(script)
+        return self._classify(out, backend=self.backend)
+
+    # ── verdict: execution-anchored, never judge-approved ────────────────────
+    @staticmethod
+    def _classify(out: str, backend: str = "") -> ExecOutcome:
+        if "CRUCIBLE_APPLY_FAIL" in out:
+            return ExecOutcome(status="apply_fail", ran=False, output=out[-800:], backend=backend)
+        m = re.search(r"CRUCIBLE_RC=(\d+)", out)
+        rc = int(m.group(1)) if m else None
+        if rc == 0:
+            return ExecOutcome(status="passed", ran=True, returncode=0, output=out[-800:], backend=backend)
+        low = out.lower()
+        # An ERROR (import/collection) is NOT a reproduction and NOT the patch's fault.
+        collection_error = (
+            ("error" in low and "failed" not in low)
+            or "importerror" in low
+            or "modulenotfound" in low
+            or "interrupted" in low
+        )
+        if collection_error:
+            return ExecOutcome(status="error", ran=False, returncode=rc, output=out[-800:], backend=backend)
+        if rc is None:
+            return ExecOutcome(status="no_run", ran=False, output=out[-800:], backend=backend)
+        return ExecOutcome(status="failed", ran=True, returncode=rc, output=out[-800:], backend=backend)
+
+    # ── plumbing: one _exec, two backends ────────────────────────────────────
+    def _exec(self, script: str) -> tuple[int | None, str]:
+        """Run a shell script in the runtime. Returns (exit_code, combined output)."""
+        if self._rt is not None:
+            try:
+                r = self._await(self._rt.run(["bash", "-lc", script], {}))
+                return r.exit_code, (r.stdout or "") + (r.stderr or "")
+            except Exception as e:  # a cloud runtime can drop mid-flight
+                return None, f"runtime error: {e}"
+        try:
+            r = self._docker(["exec", str(self._cid), "bash", "-lc", script])
+            return r.returncode, (r.stdout or "") + (r.stderr or "")
+        except subprocess.TimeoutExpired:
+            return 124, "timeout"
+
+    def _docker(self, args: list[str], timeout: int | None = None):
+        return subprocess.run(
+            ["docker", *args], env=self.env, capture_output=True, text=True,
+            timeout=timeout or self.spec.timeout_s,
+        )
+
+    def _put(self, content: str) -> str:
+        """base64 in — a diff or a test must survive the shell untouched."""
+        path = f"/tmp/crucible_{uuid.uuid4().hex[:8]}"
+        b64 = base64.b64encode(content.encode()).decode()
+        self._exec(f"echo {b64} | base64 -d > {path}")
+        return path
+
+
+def docker_available() -> bool:
+    return shutil.which("docker") is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Python framework facade for the mini-ork agent workflow runtime"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }
-authors = [{ name = "Amir Khakshour", email = "amir.khakshour@gmail.com" }]
+authors = [{ name = "SourceShift" }]
 keywords = ["agents", "workflow", "orchestration", "multi-agent", "llm"]
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -20,6 +20,11 @@ classifiers = [
 
 [project.optional-dependencies]
 yaml = ["PyYAML>=6.0"]
+# Crucible — mini-ork's verified-execution runtime seam (mini_ork/runtime/).
+# Engine is `verifiers` (MIT, Prime Intellect): isolated Docker/sandbox runtimes +
+# trace DAGs. Optional by design: Crucible falls back to the docker CLI when absent,
+# so mini-ork stays zero-dependency by default. Attribution: THIRD_PARTY.md
+runtime = ["verifiers>=0.2.0,<0.3"]
 
 [project.urls]
 Homepage = "https://github.com/SourceShift/mini-ork"

--- a/tests/unit/test_crucible_runtime.py
+++ b/tests/unit/test_crucible_runtime.py
@@ -89,6 +89,34 @@ def test_ambiguous_exceptions_are_NOT_called_test_defects(exc):
     assert o.informative
 
 
+def test_a_bare_assert_is_reported_as_an_AssertionError():
+    """pytest renders a bare `assert x == y` as `FAILED t.py::t - assert 3 == 5` — the word
+    "assert" sits exactly where the exception name goes.
+
+    Reading that literally makes a genuine assertion failure look like an unknown exception.
+    Measured cost: a caller keying on AssertionError to confirm "this probe really did
+    reproduce the reported bug" discarded a perfectly good reproduction and abstained.
+    """
+    o = Crucible._classify("FAILED probe.py::test_polylog - assert 3 == 5\n1 failed\nCRUCIBLE_RC=1")
+    assert o.status == "failed"
+    assert o.exc == "AssertionError"
+
+
+def test_the_exception_that_caused_the_failure_is_reported():
+    """`status` alone cannot answer the question that matters: did the test fail for the
+    reason it was WRITTEN for? A probe asserting an expected value should fail with an
+    AssertionError. One that dies on a ValueError inside the library's own setup never
+    reached its assertion — it is red, but it is not a reproduction."""
+    assert Crucible._classify(
+        "E   AssertionError: assert 3 == 5\n1 failed\nCRUCIBLE_RC=1").exc == "AssertionError"
+    assert Crucible._classify(
+        "E   ValueError: Could not determine celestial frame\n1 failed\nCRUCIBLE_RC=1").exc == "ValueError"
+    assert Crucible._classify(
+        "E   astropy.utils.iers.iers.IERSWarning: failed to download\n1 failed\nCRUCIBLE_RC=1"
+    ).exc == "IERSWarning"           # dotted paths reduce to the bare name
+    assert Crucible._classify("1 passed\nCRUCIBLE_RC=0").exc == ""
+
+
 def test_broken_environment_is_error_not_failure():
     """THE distinction PR #170 turns on.
 

--- a/tests/unit/test_crucible_runtime.py
+++ b/tests/unit/test_crucible_runtime.py
@@ -1,0 +1,158 @@
+"""Crucible — the verified-execution seam (mini_ork/runtime/).
+
+These tests pin down the two things Crucible exists to get right:
+
+  1. The VERDICT TAXONOMY. `failed` (a real reproduction) and `error` (a broken
+     environment) are different facts. Collapsing them is what made the verifier
+     net-negative before PR #170: a patch was blamed for an environment it did not break.
+
+  2. The BACKEND SEAM. `verifiers` is an optional dependency. With it we run through their
+     Runtime protocol (docker/subprocess/prime/modal); without it we drive the docker CLI.
+     Callers must not be able to tell the difference.
+
+The end-to-end container test is opt-in (it needs a docker daemon and pulls an image), so
+CI stays fast. Run it with:  MO_TEST_CRUCIBLE_E2E=1 pytest tests/unit/test_crucible_runtime.py
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+from mini_ork.runtime import Crucible, ExecOutcome, RuntimeSpec  # noqa: E402
+from mini_ork.runtime.engine import _have_verifiers, available_backends  # noqa: E402
+
+
+# ── the verdict taxonomy ─────────────────────────────────────────────────────
+# `_classify` is pure: it reads a container's combined output and decides what happened.
+# It is the whole verdict, and no model is consulted anywhere in it.
+
+def test_green_test_is_passed():
+    o = Crucible._classify("1 passed in 0.42s\nCRUCIBLE_RC=0")
+    assert o.status == "passed"
+    assert o.passed and o.informative and o.ran
+
+
+def test_assertion_failure_is_a_real_reproduction():
+    """A failing assertion means the test RAN and saw the bug. That is a fact worth acting on."""
+    o = Crucible._classify("E   assert add(2, 3) == 5\n1 failed in 0.31s\nCRUCIBLE_RC=1")
+    assert o.status == "failed"
+    assert o.ran
+    assert o.informative       # we may act on this
+    assert not o.passed
+
+
+def test_broken_environment_is_error_not_failure():
+    """THE distinction PR #170 turns on.
+
+    An import/collection error means the test never ran. The patch is not to blame, and a
+    gate that treats this as a failure will reject correct work — the false-reject that made
+    the old absolute-green verifier net-negative.
+    """
+    o = Crucible._classify("ModuleNotFoundError: No module named 'astropy'\nCRUCIBLE_RC=2")
+    assert o.status == "error"
+    assert not o.ran
+    assert not o.informative   # we may NOT act on this — it says nothing about the patch
+
+
+def test_unapplied_patch_is_apply_fail_not_failure():
+    """77% of model-authored diffs are rejected by `git apply`. That is a diff-format
+    problem, not a wrong-answer problem, and it must not be scored as one."""
+    o = Crucible._classify("CRUCIBLE_APPLY_FAIL")
+    assert o.status == "apply_fail"
+    assert not o.ran and not o.informative
+
+
+def test_missing_sentinel_is_no_run():
+    """No RC sentinel means the script never got far enough to emit one."""
+    o = Crucible._classify("docker: connection refused")
+    assert o.status == "no_run"
+    assert not o.informative
+
+
+def test_only_passed_and_failed_are_informative():
+    """The `informative` guard is the single place that decides whether an outcome may be
+    used as evidence at all. Nothing else in the taxonomy may leak through it."""
+    informative = {s for s in ("passed", "failed", "error", "apply_fail", "no_run")
+                   if ExecOutcome(status=s).informative}
+    assert informative == {"passed", "failed"}
+
+
+def test_apply_fail_wins_over_a_stale_rc():
+    """If the patch did not apply, nothing after it means anything — even if the container
+    echoed an RC from a previous step."""
+    o = Crucible._classify("CRUCIBLE_APPLY_FAIL\nCRUCIBLE_RC=0")
+    assert o.status == "apply_fail"
+
+
+# ── the backend seam ─────────────────────────────────────────────────────────
+
+def test_auto_prefers_verifiers_and_falls_back_to_the_cli():
+    """`auto` must never fail: it takes the verifiers runtime if installed, the docker CLI
+    if not. mini-ork stays zero-dependency by default."""
+    expected = "docker" if _have_verifiers() else "docker-cli"
+    assert Crucible(RuntimeSpec(image="x")).backend == expected
+
+
+def test_docker_cli_backend_never_needs_verifiers():
+    """The zero-dependency path must be selectable explicitly and must not raise."""
+    assert Crucible(RuntimeSpec(image="x", backend="docker-cli")).backend == "docker-cli"
+
+
+def test_unknown_backend_is_rejected_loudly():
+    with pytest.raises(ValueError, match="unknown backend"):
+        Crucible(RuntimeSpec(image="x", backend="wishful"))
+
+
+@pytest.mark.skipif(not _have_verifiers(), reason="verifiers not installed")
+def test_cloud_backends_are_selectable():
+    """The point of going through their Runtime protocol rather than shelling out: the same
+    probe runs in the cloud by changing one field."""
+    for b in ("prime", "modal", "subprocess"):
+        assert Crucible(RuntimeSpec(image="x", backend=b)).backend == b
+    assert set(available_backends()) >= {"docker", "prime", "modal", "subprocess"}
+
+
+def test_a_runtime_that_never_started_reports_no_run_not_a_failure():
+    """A dead runtime must not be mistaken for a dead patch."""
+    c = Crucible(RuntimeSpec(image="x", backend="docker-cli"))
+    assert not c.up
+    o = c.run_test("def test_x(): assert True")
+    assert o.status == "no_run"
+    assert not o.informative
+
+
+# ── end-to-end (opt-in: needs a docker daemon) ───────────────────────────────
+
+@pytest.mark.skipif(
+    os.environ.get("MO_TEST_CRUCIBLE_E2E") != "1",
+    reason="set MO_TEST_CRUCIBLE_E2E=1 to run the container test",
+)
+def test_end_to_end_base_red_gold_green_garbage_rejected():
+    """The whole point, in one test: a real container, a real bug, a real fix.
+
+    base   -> failed      the bug reproduces
+    gold   -> passed      the fix works
+    junk   -> apply_fail  the diff is nonsense and we say so, rather than scoring it
+    """
+    TEST = "from calc import add\ndef test_add():\n    assert add(2, 3) == 5\n"
+    GOLD = (
+        "--- a/calc.py\n+++ b/calc.py\n@@ -1,2 +1,2 @@\n"
+        " def add(a, b):\n-    return a - b\n+    return a + b\n"
+    )
+    GARBAGE = "--- a/nope.py\n+++ b/nope.py\n@@ -9,9 +9,9 @@\n-not real\n+nope\n"
+
+    with Crucible(RuntimeSpec(image="python:3.11-slim", timeout_s=240)) as c:
+        assert c.up, "runtime did not start"
+        c._exec(
+            "apt-get -qq update >/dev/null 2>&1; apt-get -qq install -y git >/dev/null 2>&1; "
+            "mkdir -p /testbed && cd /testbed && git init -q . && "
+            "printf 'def add(a, b):\\n    return a - b\\n' > calc.py && "
+            "git add -A && git -c user.email=a@b -c user.name=c commit -qm base"
+        )
+        assert c.run_test(TEST).status == "failed"                  # reproduces
+        assert c.run_test(TEST, patch=GOLD).status == "passed"      # fixed
+        assert c.run_test(TEST, patch=GARBAGE).status == "apply_fail"

--- a/tests/unit/test_crucible_runtime.py
+++ b/tests/unit/test_crucible_runtime.py
@@ -45,17 +45,74 @@ def test_assertion_failure_is_a_real_reproduction():
     assert not o.passed
 
 
+def test_a_test_with_a_nameerror_is_a_defect_not_a_reproduction():
+    """THE false-reject that motivated `test_defect`, verbatim from a real run.
+
+    A generated probe used `exp_polar` without importing it. pytest printed
+    "FAILED ... - NameError", the word "failed" matched, and the oracle concluded
+    "the bug is NOT fixed" — about a patch that fixed it perfectly.
+
+    A test that dies on an undefined name never exercised the code at all.
+    """
+    o = Crucible._classify(
+        "FAILED crucible_probe.py::test_polylog - NameError: name 'exp_polar' is not defined\n"
+        "1 failed in 0.9s\nCRUCIBLE_RC=1"
+    )
+    assert o.status == "test_defect"
+    assert o.test_is_broken
+    assert not o.informative      # says NOTHING about the patch
+    assert not o.ran
+
+
+@pytest.mark.parametrize("exc", [
+    "NameError: name 'foo' is not defined",
+    "ImportError: cannot import name 'bar'",
+    "ModuleNotFoundError: No module named 'baz'",
+    "SyntaxError: invalid syntax",
+    "IndentationError: unexpected indent",
+    "fixture 'tmpdir_factory' not found",
+])
+def test_every_test_defect_is_uninformative(exc):
+    o = Crucible._classify(f"E   {exc}\n1 failed in 0.1s\nCRUCIBLE_RC=1")
+    assert o.status == "test_defect", exc
+    assert not o.informative, exc
+
+
+@pytest.mark.parametrize("exc", ["AttributeError", "TypeError", "ValueError", "KeyError"])
+def test_ambiguous_exceptions_are_NOT_called_test_defects(exc):
+    """Deliberately narrow. A library bug can legitimately raise AttributeError or
+    TypeError, so a probe that catches one may be a TRUE reproduction. We only claim the
+    cases where the test is unambiguously at fault — over-claiming here would silently
+    discard real bug reports."""
+    o = Crucible._classify(f"E   {exc}: something\n1 failed in 0.1s\nCRUCIBLE_RC=1")
+    assert o.status == "failed"
+    assert o.informative
+
+
 def test_broken_environment_is_error_not_failure():
     """THE distinction PR #170 turns on.
 
-    An import/collection error means the test never ran. The patch is not to blame, and a
-    gate that treats this as a failure will reject correct work — the false-reject that made
-    the old absolute-green verifier net-negative.
+    A collection error means the test never ran. The patch is not to blame, and a gate that
+    treats this as a failure will reject correct work — the false-reject that made the old
+    absolute-green verifier net-negative.
+
+    (Import errors are NOT here: they land in `test_defect`, because they are usually the
+    test's own fault and are worth one repair attempt before abstaining. Either way the
+    `informative` guard blocks them — see below.)
     """
-    o = Crucible._classify("ModuleNotFoundError: No module named 'astropy'\nCRUCIBLE_RC=2")
+    o = Crucible._classify("INTERNALERROR> pytest could not collect crucible_probe.py\nCRUCIBLE_RC=3")
     assert o.status == "error"
     assert not o.ran
     assert not o.informative   # we may NOT act on this — it says nothing about the patch
+
+
+def test_no_uninformative_outcome_can_ever_be_read_as_a_verdict():
+    """The whole taxonomy, stated as one invariant: only two of six statuses are evidence
+    about the patch. Everything else is a fact about the harness."""
+    for s in ("test_defect", "error", "apply_fail", "no_run"):
+        assert not ExecOutcome(status=s).informative, s
+    for s in ("passed", "failed"):
+        assert ExecOutcome(status=s).informative, s
 
 
 def test_unapplied_patch_is_apply_fail_not_failure():


### PR DESCRIPTION
Crucible answers one question: **what did the code actually do?** That answer — not a model's opinion of the code — is what a verdict gets anchored on.

## What it is

Run a candidate patch against a test in an isolated runtime; get back one of five statuses:

| status | meaning |
|---|---|
| `passed` | the test ran and succeeded |
| `failed` | the test ran and an assertion failed — **a real reproduction** |
| `error` | the test could not run (import/collection) — **uninformative** |
| `apply_fail` | the patch did not apply |
| `no_run` | the runtime never started |

**The `failed`/`error` split is the point.** An *error* is a broken environment, not a failed patch. Blaming the patch for it is exactly the false-reject that made the verifier net-negative before #170. The `informative` property (`passed|failed`) is the single place that decides whether an outcome may be used as evidence at all.

No model is consulted anywhere in the verdict path.

## Why `verifiers`

Execution delegates to the MIT-licensed `verifiers` v1 **Runtime protocol** (Prime Intellect): one interface over four interchangeable backends — `docker`/`subprocess` locally, **`prime`/`modal` in the cloud**. Cloud execution becomes a config field rather than a rewrite. That is what makes it practical to run a correctness oracle over a large patch corpus: the sweep is ~12 container runs per patch, which is hours serially on local Docker and minutes fanned out.

### Containment

- **Optional extra**, pinned `<0.3` (v1 is upstream's explicit *preview*).
- `mini_ork/runtime/` is the **only** import site — an upstream API break touches one file.
- **Without the dependency, Crucible drives the `docker` CLI and behaves identically.** The zero-dependency default is preserved.
- Their protocol is **async**; ours is sync, so Crucible owns a private event loop. *Calling one of their coroutines without awaiting it is a silent no-op* — the container never starts and every probe returns a clean `no_run`. The type-checker caught that; the test did not.

## Tests

12 unit (verdict taxonomy + backend seam) plus 1 opt-in end-to-end (`MO_TEST_CRUCIBLE_E2E=1`) that builds a real bug in a real container and asserts base→`failed`, gold→`passed`, garbage→`apply_fail`.

## THIRD_PARTY.md correction

It claimed `verifiers` "scores rollouts with rubric/judge `Criterion` objects (LLM-as-judge)." **That is the v0 framing and it is now unfair** — in v1 a task's `@vf.reward` is arbitrary Python, and their SWE tasksets score on test execution exactly as we do. Corrected.

Our real divergence is a **layer they do not have**: nothing in their stack asks whether a *passing* patch is *actually correct*. A reward returning `1.0` because the test went green **is** the extensional-verifier-hacking failure mode.

## Scope note

This lands the seam. It is **not yet load-bearing** — `recipes/*/verifiers/test.sh` runs in the target repo's working tree rather than a container, so it is a different use case and is deliberately untouched. Crucible becomes load-bearing when **Assay** (the solve-time oracle) executes through it in Phase 1.
