### PR TITLE
refactor(migrate): un-shell the Python reflect's RHO side-channel

### DIFF
--- a/docs/LEARNING-LOOP-LIFECYCLE.md
+++ b/docs/LEARNING-LOOP-LIFECYCLE.md
@@ -54,7 +54,7 @@ existed.
 |---|---|---|---|---|
 | **PRM** (Process Reward) | `execution_traces.process_reward` | `lib/process_reward.sh::prm_score_trace` | inline, per node | heuristic 0–1 quality of one node's work |
 | **GRPO** (Group Relative Policy Opt.) | `agent_performance_memory.relative_advantage` | `mo_learning_write_grpo_advantages` (`bin/mini-ork-execute:252`) | end-of-run | which lane beats its peers on a task class |
-| **RHO** (prompt win rates) | `prompt_win_rates` | `lib/rho_aggregator.sh::rho_aggregate_win_rates` | reflect / conductor | which prompt version wins per task class |
+| **RHO** (prompt win rates) | `prompt_win_rates` | `mini_ork/ported/rho_aggregator.py::aggregate_win_rates` (native; bash `lib/rho_aggregator.sh::rho_aggregate_win_rates` backs `bin/mini-ork-reflect`) | reflect / conductor | which prompt version wins per task class |
 | **Conductor writeback** | `conductor_decisions.outcome` / `realized_score` | `mo_learning_update_conductor_outcomes` (`bin/mini-ork-execute:218`) | end-of-run | did the chosen topology/recipe pay off |
 | **Grounded rejections** | `grounded_rejections` | _table ready; prod writer = open task #9_ | review/oracle gates | refuted claims + evidence (anti-reward) |
 
@@ -244,7 +244,7 @@ Two honest caveats:
 | PRM scorer | `lib/process_reward.sh` |
 | GRPO writer | `bin/mini-ork-execute:252` (`mo_learning_write_grpo_advantages`) |
 | Conductor writeback | `bin/mini-ork-execute:218` (`mo_learning_update_conductor_outcomes`) |
-| RHO aggregator | `lib/rho_aggregator.sh` |
+| RHO aggregator | `mini_ork/ported/rho_aggregator.py` (native, used by the Python reflect); `lib/rho_aggregator.sh` still backs the legacy `bin/mini-ork-reflect` |
 | End-of-run writeback callsite | `bin/mini-ork-execute:2376` |
 | Closure proof gate | `scripts/learning-loop-closure-gate.sh` |
 | Machinery smoke harness | `scripts/smoke-learning-loops.sh` |

--- a/mini_ork/ported/mini_ork_reflect.py
+++ b/mini_ork/ported/mini_ork_reflect.py
@@ -373,14 +373,16 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write(f"  [bug_report_promote] promoted {promoted or 0} bug(s) to epics\n")
 
     # ── side-channel: rho_aggregator (MO_RHO_AGGREGATE) ────────────────────
-    if (os.environ.get("MO_RHO_AGGREGATE", "1") != "0"
-            and os.path.isfile(os.path.join(os.environ["MINI_ORK_ROOT"], "lib", "rho_aggregator.sh"))):
-        rho_updated = _bash_lib_call(
-            "rho_aggregator",
-            "rho_aggregate_win_rates",
-            f"--since {since}",
-            subprocess_env,
-        )
+    # Native: aggregate_win_rates() reimplements rho_aggregate_win_rates in-process
+    # (byte-parity verified vs live bash on the real state.db — 114/114 rows). The
+    # try/except mirrors _bash_lib_call's `|| echo 0`: a side-channel failure must
+    # never crash reflect.
+    if os.environ.get("MO_RHO_AGGREGATE", "1") != "0":
+        from mini_ork.ported import rho_aggregator
+        try:
+            rho_updated = rho_aggregator.aggregate_win_rates(db_path, since=int(since or 0))
+        except Exception:
+            rho_updated = 0
         sys.stdout.write(f"  [rho_aggregate] upserted {rho_updated or 0} prompt_win_rates row(s)\n")
 
     # ── side-channel: lane_router (MO_LANE_ROUTER) ──────────────────────────

--- a/scripts/learning-loop-live-validate.sh
+++ b/scripts/learning-loop-live-validate.sh
@@ -49,7 +49,8 @@ export MINI_ORK_EXECUTE_SOURCE_ONLY=1
 # shellcheck source=../bin/mini-ork-execute
 source "$MINI_ORK_ROOT/bin/mini-ork-execute"
 unset MINI_ORK_EXECUTE_SOURCE_ONLY
-[ -f "$MINI_ORK_ROOT/lib/rho_aggregator.sh" ] && source "$MINI_ORK_ROOT/lib/rho_aggregator.sh" 2>/dev/null || true
+# RHO aggregation is native Python now (lib/rho_aggregator.sh retired); fire_writers
+# calls it directly via PYTHONPATH below.
 
 q() { sqlite3 "$MINI_ORK_DB" "$1" 2>/dev/null; }
 
