### PR TITLE
fix(framework-edit): capture the implementer delta, not pre-existing tree dirt

### DIFF
--- a/mini_ork/ported/mini_ork_execute.py
+++ b/mini_ork/ported/mini_ork_execute.py
@@ -1179,6 +1179,49 @@ def _researcher_output_file(run_dir, recipe, node_id):
     return os.path.join(run_dir, f"context-{node_id}.json")
 
 
+def _capture_pre_impl_baseline(run_dir):
+    """Snapshot the working-tree state BEFORE the implementer edits, so the
+    reviewer diff (below) captures ONLY the implementer's delta — never
+    pre-existing dirt from a concurrent session sharing this in-place tree.
+
+    Why this exists: framework-edit's implementer edits MO_TARGET_CWD in place,
+    and the reviewer diff was `git diff` (working tree vs HEAD). With any
+    unrelated uncommitted change already present, that diff swept it into
+    review-diff.patch — so the run could review, and publish, another session's
+    work. (Observed repeatedly; a concurrent session hit the same confound.)
+
+    `git stash create` records the current tracked modifications as a commit
+    object WITHOUT touching the working tree, index, or stash list — a purely
+    non-destructive snapshot. Empty output means a clean tree, so the baseline is
+    HEAD. The ref is persisted to <run_dir>/pre-implementer-ref and read back by
+    _assemble_reviewer_inputs. Idempotent: only the first call (before the first
+    implementer iteration) writes it.
+    """
+    if not run_dir:
+        return
+    ref_path = os.path.join(run_dir, "pre-implementer-ref")
+    if os.path.isfile(ref_path):
+        return
+    cwd = os.environ.get("MO_TARGET_CWD") or os.getcwd()
+    try:
+        if subprocess.run(["git", "-C", cwd, "rev-parse", "--git-dir"],
+                          capture_output=True).returncode != 0:
+            return
+        created = subprocess.run(["git", "-C", cwd, "stash", "create"],
+                                 capture_output=True, text=True)
+        ref = (created.stdout or "").strip()
+        if not ref:
+            head = subprocess.run(["git", "-C", cwd, "rev-parse", "HEAD"],
+                                  capture_output=True, text=True)
+            ref = (head.stdout or "").strip()
+        if ref:
+            os.makedirs(run_dir, exist_ok=True)
+            with open(ref_path, "w") as fh:
+                fh.write(ref + "\n")
+    except Exception:
+        pass
+
+
 def _assemble_reviewer_inputs(run_dir):
     """F2-B (bash _mo_assemble_reviewer_inputs:182-275). Build the reviewer input block:
     implementer-summary.json + verifier_{typecheck,test}.json + a generated
@@ -1203,11 +1246,27 @@ def _assemble_reviewer_inputs(run_dir):
     if not worktree or not os.path.isdir(worktree):
         worktree = os.environ.get("MO_TARGET_CWD") or os.getcwd()
     diff_path = os.path.join(run_dir, "review-diff.patch")
+    # Diff against the pre-implementer baseline (captured at run start by
+    # _capture_pre_impl_baseline) so the reviewer sees ONLY the implementer's
+    # delta, never pre-existing dirt from a concurrent session sharing this
+    # in-place working tree. Falls back to a plain working-tree diff only when no
+    # baseline was recorded (e.g. an isolated worktree that started clean).
+    baseline = ""
+    ref_path = os.path.join(run_dir, "pre-implementer-ref")
+    if os.path.isfile(ref_path):
+        try:
+            baseline = open(ref_path).read().strip()
+        except OSError:
+            baseline = ""
     try:
         if os.path.isdir(worktree) and subprocess.run(
                 ["git", "-C", worktree, "rev-parse", "--git-dir"],
                 capture_output=True).returncode == 0:
-            args = ["git", "-C", worktree, "diff", "--no-color"] + (["--", *files] if files else [])
+            args = ["git", "-C", worktree, "diff", "--no-color"]
+            if baseline:
+                args.append(baseline)
+            if files:
+                args += ["--", *files]
             with open(diff_path, "w") as fh:
                 subprocess.run(args, stdout=fh, stderr=subprocess.DEVNULL)
         if not (os.path.isfile(diff_path) and os.path.getsize(diff_path) > 0):
@@ -1714,6 +1773,10 @@ def dispatch_node(fields, *, root, run_dir, plan_path, task_class, db, run_id,
     def trace(node_id, status, node_type, output_file="", verdict="", finish_reason=""):
         _base_trace(node_id, status, node_type, output_file, verdict, finish_reason, lane=lane)
     run_dir_eff = os.environ.get("MINI_ORK_RUN_DIR", run_dir)
+    # Snapshot the tree BEFORE any implementer node edits it, so the reviewer
+    # diff captures only the implementer's delta (not pre-existing dirt from a
+    # concurrent session sharing this in-place working tree). Non-destructive.
+    _capture_pre_impl_baseline(run_dir_eff)
     cost_sidecar = os.path.join(run_dir_eff, ".last-llm-cost")
 
     def _charge():

--- a/tests/unit/test_framework_edit_capture_baseline_py.py
+++ b/tests/unit/test_framework_edit_capture_baseline_py.py
@@ -1,0 +1,102 @@
+"""Regression: framework-edit diff capture must not sweep up pre-existing dirt.
+
+The implementer edits MO_TARGET_CWD in place. Before this fix, the reviewer
+diff was `git diff` (working tree vs HEAD), so any unrelated uncommitted change
+already present — e.g. a CONCURRENT session sharing the working tree — was
+captured into review-diff.patch and could be reviewed and published as if it
+were the run's own output. Observed repeatedly.
+
+The fix snapshots the tree before the implementer runs
+(``_capture_pre_impl_baseline`` → ``pre-implementer-ref`` via non-destructive
+``git stash create``) and diffs against that baseline, so only the implementer's
+delta survives. These tests drive the real functions against a real throwaway
+git repo — no mocks.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+from mini_ork.ported import mini_ork_execute as ex  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True, check=True)
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "A.txt").write_text("A original\n")
+    (repo / "B.txt").write_text("B original\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+
+
+def test_capture_excludes_preexisting_dirt(tmp_path, monkeypatch):
+    """A concurrent session's uncommitted edit to A.txt must NOT appear in the
+    captured diff; the implementer's edit to B.txt must."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setenv("MO_TARGET_CWD", str(repo))
+    monkeypatch.delenv("MINI_ORK_RUN_DIR", raising=False)
+
+    # Pre-existing dirt (another session), present BEFORE the baseline snapshot.
+    (repo / "A.txt").write_text("A CONCURRENT-SESSION EDIT\n")
+
+    # Run start: snapshot the tree.
+    ex._capture_pre_impl_baseline(str(run_dir))
+    assert (run_dir / "pre-implementer-ref").is_file()
+
+    # Implementer edits B in place.
+    (repo / "B.txt").write_text("B IMPLEMENTER EDIT\n")
+
+    # Reviewer input assembly generates review-diff.patch.
+    ex._assemble_reviewer_inputs(str(run_dir))
+    diff = (run_dir / "review-diff.patch").read_text()
+
+    assert "B IMPLEMENTER EDIT" in diff, "implementer's own change must be captured"
+    assert "CONCURRENT-SESSION EDIT" not in diff, "pre-existing dirt must be excluded"
+    assert "A.txt" not in diff, "the pre-existing dirty file must not appear at all"
+
+
+def test_capture_on_clean_tree_still_captures_implementer(tmp_path, monkeypatch):
+    """No regression on the happy path: with a clean tree at baseline (== HEAD),
+    the implementer's change is still captured."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setenv("MO_TARGET_CWD", str(repo))
+    monkeypatch.delenv("MINI_ORK_RUN_DIR", raising=False)
+
+    ex._capture_pre_impl_baseline(str(run_dir))
+    (repo / "B.txt").write_text("B IMPLEMENTER EDIT\n")
+    ex._assemble_reviewer_inputs(str(run_dir))
+    diff = (run_dir / "review-diff.patch").read_text()
+
+    assert "B IMPLEMENTER EDIT" in diff
+
+
+def test_baseline_is_idempotent(tmp_path, monkeypatch):
+    """The baseline is captured once (before the first implementer iteration) and
+    not overwritten by later calls in a revision loop."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    monkeypatch.setenv("MO_TARGET_CWD", str(repo))
+
+    ex._capture_pre_impl_baseline(str(run_dir))
+    first = (run_dir / "pre-implementer-ref").read_text()
+    # A later edit + second call must not move the baseline.
+    (repo / "A.txt").write_text("later dirt\n")
+    ex._capture_pre_impl_baseline(str(run_dir))
+    assert (run_dir / "pre-implementer-ref").read_text() == first


### PR DESCRIPTION
## The bug
framework-edit's implementer edits `MO_TARGET_CWD` **in place**, and the reviewer diff was a plain `git diff` (working tree vs HEAD). So any unrelated uncommitted change already in the tree — most commonly a **concurrent session** sharing the same working tree — was captured into `review-diff.patch`. The run could then review, and *publish*, another session's uncommitted work.

This is deterministic whenever the tree is dirty (not intermittent). It bit multiple runs while building #173, and a concurrent session independently worked around it by stashing its own files (`stash@{0}: session-…: landed-via-PR dirt confounding framework-edit`). The `implementer-summary.json` that would have supplied a `worktree_path` / `files_changed` filter is never written on this path, so the capture always fell back to `MO_TARGET_CWD` with an unrestricted diff.

## The fix
Snapshot the tree **before** the implementer runs, and diff against that baseline:

- `_capture_pre_impl_baseline(run_dir)` runs once at run start. It uses `git stash create`, which records the current tracked modifications as a commit object **without touching the working tree, index, or stash list** — purely non-destructive. Empty output (clean tree) → baseline is `HEAD`. Persisted to `<run_dir>/pre-implementer-ref`; idempotent across revision iterations.
- `_assemble_reviewer_inputs` diffs `git diff <baseline>` instead of `git diff`, so only the implementer's delta survives. Pre-existing tracked dirt is in the baseline and is excluded.

Untracked pre-existing files were already excluded (`git diff` never shows them). No isolated-worktree behavior changes (a clean worktree's baseline == HEAD).

## Verification
Real throwaway git repo, no mocks (`tests/unit/test_framework_edit_capture_baseline_py.py`):
- **The bug, reproduced:** a concurrent edit to `A.txt` present before the baseline is **excluded** from the capture, while the implementer's edit to `B.txt` is **captured**.
- Clean-tree happy path still captures the implementer's change.
- The baseline is idempotent (not moved by later calls in a revision loop).

`bash tests/run-all.sh unit` → 520/520 · `python -m pytest tests/` → **1273 passed, 27 skipped**.

## Why this matters
This is the defect that made dogfooding framework-edit unsafe on a shared/dirty tree, and forced the #173 work into an isolated worktree. With this fix, a dirty working tree no longer corrupts the captured diff.
