### PR TITLE
refactor(migrate): un-shell the Python reflect's bug_report side-channel

### DIFF
--- a/mini_ork/ported/mini_ork_reflect.py
+++ b/mini_ork/ported/mini_ork_reflect.py
@@ -371,22 +371,24 @@ def main(argv: list[str] | None = None) -> int:
         sys.stdout.write(f"  [cross_epic_gradient] promoted {cross_written or 0} cross-class gradients\n")
 
     # ── side-channel: bug_report (MO_BUG_REPORT_SWEEP) ──────────────────────
+    # Native: bug_report_sweep()/bug_report_promote() reimplement the bash lib in-
+    # process (both return-only, no stdout to capture). sweep resolves the db from
+    # MINI_ORK_DB (set above) and the runs dir from `home`; promote's repo_root=None
+    # falls back to $MINI_ORK_ROOT — matching the bash _bash_lib_call env. try/except
+    # mirrors `|| echo 0`.
     if os.environ.get("MO_BUG_REPORT_SWEEP", "1") != "0":
-        bugs_swept = _bash_lib_call(
-            "bug_report",
-            "bug_report_sweep",
-            f"--since {since}",
-            subprocess_env,
-        )
+        from mini_ork.ported import bug_report
+        try:
+            bugs_swept = bug_report.bug_report_sweep(since=int(since or 0), home=mini_ork_home)
+        except Exception:
+            bugs_swept = 0
         sys.stdout.write(f"  [bug_report_sweep] swept {bugs_swept or 0} new noticed bug(s)\n")
         auto_promote = os.environ.get("MO_BUG_REPORT_AUTO_PROMOTE", "0")
         if auto_promote != "0":
-            promoted = _bash_lib_call(
-                "bug_report",
-                "bug_report_promote",
-                f"--top {auto_promote}",
-                subprocess_env,
-            )
+            try:
+                promoted = bug_report.bug_report_promote(top=int(auto_promote))
+            except Exception:
+                promoted = 0
             sys.stdout.write(f"  [bug_report_promote] promoted {promoted or 0} bug(s) to epics\n")
 
     # ── side-channel: rho_aggregator (MO_RHO_AGGREGATE) ────────────────────

--- a/tests/unit/test_mini_ork_usage_report_py.py
+++ b/tests/unit/test_mini_ork_usage_report_py.py
@@ -444,7 +444,13 @@ def test_since_filter_excludes_old_rows(temp_db, tmp_path):
     --since=N (current epoch), only the fresh row is visible. The
     ancient row's (region, lane) pair must NOT appear.
     """
-    now_epoch = int(time.time())
+    # 60s buffer: the "fresh" row is stamped at _now_iso_ms() (≈now). A --since
+    # threshold of exactly int(time.time()) sits on the same-second boundary, so
+    # ms rounding + subprocess scheduling skew can push the fresh row just under
+    # the cutoff → entry_count 0 (a CI-timing flake). Backdating the threshold 60s
+    # keeps the fresh row unambiguously in-window and the 2020 row out, preserving
+    # the test's intent. (See memory: relative-window test time-bomb.)
+    now_epoch = int(time.time()) - 60
     _seed_lane_region_advantage(temp_db["db"], [
         ("codex_lens", "code-fix", "implementer", "code-delivery",
          "lib", 0.45, 2, 2, _now_iso_ms()),


### PR DESCRIPTION
Fourth (and last cleanly-portable) clean caller-rewire in the reflect-side-channel series (after RHO #180, cross_epic #181, pattern_store #182). reflect's bug_report sweep + auto-promote now call native `bug_report_sweep()` / `bug_report_promote()` in-process instead of shelling `lib/bug_report.sh`.

**Return-only:** no `print()` anywhere in `bug_report.py` (AST-verified), so no `redirect_stdout` wrapper. sweep resolves the db from `MINI_ORK_DB` (reflect sets it) + runs dir from `home=`; promote's `repo_root=None` → `$MINI_ORK_ROOT`.

**Verified:** reflect `test_happy_path_default` green; `test_bug_report_py.py` green; pyright 0/0; live-db parity (both sweep 0).

**Scope guard:** `lib/bug_report.sh` retained — `bin/mini-ork-reflect` + `bin/mini-ork-bugs` still call it.

After this, the only reflect side-channel still shelling out is `lane_router` — it has **no** Python port yet (port-from-scratch, deferred).

**Pre-existing flaky tests (not this change):** 2 `test_mini_ork_reflect_py` opt_out tests fail locally due to a test-isolation bug — `temp_db` shares one db between `_run_bash` and `_run_py`, and the stateful `bug_report_sweep` registers a bug on the first run so the second sweeps 0. They pass in CI and are unchanged by this rewire (stash-verified). A proper fix (per-implementation db copies) is separate test-infra work.