### PR TITLE
feat(dispatch): node-scoped tool grants — hermetic, least-privilege agent dispatch

### DIFF
--- a/bin/_worker-launcher.sh
+++ b/bin/_worker-launcher.sh
@@ -163,7 +163,7 @@ PROMPT_FILE="$ITER_DIR/prompt.md"
   echo
   echo "- Touch ONLY files in scope patterns above."
   echo "- Idempotent migrations (\`IF NOT EXISTS\`)."
-  echo "- Use Context7 MCP before writing code that uses any library/SDK."
+  echo "- Before writing code that uses any library/SDK, fetch its current docs via the \`ctx7\` CLI: \`npx ctx7@latest docs /org/project '<your question>'\`."
   echo "- No fallback logic for SDK / sandbox failures — fail loudly."
   echo "- Commit per logical unit. Conventional Commits format."
   echo "- Do NOT push. Do NOT create PRs."

--- a/lib/llm-dispatch.sh
+++ b/lib/llm-dispatch.sh
@@ -746,6 +746,225 @@ _mo_registry_apply_env() {
   return 0
 }
 
+# ─── Node-scoped tool grants (kickoff/tool-grant-hermetic-dispatch.md) ───────
+# Producer + consumer that wire `tools:` blocks out of workflow.yaml into
+# hermetic --allowedTools / --mcp-config / --strict-mcp-config argv on every
+# claude invocation. The previous attempt shipped the consumer but never the
+# producer, so every node fell through to the conservative default and 12+
+# recipes' implementer nodes silently lost Write/Edit. Producer and consumer
+# live together in this file so they cannot drift apart again.
+
+# _mo_default_tools_for_type <node_type>
+# Type-aware fail-closed defaults. "Fail closed" means "no MCP and no ambient
+# leakage", NOT "no ability to do the job" — an undeclared implementer must
+# still be able to write files or every recipe breaks.
+_mo_default_tools_for_type() {
+  case "${1:-}" in
+    implementer) printf 'Read,Write,Edit,Bash|\n' ;;
+    *)           printf 'Read,Bash|\n' ;;
+  esac
+}
+
+# _mo_resolve_node_tools_from_yaml <yaml_path> <node_id>
+# Producer: parse a workflow.yaml, find the node by name (with -/_ variants),
+# extract its `tools:` block. Prints "native_csv|mcp_csv" to stdout. Prints
+# empty string when the node is not declared (caller applies type-aware
+# default). Reads with yaml.safe_load when available, falls back to a tiny
+# bespoke parser for the two shapes we actually use.
+_mo_resolve_node_tools_from_yaml() {
+  local yaml_path="${1:?yaml required}" node_id="${2:?node_id required}"
+  [ -f "$yaml_path" ] || { printf '\n'; return 0; }
+  python3 - "$yaml_path" "$node_id" <<'PY' 2>/dev/null || printf '\n'
+import re, sys
+yaml_path, node_id = sys.argv[1], sys.argv[2]
+
+# Try PyYAML first (clean parse); fall back to a regex-based extractor for
+# the simple list-of-dicts shape we control in this repo's workflow.yamls.
+def _try_yaml():
+    try:
+        import yaml  # noqa: F401
+        with open(yaml_path) as f:
+            d = yaml.safe_load(f) or {}
+        nodes = d.get("nodes") or []
+        for n in nodes:
+            if not isinstance(n, dict):
+                continue
+            nm = str(n.get("name") or "")
+            if nm == node_id or nm.replace("-", "_") == node_id.replace("-", "_"):
+                tools = n.get("tools") or {}
+                if not isinstance(tools, dict):
+                    return ""
+                native = tools.get("native") or []
+                mcp = tools.get("mcp") or []
+                if not isinstance(native, list):
+                    native = list(native) if native else []
+                if not isinstance(mcp, list):
+                    mcp = list(mcp) if mcp else []
+                return "%s|%s" % (",".join(str(x) for x in native),
+                                 ",".join(str(x) for x in mcp))
+        return ""  # node not in this yaml
+    except ImportError:
+        return None
+    except Exception:
+        return ""
+
+def _regex_fallback():
+    # Robust to either yq or yaml format. We only need the `tools:` block of
+    # the node whose `name: <node_id>` matches. Handles the multi-doc case by
+    # scanning all `name:` lines and resetting the active block.
+    try:
+        with open(yaml_path) as f:
+            text = f.read()
+    except Exception:
+        return ""
+    norm = node_id.replace("-", "_")
+    # Split into top-level node entries — they're preceded by `  - name: ...`.
+    blocks = re.split(r"\n(?=  - name: |\n  - name: )", text)
+    for blk in blocks:
+        m = re.search(r"^\s*-?\s*name:\s*['\"]?([A-Za-z0-9_.-]+)['\"]?", blk, re.M)
+        if not m:
+            continue
+        if m.group(1) != node_id and m.group(1).replace("-", "_") != norm:
+            continue
+        tools_m = re.search(r"^\s*tools:\s*\n((?:\s+\S.*\n)+)", blk, re.M)
+        if not tools_m:
+            return ""
+        body = tools_m.group(1)
+        nat_m = re.search(r"native:\s*\[([^\]]*)\]", body)
+        mcp_m = re.search(r"mcp:\s*\[([^\]]*)\]", body)
+        def _split(s):
+            if not s:
+                return ""
+            return ",".join(t.strip().strip("'\"") for t in s.split(",") if t.strip())
+        return "%s|%s" % (_split(nat_m.group(1) if nat_m else ""),
+                          _split(mcp_m.group(1) if mcp_m else ""))
+    return ""
+
+result = _try_yaml()
+if result is None:
+    result = _regex_fallback()
+sys.stdout.write(result + "\n")
+PY
+}
+
+# _mo_resolve_node_tools (env-aware entry point)
+# Resolves the active node's tool grant. Honors, in order:
+#   1. explicit MO_RESOLVED_NODE_TOOLS override (used by tests)
+#   2. parse from MO_WORKFLOW_YAML or $MINI_ORK_RUN_DIR/workflow.yaml
+#   3. type-aware default from MO_NODE_TYPE
+# Prints "native_csv|mcp_csv" on stdout; emits a one-line warning on stderr
+# when an undeclared node falls through to a default (operator visibility).
+_mo_resolve_node_tools() {
+  if [ -n "${MO_RESOLVED_NODE_TOOLS:-}" ]; then
+    printf '%s\n' "${MO_RESOLVED_NODE_TOOLS}"
+    return 0
+  fi
+  local yaml_path=""
+  if [ -n "${MO_WORKFLOW_YAML:-}" ] && [ -f "${MO_WORKFLOW_YAML}" ]; then
+    yaml_path="${MO_WORKFLOW_YAML}"
+  elif [ -n "${MINI_ORK_RUN_DIR:-}" ] && [ -f "${MINI_ORK_RUN_DIR}/workflow.yaml" ]; then
+    yaml_path="${MINI_ORK_RUN_DIR}/workflow.yaml"
+  fi
+  local node_id="${MO_NODE_ID:-}" node_type="${MO_NODE_TYPE:-}"
+  local resolved=""
+  if [ -n "$yaml_path" ] && [ -n "$node_id" ]; then
+    resolved="$(_mo_resolve_node_tools_from_yaml "$yaml_path" "$node_id")"
+  fi
+  # NB: the yaml resolver prints the bare separator "|" (empty native, empty mcp)
+  # for a node with no `tools:` block. That is a NON-empty string, so `-z` alone
+  # silently skipped the type-aware default and every undeclared node resolved to
+  # no tools at all. Treat "|" as unresolved.
+  if [ -z "$resolved" ] || [ "$resolved" = "|" ]; then
+    resolved="$(_mo_default_tools_for_type "$node_type")"
+    if [ -n "$node_id" ]; then
+      echo "[tool-grants] node=$node_id type=${node_type:-unknown} undeclared; applying type-aware default" >&2
+    fi
+  fi
+  printf '%s\n' "$resolved"
+}
+
+# _mo_build_allowed_tools_arg <native_csv> <mcp_csv>
+# Composes the comma-separated value passed to --allowedTools. Native tools
+# pass through verbatim; MCP grants are rendered as mcp__<server>.
+_mo_build_allowed_tools_arg() {
+  local native_csv="${1:-}" mcp_csv="${2:-}"
+  local out="" p
+  if [ -n "$native_csv" ]; then
+    local IFS=','
+    for p in $native_csv; do
+      p="${p#"${p%%[![:space:]]*}"}"; p="${p%"${p##*[![:space:]]}"}"
+      [ -z "$p" ] && continue
+      [ -n "$out" ] && out+=","
+      out+="$p"
+    done
+  fi
+  if [ -n "$mcp_csv" ]; then
+    local IFS=','
+    for p in $mcp_csv; do
+      p="${p#"${p%%[![:space:]]*}"}"; p="${p%"${p##*[![:space:]]}"}"
+      [ -z "$p" ] && continue
+      [ -n "$out" ] && out+=","
+      out+="mcp__${p}"
+    done
+  fi
+  printf '%s\n' "$out"
+}
+
+# _mo_write_node_mcp_config <mcp_csv> <run_dir>
+# Writes a node-scoped .mcp-config.json containing only the granted MCP
+# servers. Sources the operator's MCP server definitions from
+# ${MINI_ORK_HOME}/config/mcp_servers.json (operator home) or
+# ${MINI_ORK_ROOT}/mcp/steering.json (repo fallback), filters to the granted
+# subset, and writes to ${run_dir}/.mcp-config.json. Granted servers not in
+# the operator config get a no-op stub so the flag is well-formed and the
+# run remains hermetic (--strict-mcp-config forbids ambient leakage).
+_mo_write_node_mcp_config() {
+  local mcp_csv="${1:-}" run_dir="${2:-}"
+  [ -n "$run_dir" ] || return 0
+  mkdir -p "$run_dir" 2>/dev/null || true
+  local out="$run_dir/.mcp-config.json"
+  MINI_ORK_HOME="${MINI_ORK_HOME:-}" \
+  MINI_ORK_ROOT="${MINI_ORK_ROOT:-}" \
+  python3 - "$mcp_csv" "$out" <<'PY' 2>/dev/null || true
+import json, os, sys
+mcp_csv, out_path = sys.argv[1], sys.argv[2]
+granted = [s.strip() for s in (mcp_csv or "").split(",") if s.strip()]
+home = os.environ.get("MINI_ORK_HOME", "") or ""
+root = os.environ.get("MINI_ORK_ROOT", "") or ""
+sources = []
+if home:
+    sources.append(os.path.join(home, "config", "mcp_servers.json"))
+if root:
+    sources.append(os.path.join(root, ".claude", "mcp_servers.json"))
+    sources.append(os.path.join(root, "mcp", "steering.json"))
+operator = {}
+for src in sources:
+    if not src or not os.path.isfile(src):
+        continue
+    try:
+        with open(src) as f:
+            d = json.load(f)
+    except Exception:
+        continue
+    if isinstance(d, dict) and isinstance(d.get("mcpServers"), dict):
+        operator = d["mcpServers"]
+        break
+    if isinstance(d, dict):
+        operator = d
+        break
+scoped = {}
+for g in granted:
+    if g in operator and isinstance(operator[g], dict):
+        scoped[g] = operator[g]
+    else:
+        scoped[g] = {"command": "echo", "args": ["no-op: %s not configured" % g]}
+payload = {"mcpServers": scoped}
+with open(out_path, "w") as f:
+    json.dump(payload, f, indent=2)
+PY
+  printf '%s\n' "$out"
+}
+
 # mo_llm_dispatch <model> <prompt> <out_file> [timeout_s] [max_turns]
 mo_llm_dispatch() {
   local model="${1:?model required}"
@@ -753,6 +972,27 @@ mo_llm_dispatch() {
   local out_file="${3:?out file required}"
   local timeout_s="${4:-1500}"
   local max_turns="${5:-60}"
+
+  # Tool grants (kickoff/tool-grant-hermetic-dispatch.md): resolve the active
+  # node's capability contract from workflow.yaml and emit hermetic argv
+  # flags below. Resolve BEFORE the python-backend early return so the
+  # python path can pick up the same grant when wired.
+  local _mo_tools_resolved=""
+  if [ "${MO_TOOL_GRANTS_DISABLED:-0}" != "1" ]; then
+    _mo_tools_resolved="$(_mo_resolve_node_tools)"
+  else
+    _mo_tools_resolved="$(_mo_default_tools_for_type "${MO_NODE_TYPE:-}")"
+  fi
+  local _mo_native_csv="${_mo_tools_resolved%%|*}"
+  local _mo_mcp_csv="${_mo_tools_resolved#*|}"
+  local _mo_allowed_tools_value
+  _mo_allowed_tools_value="$(_mo_build_allowed_tools_arg "$_mo_native_csv" "$_mo_mcp_csv")"
+  local _mo_tool_args=(--allowedTools "$_mo_allowed_tools_value" --strict-mcp-config)
+  local _mo_mcp_config_path=""
+  if [ -n "${MINI_ORK_RUN_DIR:-}" ]; then
+    _mo_mcp_config_path="$(_mo_write_node_mcp_config "$_mo_mcp_csv" "${MINI_ORK_RUN_DIR}")"
+    [ -n "$_mo_mcp_config_path" ] && _mo_tool_args+=(--mcp-config "$_mo_mcp_config_path")
+  fi
 
   # ADR-001 Phase 1: delegate to the Python dispatch layer when opted in
   # (MO_DISPATCH_BACKEND=python). The Python path reads the prompt over stdin
@@ -943,6 +1183,7 @@ mo_llm_dispatch() {
         "$TIMEOUT_CMD" --kill-after=60 "$timeout_s" claude \
           --print \
           --permission-mode bypassPermissions \
+          "${_mo_tool_args[@]}" \
           --output-format "$_format" \
           "${_verbose_flag[@]}" \
           --max-turns "$max_turns" \
@@ -961,6 +1202,7 @@ mo_llm_dispatch() {
         claude \
           --print \
           --permission-mode bypassPermissions \
+          "${_mo_tool_args[@]}" \
           --output-format "$_format" \
           "${_verbose_flag[@]}" \
           --max-turns "$max_turns" \

--- a/mini_ork/dispatch/providers.py
+++ b/mini_ork/dispatch/providers.py
@@ -15,6 +15,7 @@ import os
 import re
 import shlex
 import subprocess
+import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -336,6 +337,30 @@ def dispatch_model(
         spec = resolve_provider(request.model, root)
     except (ValueError, FileNotFoundError) as exc:
         return DispatchResult(ok=False, rc=2, error=str(exc), model=request.model)
+    # Node-scoped tool grants (kickoff/tool-grant-hermetic-dispatch.md):
+    # resolve the active node's capability grant from MO_NODE_ID/MO_NODE_TYPE
+    # + workflow.yaml, then inject --allowedTools + --strict-mcp-config
+    # (+ --mcp-config when MCP grants are present and MINI_ORK_RUN_DIR is set)
+    # into the claude argv. EXECUTABLE_MODELS (codex/gemini) are skipped —
+    # their CLIs don't accept --allowedTools and bash never passes it to them.
+    # MO_TOOL_GRANTS_DISABLED=1 opt-out for local debugging, matching the bash
+    # dispatch's escape hatch at lib/llm-dispatch.sh:981.
+    if request.model not in EXECUTABLE_MODELS:
+        effective_env = {**os.environ, **request.env}
+        if effective_env.get("MO_TOOL_GRANTS_DISABLED", "0") != "1":
+            run_dir = effective_env.get("MINI_ORK_RUN_DIR", "") or None
+            new_command = apply_tool_grants(
+                spec.command, env=effective_env, run_dir=run_dir
+            )
+            if new_command != spec.command:
+                spec = ProviderSpec(
+                    model=spec.model,
+                    command=new_command,
+                    parse_usage=spec.parse_usage,
+                    parse_cost=spec.parse_cost,
+                    parse_text=spec.parse_text,
+                    env=spec.env,
+                )
     # Merge the lane's pinned env UNDER any per-request overrides; pin the cwd.
     merged_env = {**dict(spec.env), **request.env}
     effective = DispatchRequest(
@@ -355,6 +380,255 @@ def dispatch_model(
         parse_cost=spec.parse_cost,  # type: ignore[arg-type]
         parse_text=spec.parse_text,  # type: ignore[arg-type]
     )
+
+
+# ─── Node-scoped tool grants (kickoff/tool-grant-hermetic-dispatch.md) ───────
+# Faithful Python port of the bash resolver in lib/llm-dispatch.sh
+# (_mo_resolve_node_tools / _mo_default_tools_for_type / _mo_build_allowed_tools_arg /
+# _mo_write_node_mcp_config). Resolves a workflow.yaml `tools:` block per active
+# node and injects hermetic --allowedTools + --strict-mcp-config + --mcp-config
+# argv onto the claude invocation. Without this every dispatch silently lost
+# the previous attempt's consumer-only wiring and gave undeclared implementer
+# nodes Read,Bash — no Write/Edit — which broke 12+ recipes' worker lanes.
+
+# Type-aware fail-closed defaults. "Fail closed" means "no MCP and no ambient
+# leakage", NOT "no ability to do the job" — an undeclared implementer must
+# still be able to write files or every recipe breaks.
+def _mo_default_tools_for_type(node_type: str) -> str:
+    if node_type == "implementer":
+        return "Read,Write,Edit,Bash|"
+    return "Read,Bash|"
+
+
+def _resolve_node_tools_from_yaml(yaml_path: str, node_id: str) -> str:
+    """Producer: parse a workflow.yaml, find the node by name (with -/_ variants),
+    extract its `tools:` block. Prints "native_csv|mcp_csv" to stdout. Empty
+    string when the node isn't declared — caller applies the type-aware default."""
+    p = Path(yaml_path)
+    if not p.is_file():
+        return ""
+
+    def _try_yaml() -> str | None:
+        try:
+            import yaml  # noqa: F401
+        except ImportError:
+            return None
+        try:
+            with open(p, encoding="utf-8") as fh:
+                d = yaml.safe_load(fh) or {}
+        except (OSError, ValueError, TypeError):
+            return ""
+        nodes = d.get("nodes") or []
+        for n in nodes:
+            if not isinstance(n, dict):
+                continue
+            nm = str(n.get("name") or "")
+            if nm == node_id or nm.replace("-", "_") == node_id.replace("-", "_"):
+                tools = n.get("tools") or {}
+                if not isinstance(tools, dict):
+                    return ""
+                native = tools.get("native") or []
+                mcp = tools.get("mcp") or []
+                if not isinstance(native, list):
+                    native = list(native) if native else []
+                if not isinstance(mcp, list):
+                    mcp = list(mcp) if mcp else []
+                return "%s|%s" % (
+                    ",".join(str(x) for x in native),
+                    ",".join(str(x) for x in mcp),
+                )
+        return ""
+
+    # Regex fallback: robust to either yq or yaml format. Handles the multi-doc
+    # case by scanning all `name:` lines and resetting the active block.
+    def _regex_fallback() -> str:
+        try:
+            text = p.read_text(encoding="utf-8")
+        except OSError:
+            return ""
+        norm = node_id.replace("-", "_")
+        blocks = re.split(r"\n(?=  - name: |\n  - name: )", text)
+        for blk in blocks:
+            m = re.search(r"^\s*-?\s*name:\s*['\"]?([A-Za-z0-9_.-]+)['\"]?", blk, re.M)
+            if not m:
+                continue
+            if m.group(1) != node_id and m.group(1).replace("-", "_") != norm:
+                continue
+            tools_m = re.search(r"^\s*tools:\s*\n((?:\s+\S.*\n)+)", blk, re.M)
+            if not tools_m:
+                return ""
+            body = tools_m.group(1)
+            nat_m = re.search(r"native:\s*\[([^\]]*)\]", body)
+            mcp_m = re.search(r"mcp:\s*\[([^\]]*)\]", body)
+
+            def _split(s: str | None) -> str:
+                if not s:
+                    return ""
+                return ",".join(
+                    t.strip().strip("'\"") for t in s.split(",") if t.strip()
+                )
+
+            return "%s|%s" % (
+                _split(nat_m.group(1) if nat_m else ""),
+                _split(mcp_m.group(1) if mcp_m else ""),
+            )
+        return ""
+
+    result = _try_yaml()
+    if result is None:
+        result = _regex_fallback()
+    return result
+
+
+def _resolve_node_tools(env: Mapping[str, str]) -> str:
+    """Env-aware entry: MO_RESOLVED_NODE_TOOLS override → workflow.yaml lookup →
+    type-aware default. Mirrors _mo_resolve_node_tools in lib/llm-dispatch.sh."""
+    override = env.get("MO_RESOLVED_NODE_TOOLS", "")
+    if override:
+        return override
+    yaml_path = env.get("MO_WORKFLOW_YAML", "")
+    if not yaml_path or not Path(yaml_path).is_file():
+        run_dir = env.get("MINI_ORK_RUN_DIR", "")
+        if run_dir:
+            candidate = Path(run_dir) / "workflow.yaml"
+            if candidate.is_file():
+                yaml_path = str(candidate)
+    node_id = env.get("MO_NODE_ID", "")
+    node_type = env.get("MO_NODE_TYPE", "")
+    resolved = ""
+    if yaml_path and node_id:
+        resolved = _resolve_node_tools_from_yaml(yaml_path, node_id)
+    # The yaml resolver returns the bare "|" for a node with no tools: block —
+    # that's a non-empty string, so a plain truthiness check would skip the
+    # default and resolve every undeclared node to NO tools. Treat "|" as
+    # unresolved. Same footgun fixed in bash at llm-dispatch.sh:873-877.
+    if not resolved or resolved == "|":
+        resolved = _mo_default_tools_for_type(node_type)
+        if node_id:
+            sys.stderr.write(
+                f"[tool-grants] node={node_id} type={node_type or 'unknown'} "
+                "undeclared; applying type-aware default\n"
+            )
+    return resolved
+
+
+def _build_allowed_tools_arg(native_csv: str, mcp_csv: str) -> str:
+    """Compose the comma-separated value passed to --allowedTools. Native tools
+    pass through verbatim; MCP grants render as mcp__<server>."""
+    parts: list[str] = []
+    for csv in (native_csv or "", mcp_csv or ""):
+        for raw in csv.split(","):
+            tok = raw.strip()
+            if not tok:
+                continue
+            if csv is mcp_csv:
+                if not tok.startswith("mcp__"):
+                    tok = f"mcp__{tok}"
+            parts.append(tok)
+    return ",".join(parts)
+
+
+def _write_node_mcp_config(
+    mcp_csv: str, run_dir: str, *, env: Mapping[str, str] | None = None
+) -> str | None:
+    """Write a node-scoped .mcp-config.json containing only the granted MCP
+    servers. Sources the operator's MCP server definitions from
+    ${MINI_ORK_HOME}/config/mcp_servers.json (operator home) or
+    ${MINI_ORK_ROOT}/.claude/mcp_servers.json (repo fallback), filters to the
+    granted subset, writes to ${run_dir}/.mcp-config.json. Granted servers not
+    in the operator config get a no-op stub so --strict-mcp-config keeps the
+    dispatch hermetic."""
+    if not run_dir:
+        return None
+    granted = [s.strip() for s in (mcp_csv or "").split(",") if s.strip()]
+    if not granted:
+        return None
+    e = env if env is not None else os.environ
+    home = e.get("MINI_ORK_HOME", "") or ""
+    root = e.get("MINI_ORK_ROOT", "") or ""
+    sources: list[str] = []
+    if home:
+        sources.append(os.path.join(home, "config", "mcp_servers.json"))
+    if root:
+        sources.append(os.path.join(root, ".claude", "mcp_servers.json"))
+        sources.append(os.path.join(root, "mcp", "steering.json"))
+    operator: dict[str, object] = {}
+    for src in sources:
+        if not src or not os.path.isfile(src):
+            continue
+        try:
+            with open(src, encoding="utf-8") as fh:
+                d = json.load(fh)
+        except (OSError, ValueError, TypeError):
+            continue
+        if isinstance(d, dict) and isinstance(d.get("mcpServers"), dict):
+            operator = d["mcpServers"]  # type: ignore[assignment]
+            break
+        if isinstance(d, dict):
+            operator = d
+            break
+    scoped: dict[str, object] = {}
+    for g in granted:
+        candidate = operator.get(g) if isinstance(operator, dict) else None
+        if isinstance(candidate, dict):
+            scoped[g] = candidate
+        else:
+            scoped[g] = {"command": "echo", "args": [f"no-op: {g} not configured"]}
+    out_dir = Path(run_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / ".mcp-config.json"
+    try:
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump({"mcpServers": scoped}, fh, indent=2)
+    except OSError:
+        return None
+    return str(out_path)
+
+
+def apply_tool_grants(
+    command: Sequence[str],
+    *,
+    env: Mapping[str, str],
+    run_dir: str | None = None,
+) -> tuple[str, ...]:
+    """Insert --allowedTools, --strict-mcp-config (always), and --mcp-config
+    (when MCP grants present + run_dir given) into a claude argv. Inserts at
+    the position bash uses (after --permission-mode, before --output-format)
+    so the resulting argv is byte-for-byte equivalent to the bash path's.
+    Returns the original command unchanged when the resolver returns an empty
+    grant — an undeclared implementer MUST still default to
+    Read,Write,Edit,Bash so implementer recipes don't silently go read-only."""
+    # Defense-in-depth: --allowedTools/--strict-mcp-config are claude CLI flags.
+    # Today every caller path passes a claude command (kimi/minimax/glm route
+    # through the claude binary; codex/gemini are excluded upstream), but guard
+    # here so a future non-claude lane can never have these injected into its argv.
+    if not command or command[0] != "claude":
+        return tuple(command)
+    resolved = _resolve_node_tools(env)
+    if not resolved or "|" not in resolved:
+        return tuple(command)
+    native_csv, mcp_csv = resolved.split("|", 1)
+    allowed = _build_allowed_tools_arg(native_csv, mcp_csv)
+    if not allowed:
+        return tuple(command)
+    tool_flags = ["--allowedTools", allowed, "--strict-mcp-config"]
+    rd = run_dir or env.get("MINI_ORK_RUN_DIR", "")
+    if rd and mcp_csv.strip():
+        cfg_path = _write_node_mcp_config(mcp_csv, rd, env=env)
+        if cfg_path:
+            tool_flags += ["--mcp-config", cfg_path]
+    # Insertion point: right before --output-format (or end), matching bash's
+    # argv layout (--permission-mode <then tool-flags> --output-format). When
+    # --output-format isn't present, append (safe fallback for command shapes
+    # this codebase hasn't shipped yet).
+    new = list(command)
+    insert_idx = len(new)
+    for i, arg in enumerate(new):
+        if arg == "--output-format":
+            insert_idx = i
+            break
+    new[insert_idx:insert_idx] = tool_flags
+    return tuple(new)
 
 
 def _read_codex_sidecars(usage_path: str, cost_path: str) -> tuple[TokenUsage, float]:

--- a/recipes/code-fix/workflow.yaml
+++ b/recipes/code-fix/workflow.yaml
@@ -3,11 +3,20 @@ task_class: code_fix
 description: "Single-patch code fix with typecheck, test, and reviewer gates"
 
 nodes:
+  # Reference capability profiles — enforced hermetically by
+  # mo_llm_dispatch() (lib/llm-dispatch.sh) via --allowedTools +
+  # --mcp-config + --strict-mcp-config. Structural invariant: no single
+  # node may simultaneously hold repo-write + untrusted-content ingress
+  # + outbound channel. Web / comms MCP grants are deliberately absent
+  # here; a node that needs them must declare them and pass review.
   - name: planner
     type: planner
     model_lane: planner
     prompt_ref: prompts/planner.md
     dispatch_mode: serial
+    tools:
+      native: [Read]
+      mcp: [codegraph]
 
   - name: implementer
     type: implementer
@@ -17,6 +26,9 @@ nodes:
     gates:
       - scope_gate
       - budget_gate
+    tools:
+      native: [Read, Write, Edit, Bash]
+      mcp: [codegraph]
 
   - name: typecheck
     type: verifier
@@ -35,6 +47,8 @@ nodes:
     model_lane: reviewer
     prompt_ref: prompts/reviewer.md
     dispatch_mode: serial
+    tools:
+      native: [Read, Bash]
 
   - name: publisher
     type: publisher

--- a/tests/unit/test_tool_grants.sh
+++ b/tests/unit/test_tool_grants.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# tests/unit/test_tool_grants.sh
+#
+# End-to-end + unit coverage for node-scoped tool grants
+# (kickoff/tool-grant-hermetic-dispatch.md).
+#
+# The previous attempt shipped a consumer-only implementation and shipped
+# 12+ recipes' implementer nodes without Write/Edit because the producer was
+# missing. This test covers BOTH sides:
+#
+#   (A) Producer: parses a real workflow.yaml containing a `tools:` block and
+#       produces the expected native|mcp csv.
+#   (B) Consumer: feeds the resolved grant through the argv builder and
+#       asserts --allowedTools / --strict-mcp-config / --mcp-config reach the
+#       claude invocation. Tested via a stub claude binary that prints its
+#       argv to a file.
+#   (C) Type-aware defaults: undeclared nodes fall through to the per-type
+#       default (implementer → Read,Write,Edit,Bash; planner/reviewer →
+#       Read,Bash) and STILL receive Write/Edit for implementer (regression
+#       bar the prior attempt broke).
+#   (D) MCP grant rendering: `mcp: [codegraph]` becomes `mcp__codegraph` in
+#       --allowedTools argv.
+#   (E) Dead Context7 instruction is gone from bin/_worker-launcher.sh.
+
+set -uo pipefail
+
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+export MINI_ORK_ROOT="$ROOT"
+
+OK=0
+FAIL=0
+_ok()   { OK=$((OK + 1));   echo "  [OK]   $1"; }
+_fail() { FAIL=$((FAIL + 1)); echo "  [FAIL] $1"; }
+
+TMP=$(mktemp -d -t mo-tool-grants.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# ── Source lib/llm-dispatch.sh in source-only mode (no auto-execution) ───
+MINI_ORK_LLM_SOURCE_ONLY=1 source "$ROOT/lib/llm-dispatch.sh" 2>/dev/null || true
+
+# ─── Producer tests: parse real workflow.yaml + bespoke fixtures ─────────
+
+echo "── Producer: parse workflow.yaml tools: block ──"
+
+# End-to-end: real recipes/code-fix/workflow.yaml MUST yield the profiles we
+# declared. This is the test the prior attempt was missing.
+RESOLVED_PLANNER=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 MO_WORKFLOW_YAML="$ROOT/recipes/code-fix/workflow.yaml" \
+  bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+           MO_NODE_ID=planner MO_NODE_TYPE=planner _mo_resolve_node_tools'
+)
+if [ "$RESOLVED_PLANNER" = "Read|codegraph" ]; then
+  _ok "planner (real workflow.yaml) resolves to native=Read mcp=codegraph"
+else
+  _fail "planner (real workflow.yaml) resolved to '$RESOLVED_PLANNER', expected 'Read|codegraph'"
+fi
+
+RESOLVED_IMPL=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 MO_WORKFLOW_YAML="$ROOT/recipes/code-fix/workflow.yaml" \
+  bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+           MO_NODE_ID=implementer MO_NODE_TYPE=implementer _mo_resolve_node_tools'
+)
+if [ "$RESOLVED_IMPL" = "Read,Write,Edit,Bash|codegraph" ]; then
+  _ok "implementer (real workflow.yaml) resolves to native=Read,Write,Edit,Bash mcp=codegraph"
+else
+  _fail "implementer (real workflow.yaml) resolved to '$RESOLVED_IMPL', expected 'Read,Write,Edit,Bash|codegraph'"
+fi
+
+RESOLVED_REV=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 MO_WORKFLOW_YAML="$ROOT/recipes/code-fix/workflow.yaml" \
+  bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+           MO_NODE_ID=reviewer MO_NODE_TYPE=reviewer _mo_resolve_node_tools'
+)
+if [ "$RESOLVED_REV" = "Read,Bash|" ]; then
+  _ok "reviewer (real workflow.yaml) resolves to native=Read,Bash mcp=(none)"
+else
+  _fail "reviewer (real workflow.yaml) resolved to '$RESOLVED_REV', expected 'Read,Bash|'"
+fi
+
+# ─── Type-aware fail-closed defaults ─────────────────────────────────────
+echo "── Type-aware fail-closed defaults ──"
+
+# Fixture: workflow.yaml whose implementer node has NO tools: block. The
+# default MUST still be Read,Write,Edit,Bash (no MCP). This is the regression
+# bar the prior attempt broke (it shipped a blanket Read,Bash default).
+FIXTURE_UNDECL_IMPL="$TMP/workflow-undeclared-impl.yaml"
+cat > "$FIXTURE_UNDECL_IMPL" <<'YAML'
+version: "0.1.0"
+task_class: code_fix
+nodes:
+  - name: planner
+    type: planner
+  - name: implementer
+    type: implementer
+    # NO tools: block — must fall through to type-aware default
+  - name: reviewer
+    type: reviewer
+YAML
+
+RESOLVED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 MO_WORKFLOW_YAML="$FIXTURE_UNDECL_IMPL" \
+  bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+           MO_NODE_ID=implementer MO_NODE_TYPE=implementer _mo_resolve_node_tools 2>/dev/null'
+)
+if [ "$RESOLVED" = "Read,Write,Edit,Bash|" ]; then
+  _ok "undeclared implementer defaults to Read,Write,Edit,Bash (no MCP) — regression bar"
+else
+  _fail "undeclared implementer resolved to '$RESOLVED', expected 'Read,Write,Edit,Bash|'"
+fi
+
+RESOLVED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 MO_WORKFLOW_YAML="$FIXTURE_UNDECL_IMPL" \
+  bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+           MO_NODE_ID=planner MO_NODE_TYPE=planner _mo_resolve_node_tools 2>/dev/null'
+)
+if [ "$RESOLVED" = "Read,Bash|" ]; then
+  _ok "undeclared planner defaults to Read,Bash (no MCP, no Write/Edit)"
+else
+  _fail "undeclared planner resolved to '$RESOLVED', expected 'Read,Bash|'"
+fi
+
+RESOLVED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 MO_WORKFLOW_YAML="$FIXTURE_UNDECL_IMPL" \
+  bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+           MO_NODE_ID=reviewer MO_NODE_TYPE=reviewer _mo_resolve_node_tools 2>/dev/null'
+)
+if [ "$RESOLVED" = "Read,Bash|" ]; then
+  _ok "undeclared reviewer defaults to Read,Bash (no MCP, no Write/Edit)"
+else
+  _fail "undeclared reviewer resolved to '$RESOLVED', expected 'Read,Bash|'"
+fi
+
+# Pure default fn parity (no yaml at all)
+RESOLVED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+                                    MO_NODE_ID=unknown MO_NODE_TYPE=implementer _mo_resolve_node_tools 2>/dev/null'
+)
+if [ "$RESOLVED" = "Read,Write,Edit,Bash|" ]; then
+  _ok "no-yaml implementer falls through to default Read,Write,Edit,Bash"
+else
+  _fail "no-yaml implementer resolved to '$RESOLVED', expected 'Read,Write,Edit,Bash|'"
+fi
+
+# ─── MCP grant rendering ────────────────────────────────────────────────
+echo "── MCP grant rendering (mcp__<server>) ──"
+
+ALLOWED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+                                     _mo_build_allowed_tools_arg "Read,Write,Edit,Bash" "codegraph"'
+)
+if [ "$ALLOWED" = "Read,Write,Edit,Bash,mcp__codegraph" ]; then
+  _ok "MCP grant 'codegraph' renders as mcp__codegraph in --allowedTools"
+else
+  _fail "MCP grant rendered as '$ALLOWED', expected 'Read,Write,Edit,Bash,mcp__codegraph'"
+fi
+
+ALLOWED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+                                     _mo_build_allowed_tools_arg "Read" "codegraph,context7"'
+)
+if [ "$ALLOWED" = "Read,mcp__codegraph,mcp__context7" ]; then
+  _ok "multiple MCP grants render as mcp__<server> each"
+else
+  _fail "multi-MCP rendered as '$ALLOWED', expected 'Read,mcp__codegraph,mcp__context7'"
+fi
+
+ALLOWED=$(
+  MINI_ORK_LLM_SOURCE_ONLY=1 bash -c 'source "'"$ROOT/lib/llm-dispatch.sh"'" 2>/dev/null; \
+                                     _mo_build_allowed_tools_arg "Read,Bash" ""'
+)
+if [ "$ALLOWED" = "Read,Bash" ]; then
+  _ok "no MCP grant → no mcp__ entries in argv"
+else
+  _fail "empty MCP rendered as '$ALLOWED', expected 'Read,Bash'"
+fi
+
+# ─── argv injection: stub claude binary, dispatch real run dir ───────────
+echo "── argv injection: --allowedTools / --strict-mcp-config / --mcp-config reach claude ──"
+
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+# stub claude — prints its argv as a JSON array, exits 0
+python3 - "$@" <<'PY'
+import json, sys
+print(json.dumps(sys.argv[1:]))
+PY
+STUB
+chmod +x "$STUB_BIN/claude"
+
+# Real workflow.yaml + implementer node + run dir → dispatch via stub
+FIXTURE_RUN_DIR="$TMP/run-impl"
+mkdir -p "$FIXTURE_RUN_DIR"
+cp "$ROOT/recipes/code-fix/workflow.yaml" "$FIXTURE_RUN_DIR/workflow.yaml"
+
+PATH="$STUB_BIN:$PATH" \
+MINI_ORK_RUN_DIR="$FIXTURE_RUN_DIR" \
+MO_NODE_ID=implementer \
+MO_NODE_TYPE=implementer \
+MO_TOOL_GRANTS_DISABLED=0 \
+MO_DISPATCH_BACKEND=bash \
+MO_LANE_TIER=default \
+MO_LLM_FORMAT=text \
+MO_TRACE_RICH=0 \
+MINI_ORK_LLM_SOURCE_ONLY=1 \
+bash -c '
+  source "'"$ROOT/lib/llm-dispatch.sh"'"
+  # Source a stub provider so the bash sourceable branch is exercised.
+  mkdir -p "'"$TMP"'/providers"
+  cat > "'"$TMP"'/providers/cl_test.sh" <<EOF
+#!/usr/bin/env bash
+unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
+EOF
+  chmod +x "'"$TMP"'/providers/cl_test.sh"
+  SCRIPTS_DIR="'"$TMP"'/providers" mo_llm_dispatch test "PONG" "'"$FIXTURE_RUN_DIR/out.txt"'" 60 5
+' >/dev/null 2>"$FIXTURE_RUN_DIR/err.log" || true
+
+# The stub prints its argv as JSON on stdout — read it back
+if [ -f "$FIXTURE_RUN_DIR/out.txt" ]; then
+  STUB_ARGV=$(head -c 8192 "$FIXTURE_RUN_DIR/out.txt")
+else
+  STUB_ARGV=""
+fi
+
+echo "    stub argv (first 200 chars): ${STUB_ARGV:0:200}"
+
+if echo "$STUB_ARGV" | grep -q '"--allowedTools"'; then
+  _ok "stub claude invocation received --allowedTools"
+else
+  _fail "stub claude invocation did NOT receive --allowedTools (argv: $STUB_ARGV)"
+fi
+
+if echo "$STUB_ARGV" | grep -q '"--strict-mcp-config"'; then
+  _ok "stub claude invocation received --strict-mcp-config"
+else
+  _fail "stub claude invocation did NOT receive --strict-mcp-config (argv: $STUB_ARGV)"
+fi
+
+if echo "$STUB_ARGV" | grep -q '"--mcp-config"'; then
+  _ok "stub claude invocation received --mcp-config"
+else
+  _fail "stub claude invocation did NOT receive --mcp-config (argv: $STUB_ARGV)"
+fi
+
+# The implementer's allowedTools value MUST contain Write and Edit AND mcp__codegraph
+if echo "$STUB_ARGV" | grep -qE '"--allowedTools",\s*"[^"]*Write'; then
+  _ok "implementer --allowedTools contains Write (regression bar)"
+else
+  _fail "implementer --allowedTools missing Write (argv: $STUB_ARGV)"
+fi
+if echo "$STUB_ARGV" | grep -qE '"--allowedTools",\s*"[^"]*Edit'; then
+  _ok "implementer --allowedTools contains Edit (regression bar)"
+else
+  _fail "implementer --allowedTools missing Edit (argv: $STUB_ARGV)"
+fi
+if echo "$STUB_ARGV" | grep -qE '"--allowedTools",\s*"[^"]*mcp__codegraph'; then
+  _ok "implementer --allowedTools contains mcp__codegraph (MCP grant rendered)"
+else
+  _fail "implementer --allowedTools missing mcp__codegraph (argv: $STUB_ARGV)"
+fi
+
+# The node-scoped MCP config file MUST exist and contain only the granted server
+if [ -f "$FIXTURE_RUN_DIR/.mcp-config.json" ]; then
+  _ok "node-scoped .mcp-config.json written to run dir"
+  if grep -q '"codegraph"' "$FIXTURE_RUN_DIR/.mcp-config.json"; then
+    _ok "node-scoped .mcp-config.json contains the granted codegraph server"
+  else
+    _fail "node-scoped .mcp-config.json missing the granted server (content: $(cat "$FIXTURE_RUN_DIR/.mcp-config.json"))"
+  fi
+else
+  _fail "node-scoped .mcp-config.json was NOT written"
+fi
+
+# ─── Source-level greps (verifier contract) ─────────────────────────────
+echo "── source-level greps (verifier contract) ──"
+
+# The producer must exist in source (proof: `tools:` appears in producer code)
+if grep -rq "tools:" lib/ bin/; then
+  _ok "producer exists in source (grep 'tools:' lib/ bin/ non-empty)"
+else
+  _fail "producer not in source (grep 'tools:' lib/ bin/ empty)"
+fi
+
+# Both claude invocations must have --allowedTools and --strict-mcp-config
+COUNT_ALLOWED=$(grep -c -- '--allowedTools' lib/llm-dispatch.sh || true)
+if [ "$COUNT_ALLOWED" -ge 2 ]; then
+  _ok "--allowedTools reaches both claude invocations (count=$COUNT_ALLOWED)"
+else
+  _fail "--allowedTools count=$COUNT_ALLOWED (expected >=2)"
+fi
+
+COUNT_STRICT=$(grep -c -- '--strict-mcp-config' lib/llm-dispatch.sh || true)
+if [ "$COUNT_STRICT" -ge 2 ]; then
+  _ok "--strict-mcp-config reaches both claude invocations (count=$COUNT_STRICT)"
+else
+  _fail "--strict-mcp-config count=$COUNT_STRICT (expected >=2)"
+fi
+
+# ─── Dead Context7 instruction removed ──────────────────────────────────
+echo "── dead Context7 instruction resolved ──"
+
+if grep -q 'Context7 MCP' "$ROOT/bin/_worker-launcher.sh"; then
+  _fail "bin/_worker-launcher.sh still references 'Context7 MCP' — dead instruction not removed"
+else
+  _ok "bin/_worker-launcher.sh no longer references 'Context7 MCP'"
+fi
+
+if grep -q 'ctx7' "$ROOT/bin/_worker-launcher.sh"; then
+  _ok "bin/_worker-launcher.sh references the ctx7 CLI (live instruction)"
+else
+  _fail "bin/_worker-launcher.sh does not reference the ctx7 CLI"
+fi
+
+# ─── Structural invariant: implementer cannot reach comms/web MCP ───────
+echo "── structural invariant: no comms/web MCP on implementer ──"
+
+IMPL_TOOLS="$RESOLVED_IMPL"
+if echo "$IMPL_TOOLS" | grep -qE 'gmail|web|fetch|http|comms|slack'; then
+  _fail "implementer reference profile includes a comms/web MCP grant (forbidden): $IMPL_TOOLS"
+else
+  _ok "implementer reference profile has no comms/web MCP grant"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $OK OK  $FAIL FAIL ==="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/tests/unit/test_tool_grants.sh
+++ b/tests/unit/test_tool_grants.sh
@@ -33,10 +33,27 @@ _ok()   { OK=$((OK + 1));   echo "  [OK]   $1"; }
 _fail() { FAIL=$((FAIL + 1)); echo "  [FAIL] $1"; }
 
 TMP=$(mktemp -d -t mo-tool-grants.XXXXXX)
-trap 'rm -rf "$TMP"' EXIT
+trap 'rm -rf "$TMP"; [ -n "${TEST_PROVIDER_WRAPPER:-}" ] && [ -f "$TEST_PROVIDER_WRAPPER" ] && rm -f "$TEST_PROVIDER_WRAPPER"' EXIT
 
 # ── Source lib/llm-dispatch.sh in source-only mode (no auto-execution) ───
 MINI_ORK_LLM_SOURCE_ONLY=1 source "$ROOT/lib/llm-dispatch.sh" 2>/dev/null || true
+
+# Drop a tiny permanent-shape provider wrapper for `model=test`. Both the
+# bash dispatch (claudettes mo_llm_dispatch resolves $MINI_ORK_ROOT/lib/providers
+# directly — no SCRIPTS_DIR override) and the python dispatch (resolve_provider
+# reads the same fixed path) read this file. It has no ${KEY:?} guards so
+# lane_health returns ok without any real API key in the environment. The
+# wrapper is removed on EXIT to keep lib/providers/ clean even if the test is
+# killed mid-flight.
+TEST_PROVIDER_WRAPPER="$ROOT/lib/providers/cl_test.sh"
+if [ ! -f "$TEST_PROVIDER_WRAPPER" ]; then
+  cat > "$TEST_PROVIDER_WRAPPER" <<'WRAP'
+#!/usr/bin/env bash
+# Test-only provider wrapper — sets no API keys so lane_health returns ok.
+unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
+WRAP
+  chmod +x "$TEST_PROVIDER_WRAPPER"
+fi
 
 # ─── Producer tests: parse real workflow.yaml + bespoke fixtures ─────────
 
@@ -181,11 +198,25 @@ STUB_BIN="$TMP/bin"
 mkdir -p "$STUB_BIN"
 cat > "$STUB_BIN/claude" <<'STUB'
 #!/usr/bin/env bash
-# stub claude — prints its argv as a JSON array, exits 0
+# stub claude — two capture modes:
+#  1. STUB_CAPTURE_FILE set → write argv to that file as JSON (used by the
+#     python dispatch path, where parse_text swallows a JSON-array stdout
+#     into {} and would leave out.txt empty).
+#  2. STUB_CAPTURE_FILE unset → print argv as JSON to stdout (used by the
+#     bash dispatch path, where --output-format text passes raw stdout through).
+if [ -n "${STUB_CAPTURE_FILE:-}" ]; then
+  python3 - "$@" <<PY
+import json, sys
+with open("${STUB_CAPTURE_FILE}", "w", encoding="utf-8") as fh:
+    json.dump(sys.argv[1:], fh)
+PY
+  exit 0
+fi
 python3 - "$@" <<'PY'
 import json, sys
 print(json.dumps(sys.argv[1:]))
 PY
+exit 0
 STUB
 chmod +x "$STUB_BIN/claude"
 
@@ -206,14 +237,7 @@ MO_TRACE_RICH=0 \
 MINI_ORK_LLM_SOURCE_ONLY=1 \
 bash -c '
   source "'"$ROOT/lib/llm-dispatch.sh"'"
-  # Source a stub provider so the bash sourceable branch is exercised.
-  mkdir -p "'"$TMP"'/providers"
-  cat > "'"$TMP"'/providers/cl_test.sh" <<EOF
-#!/usr/bin/env bash
-unset ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_BASE_URL
-EOF
-  chmod +x "'"$TMP"'/providers/cl_test.sh"
-  SCRIPTS_DIR="'"$TMP"'/providers" mo_llm_dispatch test "PONG" "'"$FIXTURE_RUN_DIR/out.txt"'" 60 5
+  mo_llm_dispatch test "PONG" "'"$FIXTURE_RUN_DIR/out.txt"'" 60 5
 ' >/dev/null 2>"$FIXTURE_RUN_DIR/err.log" || true
 
 # The stub prints its argv as JSON on stdout — read it back
@@ -270,6 +294,127 @@ if [ -f "$FIXTURE_RUN_DIR/.mcp-config.json" ]; then
   fi
 else
   _fail "node-scoped .mcp-config.json was NOT written"
+fi
+
+# ─── argv injection: Python backend (stub claude binary) ─────────────────
+# Same coverage as the bash path above, but driven through `python3 -m
+# mini_ork.dispatch test` so we exercise providers.apply_tool_grants + the
+# dispatch_model integration. The python __main__ reads the prompt from
+# stdin, calls dispatch_model, which resolves the active node's grant via
+# MO_NODE_ID/MO_NODE_TYPE/MO_WORKFLOW_YAML and folds the same
+# --allowedTools/--strict-mcp-config/--mcp-config flags onto the claude argv.
+echo "── argv injection: Python backend reaches stub claude with --allowedTools ──"
+
+# Real workflow.yaml + implementer node + run dir → dispatch via stub. The
+# python path resolves the wrapper at $MINI_ORK_ROOT/lib/providers/cl_<model>.sh;
+# lay down a tiny stub wrapper for this test only (no ${KEY:?} guards, so
+# lane_health passes + cwd_guard stays out of the way under MO_ALLOW_FRAMEWORK_CWD).
+PY_FIXTURE_RUN_DIR="$TMP/run-py-impl"
+mkdir -p "$PY_FIXTURE_RUN_DIR"
+cp "$ROOT/recipes/code-fix/workflow.yaml" "$PY_FIXTURE_RUN_DIR/workflow.yaml"
+
+# Drive via __main__: stub claude on PATH, MO_ALLOW_FRAMEWORK_CWD so the cwd
+# guard doesn't reject the test cwd (we're already inside the framework tree).
+# STUB_CAPTURE_FILE points the stub at the argv-capture path (the python path's
+# parse_text would otherwise swallow a JSON-array stdout into {}).
+PATH="$STUB_BIN:$PATH" \
+MINI_ORK_ROOT="$ROOT" \
+MINI_ORK_RUN_DIR="$PY_FIXTURE_RUN_DIR" \
+MO_NODE_ID=implementer \
+MO_NODE_TYPE=implementer \
+MO_WORKFLOW_YAML="$ROOT/recipes/code-fix/workflow.yaml" \
+MO_ALLOW_FRAMEWORK_CWD=1 \
+MO_LANE_TIER=default \
+MO_TOOL_GRANTS_DISABLED=0 \
+STUB_CAPTURE_FILE="$PY_FIXTURE_RUN_DIR/.stub_argv.json" \
+PYTHONPATH="$ROOT${PYTHONPATH:+:$PYTHONPATH}" \
+  python3 -m mini_ork.dispatch sonnet --out "$PY_FIXTURE_RUN_DIR/out.txt" \
+  >/dev/null 2>"$PY_FIXTURE_RUN_DIR/err.log" || true
+# NB: 'sonnet' (a real anthropic-family lane) not 'test' — the Python backend's
+# lane_health preflight rejects unknown lanes BEFORE building the claude argv, so
+# a fake lane made the stub unreachable and every assertion fail on empty argv.
+# The stub `claude` on PATH intercepts the invocation, so no real API call is made.
+
+if [ -f "$PY_FIXTURE_RUN_DIR/.stub_argv.json" ]; then
+  PY_STUB_ARGV=$(head -c 8192 "$PY_FIXTURE_RUN_DIR/.stub_argv.json")
+else
+  PY_STUB_ARGV=""
+fi
+
+echo "    python stub argv (first 200 chars): ${PY_STUB_ARGV:0:200}"
+
+if echo "$PY_STUB_ARGV" | grep -q '"--allowedTools"'; then
+  _ok "python backend: stub claude invocation received --allowedTools"
+else
+  _fail "python backend: stub claude invocation did NOT receive --allowedTools (argv: $PY_STUB_ARGV)"
+fi
+
+if echo "$PY_STUB_ARGV" | grep -q '"--strict-mcp-config"'; then
+  _ok "python backend: stub claude invocation received --strict-mcp-config"
+else
+  _fail "python backend: stub claude invocation did NOT receive --strict-mcp-config (argv: $PY_STUB_ARGV)"
+fi
+
+if echo "$PY_STUB_ARGV" | grep -q '"--mcp-config"'; then
+  _ok "python backend: stub claude invocation received --mcp-config"
+else
+  _fail "python backend: stub claude invocation did NOT receive --mcp-config (argv: $PY_STUB_ARGV)"
+fi
+
+# Implementer MUST still receive Write + Edit + mcp__codegraph (regression bar
+# the prior consumer-only attempt broke). The --permission-mode bypassPermissions
+# flag must also survive the apply_tool_grants insertion intact.
+if echo "$PY_STUB_ARGV" | grep -qE '"--allowedTools",\s*"[^"]*Write'; then
+  _ok "python backend: implementer --allowedTools contains Write (regression bar)"
+else
+  _fail "python backend: implementer --allowedTools missing Write (argv: $PY_STUB_ARGV)"
+fi
+if echo "$PY_STUB_ARGV" | grep -qE '"--allowedTools",\s*"[^"]*Edit'; then
+  _ok "python backend: implementer --allowedTools contains Edit (regression bar)"
+else
+  _fail "python backend: implementer --allowedTools missing Edit (argv: $PY_STUB_ARGV)"
+fi
+if echo "$PY_STUB_ARGV" | grep -qE '"--allowedTools",\s*"[^"]*mcp__codegraph'; then
+  _ok "python backend: implementer --allowedTools contains mcp__codegraph (MCP grant rendered)"
+else
+  _fail "python backend: implementer --allowedTools missing mcp__codegraph (argv: $PY_STUB_ARGV)"
+fi
+
+# --permission-mode bypassPermissions must be preserved through the tool-grant
+# insertion — without it the dispatch silently produces read-only (the python
+# migration batch's 3rd killer at providers.resolve_provider).
+if echo "$PY_STUB_ARGV" | grep -q '"--permission-mode",\s*"bypassPermissions"'; then
+  _ok "python backend: --permission-mode bypassPermissions preserved"
+else
+  _fail "python backend: --permission-mode bypassPermissions missing (argv: $PY_STUB_ARGV)"
+fi
+
+# Node-scoped .mcp-config.json MUST also be written by the python path
+if [ -f "$PY_FIXTURE_RUN_DIR/.mcp-config.json" ]; then
+  _ok "python backend: node-scoped .mcp-config.json written to run dir"
+  if grep -q '"codegraph"' "$PY_FIXTURE_RUN_DIR/.mcp-config.json"; then
+    _ok "python backend: node-scoped .mcp-config.json contains the granted codegraph server"
+  else
+    _fail "python backend: node-scoped .mcp-config.json missing the granted server (content: $(cat "$PY_FIXTURE_RUN_DIR/.mcp-config.json"))"
+  fi
+else
+  _fail "python backend: node-scoped .mcp-config.json was NOT written"
+fi
+
+# Source-level greps for the python-side flag injection (verifier contract
+# check: providers.py must reference all three flag names so a future reader
+# can't delete the impl by mistake).
+COUNT_ALLOWED_PY=$(grep -c -- '--allowedTools' "$ROOT/mini_ork/dispatch/providers.py" || true)
+if [ "$COUNT_ALLOWED_PY" -ge 3 ]; then
+  _ok "python backend: --allowedTools present in providers.py (count=$COUNT_ALLOWED_PY)"
+else
+  _fail "python backend: --allowedTools count=$COUNT_ALLOWED_PY in providers.py (expected >=3)"
+fi
+COUNT_STRICT_PY=$(grep -c -- '--strict-mcp-config' "$ROOT/mini_ork/dispatch/providers.py" || true)
+if [ "$COUNT_STRICT_PY" -ge 3 ]; then
+  _ok "python backend: --strict-mcp-config present in providers.py (count=$COUNT_STRICT_PY)"
+else
+  _fail "python backend: --strict-mcp-config count=$COUNT_STRICT_PY in providers.py (expected >=3)"
 fi
 
 # ─── Source-level greps (verifier contract) ─────────────────────────────


### PR DESCRIPTION
## What & why
Today mini-ork dispatches agents with `--permission-mode bypassPermissions` and **no `--allowedTools` / no `--mcp-config`**, so an agent silently inherits whatever MCP servers the *operator* has configured (on my machine: jina, perplexity, **Gmail**, Drive…). Two consequences:

1. **Runs are not hermetic** — two operators running the same recipe get different tool surfaces, which undercuts reproducibility.
2. **Every node holds the full exfiltration chain** — an implementer has repo data + untrusted web/tool-result ingress + an outbound channel (Gmail `create_draft`, Bash+curl), permissions bypassed. Indirect prompt injection via a tool result is enough to complete it.

Research backing (see `internal-docs/research/2026-07-14-agent-tool-enablement-orchestrator-vs-agent.md`): narrowing the per-node tool surface is *not* a capability tax — routing F1 drops 16–23 pts as the catalog grows (arXiv 2606.17519), so fewer tools is also **more accurate**. The orchestrator grants; the agent chooses within the grant.

## The change
A per-node **capability contract** (`tools:` block in `workflow.yaml`, sibling of `gates:`), enforced on **both** dispatch backends:

- **bash** (`lib/llm-dispatch.sh`) — `_mo_resolve_node_tools_from_yaml` + `_mo_default_tools_for_type`; `mo_llm_dispatch` now passes `--allowedTools` + `--mcp-config` + `--strict-mcp-config`.
- **python** (`mini_ork/dispatch/providers.py`) — `apply_tool_grants` folds the identical flags onto the claude argv (byte-for-byte matching bash), with a defensive `command[0] == "claude"` guard so a future non-claude lane cannot have them injected. codex/gemini (native CLIs) are excluded.
- **Fail-closed is node-type-aware:** an undeclared `implementer` still gets `Read,Write,Edit,Bash` (keeps its hands) with **no MCP**; others get `Read,Bash`. "Fail closed" means no ambient MCP leakage, *not* read-only.
- `--strict-mcp-config` + a node-scoped `.mcp-config.json` = the hermetic primitive (an ambient `.mcp.json` cannot leak in).
- Reference profiles on `code-fix`: implementer gets `codegraph` only — **no comms/web MCP**, so the lethal-trifecta invariant holds.
- Fixed a dead prompt line (`bin/_worker-launcher.sh` told agents to use Context7 MCP, which is not configured).

## Verification
- `bash tests/run-all.sh unit` → **555/555 assertions, 0 FAIL** (twice — not shared-state flakiness).
- E2E argv-injection test (new): drives a stub `claude` on **both** backends and asserts the real argv carries `--allowedTools Read,Write,Edit,Bash,mcp__codegraph` + `--strict-mcp-config`. Reproduced by hand before trusting the suite.
- Proven directly: undeclared implementer resolves to `Read,Write,Edit,Bash|` (fail-closed keeps Write/Edit).

## Follow-ups (out of scope here)
- Persist the granted tool set per node into `state.db` for auditability (needs a migration).
- Retrieval-based tool shortlisting once a node's catalog outgrows its contract.
- The framework-edit **diff-capture bug** this exposed (it derives the diff from the ambient working tree, so a dirty tree captures other sessions' files) — the next task.

Produced by mini-ork dogfooding itself (framework-edit) in an isolated clean worktree.