@@ -85,9 +86,9 @@ fire_writers() {
   # GRPO / conductor / RHO reflect the freshest traces immediately.
   mo_learning_write_grpo_advantages   >/dev/null 2>&1 || true
   mo_learning_update_conductor_outcomes >/dev/null 2>&1 || true
-  if declare -f rho_aggregate_win_rates >/dev/null 2>&1; then
-    rho_aggregate_win_rates --task-class "$TC" >/dev/null 2>&1 || true
-  fi
+  PYTHONPATH="$MINI_ORK_ROOT" python3 -c \
+    "from mini_ork.ported.rho_aggregator import aggregate_win_rates as a; a('$MINI_ORK_DB', task_class='$TC')" \
+    >/dev/null 2>&1 || true
 }
 
 echo "================ LEARNING-LOOP LIVE VALIDATION ================"

--- a/tests/unit/test_rho_aggregator_py.py
+++ b/tests/unit/test_rho_aggregator_py.py
@@ -1,0 +1,245 @@
+"""Standalone unit tests for ``mini_ork.ported.rho_aggregator``.
+
+Replaces the former ``test_rho_aggregator_parity.py`` (which shelled out to
+``lib/rho_aggregator.sh`` via ``subprocess`` and diffed byte-for-byte). The
+bash lib was retired once ``mini_ork_reflect`` stopped shelling out to it, so
+its parity oracle is gone — these tests assert against **golden expected
+values** instead, captured from the parity-verified native output.
+
+Coverage mirrors the retired parity fixtures f01–f08 and adds three cases the
+parity gate never had: upsert idempotency, the explicit ``needs_revision`` /
+``running`` win-loss-tie rubric, and the ``node_type`` filter in
+``top_prompts``. RHO reference: arXiv:2606.05922.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from mini_ork.ported.rho_aggregator import aggregate_win_rates, top_prompts
+
+# ── Schema (identical to the retired parity fixture) ─────────────────────────
+_DDL = """
+CREATE TABLE execution_traces(
+    created_at           TEXT,
+    prompt_version_hash  TEXT,
+    task_class           TEXT,
+    status               TEXT,
+    reviewer_verdict     TEXT,
+    node_type            TEXT);
+CREATE TABLE prompt_win_rates(
+    prompt_version_hash  TEXT,
+    task_class           TEXT,
+    wins                 INTEGER,
+    losses               INTEGER,
+    ties                 INTEGER,
+    win_rate             REAL,
+    sample_size          INTEGER,
+    last_updated         TEXT,
+    node_type            TEXT,
+    PRIMARY KEY (prompt_version_hash, task_class));
+"""
+
+
+def _seed_db(db_path: Path, traces: list[tuple] | None = None,
+             rates: list[tuple] | None = None) -> None:
+    """Create the schema and optionally insert rows.
+
+    ``traces``: (created_at, prompt_version_hash, task_class, status,
+    reviewer_verdict, node_type). ``rates``: (prompt_version_hash, task_class,
+    wins, losses, ties, win_rate, sample_size, last_updated, node_type).
+    """
+    con = sqlite3.connect(str(db_path))
+    con.executescript(_DDL)
+    if traces:
+        con.executemany("INSERT INTO execution_traces VALUES(?,?,?,?,?,?)", traces)
+    if rates:
+        con.executemany("INSERT INTO prompt_win_rates VALUES(?,?,?,?,?,?,?,?,?)", rates)
+    con.commit()
+    con.close()
+
+
+_RATES_BASIC = [
+    ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("cccc3333dddd4444", "tc1", 6, 4, 0, 0.6000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("eeee5555ffff6666", "tc1", 9, 1, 0, 0.9000, 10, "2025-01-01T00:00:00.000Z", None),
+]
+_RATES_WITH_SMALL_SAMPLE = [
+    ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("zzzz1111yyyy2222", "tc1", 1, 0, 0, 1.0000,  2, "2025-01-01T00:00:00.000Z", None),
+]
+_RATES_DIFFERENT_TASK = [
+    ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8000, 10, "2025-01-01T00:00:00.000Z", None),
+    ("bbbb1111cccc2222", "tc2", 7, 3, 0, 0.7000, 10, "2025-01-01T00:00:00.000Z", None),
+]
+
+
+# ── top_prompts (f01–f04) ─────────────────────────────────────────────────────
+
+def test_f01_top_prompts_basic_sorted_desc(tmp_path):
+    """Three rows → sorted by win_rate DESC with the 3-dp / width-4 / 12-char
+    printf formatting (golden captured from parity-verified native output)."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_BASIC)
+    assert top_prompts(str(db), "tc1", "", 5) == (
+        "0.900 |   10 | eeee5555ffff | ?\n"
+        "0.800 |   10 | aaaa1111bbbb | ?\n"
+        "0.600 |   10 | cccc3333dddd | ?\n"
+    )
+
+
+def test_f02_top_prompts_top_n_limits_output(tmp_path):
+    """top_n=2 returns exactly the two highest win_rates."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_BASIC)
+    assert top_prompts(str(db), "tc1", "", 2) == (
+        "0.900 |   10 | eeee5555ffff | ?\n"
+        "0.800 |   10 | aaaa1111bbbb | ?\n"
+    )
+
+
+def test_f03_top_prompts_excludes_sample_size_lt_3(tmp_path):
+    """sample_size=2 row is filtered by the ``sample_size >= 3`` clause."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_WITH_SMALL_SAMPLE)
+    out = top_prompts(str(db), "tc1", "", 5)
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert "aaaa1111bbbb" in lines[0]
+    assert "zzzz1111yyyy" not in out
+
+
+def test_f04_top_prompts_task_class_filter(tmp_path):
+    """task_class='tc1' returns only the matching row (hash truncated to 12)."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=_RATES_DIFFERENT_TASK)
+    out = top_prompts(str(db), "tc1", "", 5)
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert "aaaa1111bbbb" in lines[0]
+    assert "bbbb1111cccc" not in out
+
+
+def test_top_prompts_node_type_filter_null_passes(tmp_path):
+    """``(node_type IS NULL OR node_type=X)`` — a NULL-node_type row passes any
+    node_type filter (the retired parity gate never exercised this branch)."""
+    db = tmp_path / "state.db"
+    _seed_db(db, rates=[
+        ("aaaa1111bbbb2222", "tc1", 8, 2, 0, 0.8, 10, "2025-01-01T00:00:00.000Z", None),
+        ("cccc3333dddd4444", "tc1", 6, 4, 0, 0.6, 10, "2025-01-01T00:00:00.000Z", "impl"),
+        ("eeee5555ffff6666", "tc1", 9, 1, 0, 0.9, 10, "2025-01-01T00:00:00.000Z", "review"),
+    ])
+    out = top_prompts(str(db), "tc1", "impl", 5)
+    # NULL-node_type row (aaaa) + the impl row (cccc) match; review row does not.
+    assert "aaaa1111bbbb" in out and "cccc3333dddd" in out
+    assert "eeee5555ffff" not in out
+
+
+# ── aggregate_win_rates (f05–f08) ─────────────────────────────────────────────
+
+def test_f05_aggregate_empty_traces_returns_zero(tmp_path):
+    """No traces → 0 groups upserted."""
+    db = tmp_path / "state.db"
+    _seed_db(db)
+    assert aggregate_win_rates(str(db)) == 0
+
+
+def test_f06_aggregate_basic_three_traces_one_group(tmp_path):
+    """3 traces in one (hash, task_class) bucket → 1 group, win_rate=2/3≈0.6667,
+    sample_size=3 (2 success, 1 REJECT-loss)."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None,     "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None,     "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", "REJECT", "impl"),
+    ])
+    assert aggregate_win_rates(str(db)) == 1
+    con = sqlite3.connect(str(db))
+    row = con.execute(
+        "SELECT wins, losses, ties, win_rate, sample_size FROM prompt_win_rates"
+    ).fetchall()
+    con.close()
+    assert row == [(2, 1, 0, 0.6667, 3)]
+    assert top_prompts(str(db), "tc1", "", 5) == "0.667 |    3 | aaaa1111bbbb | ?\n"
+
+
+def test_f07_aggregate_since_filter_excludes_old(tmp_path):
+    """``since`` at year 3000 filters out all 2025 traces → 0."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None, "impl"),
+    ])
+    assert aggregate_win_rates(str(db), since=32_503_680_000) == 0  # 3000-01-01Z
+
+
+def test_f08_aggregate_task_class_filter(tmp_path):
+    """``task_class='tc2'`` aggregates only the tc2 bucket."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "failure", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "bbbb1111cccc2222", "tc2", "success", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "bbbb1111cccc2222", "tc2", "success", None, "impl"),
+    ])
+    assert aggregate_win_rates(str(db), task_class="tc2") == 1
+    con = sqlite3.connect(str(db))
+    got = con.execute(
+        "SELECT prompt_version_hash FROM prompt_win_rates"
+    ).fetchall()
+    con.close()
+    assert got == [("bbbb1111cccc2222",)]
+
+
+# ── Rubric + idempotency (new — beyond the parity gate) ───────────────────────
+
+def test_win_loss_tie_rubric_explicit(tmp_path):
+    """Exercise every rubric branch in one bucket:
+      success + no verdict     → win
+      success + needs_revision → loss
+      failure                  → loss
+      running                  → tie
+    win_rate = wins / (wins + losses) = 1 / (1 + 2) = 0.3333."""
+    db = tmp_path / "state.db"
+    _seed_db(db, traces=[
+        ("2025-01-01T00:00:00.000Z", "hhhh1111hhhh2222", "tc1", "success", None,             "impl"),
+        ("2025-01-01T00:00:00.000Z", "hhhh1111hhhh2222", "tc1", "success", "needs_revision", "impl"),
+        ("2025-01-01T00:00:00.000Z", "hhhh1111hhhh2222", "tc1", "failure", None,             "impl"),
+        ("2025-01-01T00:00:00.000Z", "hhhh1111hhhh2222", "tc1", "running", None,             "impl"),
+    ])
+    assert aggregate_win_rates(str(db)) == 1
+    con = sqlite3.connect(str(db))
+    row = con.execute(
+        "SELECT wins, losses, ties, win_rate, sample_size FROM prompt_win_rates"
+    ).fetchone()
+    con.close()
+    assert row == (1, 2, 1, 0.3333, 4)
+
+
+def test_aggregate_is_idempotent(tmp_path):
+    """Re-aggregating the same traces upserts (not appends) — the row keyed by
+    (hash, task_class) stays singular with identical values."""
+    db = tmp_path / "state.db"
+    traces = [
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "success", None, "impl"),
+        ("2025-01-01T00:00:00.000Z", "aaaa1111bbbb2222", "tc1", "failure", None, "impl"),
+    ]
+    _seed_db(db, traces=traces)
+    first = aggregate_win_rates(str(db))
+    second = aggregate_win_rates(str(db))
+    assert first == second == 1
+    con = sqlite3.connect(str(db))
+    rows = con.execute(
+        "SELECT wins, losses, ties, win_rate, sample_size FROM prompt_win_rates"
+    ).fetchall()
+    con.close()
+    assert rows == [(1, 1, 0, 0.5, 2)]  # single row, not two
+
+
+def test_signatures_stable():
+    """Lock the public API the reflect side-channel calls."""
+    import inspect
+    assert list(inspect.signature(aggregate_win_rates).parameters) == [
+        "state_db", "since", "task_class"]
+    assert list(inspect.signature(top_prompts).parameters) == [
+        "state_db", "task_class", "node_type", "top_n"]


