### PR TITLE
refactor(migrate): un-shell the Python reflect's pattern_store side-channel

### DIFF
--- a/mini_ork/ported/mini_ork_reflect.py
+++ b/mini_ork/ported/mini_ork_reflect.py
@@ -311,16 +311,21 @@ def main(argv: list[str] | None = None) -> int:
     sys.stdout.write(f"{suggestions_json.rstrip(chr(10))}\n")
 
     # ── side-channel: pattern_store (MO_PATTERN_MINER) ──────────────────────
+    # Native: mine_from_traces() reimplements pattern_store_mine_from_traces in-
+    # process (byte-parity verified on the real state.db — both return 9). Unlike
+    # cross_epic's promote(), it returns without printing, so no stdout capture is
+    # needed. try/except mirrors _bash_lib_call's `|| echo 0`.
     patterns_written = 0
     if os.environ.get("MO_PATTERN_MINER", "1") != "0":
         window = os.environ.get("MO_PATTERN_MINER_WINDOW", "7d")
         min_cluster = os.environ.get("MO_PATTERN_MINER_MIN_CLUSTER", "3")
-        patterns_written = _bash_lib_call(
-            "pattern_store",
-            "pattern_store_mine_from_traces",
-            f"--window {window} --min-cluster {min_cluster}",
-            subprocess_env,
-        )
+        from mini_ork.ported import pattern_store
+        try:
+            patterns_written = pattern_store.mine_from_traces(
+                db_path=db_path, window=window, min_cluster=int(min_cluster)
+            )
+        except Exception:
+            patterns_written = 0
         sys.stdout.write(f"  [pattern_miner] wrote {patterns_written or 0} pattern_records rows\n")
 
     # ── learning-loop write-back ───────────────────────────────────────────


### PR DESCRIPTION
Third clean caller-rewire in the reflect-side-channel series (after RHO #180 and cross_epic #181). reflect's pattern_miner now calls native `pattern_store.mine_from_traces()` in-process instead of shelling `lib/pattern_store.sh` via `_bash_lib_call`.

**Return-only, no print:** unlike cross_epic's `promote()`, `mine_from_traces()` returns without printing (verified: captured stdout == ''), so no `redirect_stdout` wrapper is needed.

**Verified:** reflect `test_happy_path_default` green; `test_pattern_store_py.py` green; pyright 0/0; real `python -m mini_ork.ported.mini_ork_reflect` writes 9 pattern_records rows (matches bash). Parity on the live state.db: both return 9.

**Scope guard:** `lib/pattern_store.sh` retained — `bin/mini-ork-reflect` still calls it.

The 2 `test_mini_ork_reflect_py` opt_out failures are the pre-existing `bug_report_sweep` non-determinism (fail on main, pass in CI; confirmed by stash-and-rerun that they're independent of this change).