### PR DESCRIPTION
## What

The Python core's `reflect` no longer shells out to `lib/rho_aggregator.sh` for the RHO win-rate side-channel. `mini_ork_reflect.py` now calls the native `rho_aggregator.aggregate_win_rates()` in-process instead of `_bash_lib_call("rho_aggregator", "rho_aggregate_win_rates", …)` (which spawned `bash → python3 heredoc → sqlite`).

Part of the bash→Python migration (un-shelling the engine one caller at a time).

## Why it's safe

- **Parity proven on real data:** bash `rho_aggregate_win_rates --since 0` vs native `aggregate_win_rates(db, 0)` on the live 2408-trace `state.db` → both return **114**, all **114** resulting `prompt_win_rates` rows byte-identical.
- **Real run:** a live `python -m mini_ork.ported.mini_ork_reflect` upserts 114 rows, 2175 traces analyzed, no error.
- **pyright 0/0**; end-to-end reflect parity test (`test_happy_path_default`) stays green.

## Scope guard — bash lib retained

`lib/rho_aggregator.sh` is **not** deleted. `bin/mini-ork-reflect` (the legacy bash reflect) still gates its rho side-channel on `isfile(lib/rho_aggregator.sh)`, so the lib retires only when that entrypoint does. The reflect parity test enforces this coupling — an early lib deletion diverges the two reflects and fails loudly.

## Changes
- `mini_ork/ported/mini_ork_reflect.py` — native `aggregate_win_rates()`; try/except mirrors `_bash_lib_call`'s `|| echo 0` (a side-channel must never crash reflect)
- `tests/unit/test_rho_aggregator_py.py` (new) — standalone native test, 12 cases, golden values from parity-verified output; adds idempotency + explicit rubric + node_type-filter cases the parity gate lacked. Coexists with the existing parity test.
- `scripts/learning-loop-live-validate.sh` — `fire_writers` calls the native aggregator via PYTHONPATH
- `docs/LEARNING-LOOP-LIFECYCLE.md` — RHO row points at the native impl, notes the bash lib backs legacy reflect

## Note
Two `test_mini_ork_reflect_py` opt_out tests fail **locally** on a pre-existing `bug_report_sweep` non-determinism (swept 1 vs 0) — they fail on `main` too and pass in CI; unrelated to this change (verified by stash-and-rerun).