### PR TITLE
feat(recipe): self-migrate — verify-gated, integration-point-first self-migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A recipe is `workflow.yaml` + `prompts/` + `verifiers/` + an `artifact_contract`
 | `harness-bridge` | Wraps a full coding-agent harness (claude-code / codex-cli / gemini-cli) as a workflow node. |
 | `chapter-validation-10lens` | 10 parallel lens agents each judge one slice of chapter validation. |
 | `mo-vs-omnigent` | Head-to-head mini-ork vs [omnigent](https://github.com/omnigent-ai/omnigent) across 4 distinct lens families. |
+| `self-migrate` | Verify-gated bash→Python fork migration: close integration forks (outbound seams + every inbound ref → Python sole, bash entrypoint retired) gated on byte-parity, feature-acceptance, and static-feature ledger. |
 
 Add your own under `recipes/<name>/` — see [docs/EXTENSION.md](docs/EXTENSION.md).
 

--- a/docs/migration/self-migrate-feature-manifest.md
+++ b/docs/migration/self-migrate-feature-manifest.md
@@ -1,0 +1,155 @@
+# Self-migration: the core-feature manifest + acceptance probes
+
+_Written 2026-07-18. Defines what "the bash→Python migration is done **correctly**" means:
+not "unit tests pass" but "**every feature mini-ork promises still works end-to-end**."_
+
+## Why this document exists first
+
+The migration's unit-level oracle is perfect and free: `bash_fn(real.db)` vs `native_fn(real.db)`,
+byte-for-byte. But unit-parity is **necessary, not sufficient**. This session's cross_epic rewire
+passed unit-parity yet leaked a stray `0` into reflect's stdout — only the *end-to-end* reflect
+probe caught it. So the migration's real finish line is a **feature-acceptance suite**: one
+replayable probe per promised feature, run as the migration recipe's final gate. This doc is that
+suite's specification. Everything else (the recipe, the observe→improve loop) gates on getting
+this list right — hence it comes first, for sanity-check.
+
+## The competitive advantage this protects
+
+mini-ork's moat is **verification** — nothing ships unless the verify-gate says so. The migration
+is the ideal proving ground because the bash lib is an un-gameable oracle. But the *thing being
+protected* is the promise that a user's run is **verified-correct**, and that promise is only kept
+if the migrated engine still delivers every feature below. The acceptance suite is the moat applied
+to mini-ork itself.
+
+## The 9 core promised features + their acceptance probes
+
+Each probe is **end-to-end** (exercises the feature through its real entrypoint) and **replayable**
+(a command or short recipe). A feature is "migrated correctly" only when its probe is green on the
+Python runtime **and** byte-matches the bash runtime where a bash reference still exists.
+
+| # | Promised feature | Real entrypoint | Acceptance probe (end-to-end) |
+|---|---|---|---|
+| 1 | **6-stage loop** classify→plan→execute→verify→reflect→improve | `bin/mini-ork run` | Run `examples/01-hello-world/kickoff.md`; assert every stage emits its artifact (classification.json, plan, execute log, verdict, reflection) and the run reaches a terminal state. |
+| 2 | **Recipe execution** (forced recipe → its contract) | `bin/mini-ork run <recipe>` | Run `code-fix` on a seeded red→green fixture; assert the artifact_contract is satisfied. Run `framework-edit` on a 1-line kickoff; assert it produces a **diff, not a commit**. |
+| 3 | **Heterogeneous lanes + `learning_governed` routing** | `decision_service.decide()` | `MO_VALIDATE_DO_RUNS=1 MO_LEARNING_MIN_SAMPLES=1 scripts/learning-loop-live-validate.sh 1` — assert the router returns the static default BEFORE and the learned lane AFTER. |
+| 4 | **Cost governance** (budget cap + circuit breaker) | `budget_gate`, `cost_pause` | Start a run with a $0.01 per-run cap; assert it halts at the cap and writes the pause sentinel — does not silently overspend. |
+| 5 | **Runtime verify-gate** (the moat) | `bin/mini-ork verify` / `reviewer_gate` | Feed a change that is red-on-base + green-on-gold → assert **pass**. Feed a change that is green-by-coverage-gap (a genuine cheat) → assert **reject**. (Precision on hard negatives, not just apply_fail.) |
+| 6 | **Learning loop closes** (reward → routing) | `scripts/learning-loop-closure-gate.sh` | Run the closure gate; assert a real trace writes reward, GRPO recomputes advantage, and the next `decide()` reads it. |
+| 7 | **`framework-edit` self-modification** (propose-not-commit, blast-radius scope, rollback) | `recipes/framework-edit` | Run a self-edit kickoff; assert scope_gate **blocks** an out-of-scope file, the change lands as a reviewable diff, and rollback restores cleanly. |
+| 8 | **Durable / resumable runs** (checkpoints) | `--resume` | Kill a run mid-step; `--resume`; assert it resurrects at the checkpoint (STEP or TURN) without re-executing completed nodes (idempotency + tool receipts). |
+| 9 | **Multi-epic delivery** (epics + scheduler) | `bin/mini-ork epics split` / `scheduler` | Split a 3-epic roadmap with a dependency; assert the scheduler dispatches in dependency order and does not drain unrelated epics. |
+
+> Probes 3, 5, 6 are the **moat probes** — they prove the *verified-correctness* promise itself.
+> If the migration breaks these, it has broken the product regardless of unit-parity.
+
+## Migration strategy: integration-points first, root → down, one frontier
+
+_Revised 2026-07-18 per the "less deterministic, integration-points first" direction._
+
+The bottom-up leaf approach **splits** integration points: it makes a Python module native but
+leaves the paired bash entrypoint (and every lib/script/test/UI ref to it) still live — a scatter
+of half-open seams with no way to know which are complete. Replace it with a **single advancing
+frontier**:
+
+- **Unit of work = a fork** (an entrypoint's Python↔bash seam), NOT a lib. A fork is "closed"
+  only when **every** integration point is resolved:
+  - **outbound** — what the Python entrypoint shells to (`lib/X.sh` calls), and
+  - **inbound** — every lib, script, test, sandbox, and **web-UI route** that invokes the bash
+    entrypoint `bin/mini-ork-<cmd>`.
+  Then the bash entrypoint retires and the `runtime-select` fallback for that command drops.
+- **Order = root → down.** Dispatcher/`cli` first, then `classify → plan → execute → verify →
+  reflect`, closing each fork completely before descending, so a caller is never migrated after
+  the thing it calls is already gone.
+- **Above the frontier: pure Python. Below: pure bash. Nothing half-open.**
+
+**Why forks, not libs — measured 2026-07-18:** closing the *easiest* fork (`classify`, whose Python
+side is already native) still requires resolving **8 integration points**: `lib/llm-dispatch.sh`,
+`lib/sandbox/local.sh`, `mini_ork/web/routes/run_detail.py` (the UI), `scripts/runtime-parity-harness.sh`,
+`tests/unit/test_mini_ork_classify_py.py`, three `tests/security/*.sh`, and `tests/integration/test_bin_classify.sh`.
+Any one of those, if missed, is a dangling reference to a retired entrypoint. Only a **complete
+integration-point map, resolved as a set**, prevents that.
+
+### Step 0 — the integration-point map (the enforceable safeguard)
+
+Before any transform: compute every Python↔bash edge and every inbound reference to each
+`bin/mini-ork-<cmd>`. This map IS the "don't leave anything incomplete" guarantee — a fork can't be
+declared closed while any edge into it survives. Read-only; produced first.
+
+### Lane policy (per 2026-07-18 decision)
+
+| Loop role | Lane | Backoff | Rationale |
+|---|---|---|---|
+| implementer / worker (the code transform) | **codex** | codex | reliable in this env; implementer must never be GLM (analysis-only) or opus |
+| mapper / verifier / reviewer (judgment — the moat) | **opus** | codex | strongest reasoner maps each seam's contract + decides "did parity hold / did a feature break" |
+| discovery lens (non-critical) | **GLM** | codex | cheap analysis; GLM's 429 "Fair Usage" silently sinks runs, so codex-backoff is mandatory |
+
+### Per-fork pipeline (less deterministic — the agent reasons per seam)
+
+1. **Map the seam** (opus) — from Step 0's graph: every outbound shell-out + every inbound ref to
+   this entrypoint (libs, scripts, tests, sandbox, UI). Reason about each edge's contract (env
+   passed, side-effects, stdout capture) — not a fixed template.
+2. **Static-feature ledger** (opus — REQUIRED OUTPUT, see below) — before/while porting, catalog
+   every function/behavior in this part and deliberately classify it static vs agentic. This is the
+   cost/verifiability audit, not bookkeeping.
+3. **Make the Python side sole** (codex) — port/rewire every outbound seam to native
+   (AST-verify the port is native first; preserve `_bash_lib_call`'s `|| echo 0` error-swallowing
+   AND its stdout capture — a printing port leaks into caller stdout, see cross_epic).
+4. **Repoint every inbound ref** (codex) — tests → Python-only (convert bash-oracle parity tests to
+   standalone), UI/lib/script refs → the Python entrypoint or its module.
+5. **Verify** (the moat, made concrete): (a) byte-parity vs the bash oracle on the **live** state.db
+   while it still exists · (b) pytest + pyright 0 · (c) a **real run** · (d) the entrypoint's
+   **feature-acceptance probe** from the manifest above.
+6. **Close the fork** — retire `bin/mini-ork-<cmd>` + drop its `runtime-select` fallback. All gates
+   or nothing lands.
+
+## The static-feature ledger — the migration's strategic payload
+
+This is why the migration is worth more than a port. mini-ork's moat is **cost-down at constant
+verified correctness**, and those two goals share one root cause:
+
+| Kind | Cost | Verifiability |
+|---|---|---|
+| **static** (deterministic logic) | ~0 tokens | **un-gameable** — byte-parity vs an oracle, the strongest verification |
+| **agentic** (LLM call) | tokens per call | **weak** — LLM-judge is gameable (single-test execution-anchoring gets hacked through coverage gaps) |
+
+So each fork migration MUST emit a ledger classifying every behavior it touches. One row per
+function/feature:
+
+| feature | class | verifiability | cost | decision / opportunity |
+|---|---|---|---|---|
+| `aggregate_win_rates` (rho) | **static** (sqlite) | byte-parity (high) | ~0 | keep static — a unit of the moat |
+| `lane_router_*` | **static** (sqlite, 588L) | byte-parity (high) | ~0 | confirm + keep static |
+| `gradient_extract` | **agentic** (shells Claude) | LLM-judge (weak) | $$ / call | **cost-down candidate**: make template/deterministic, or gate with a deterministic check |
+| `<a runtime-select fork>` | **integration** | — | — | note whether the seam itself is static or agentic |
+
+- **static** confirmed → a unit of the moat proven (cheap + hard-verifiable).
+- **agentic** flagged → a cost *and* verifiability liability, and a candidate to push the RIGHT
+  direction (agentic→deterministic lowers cost and raises verifiability at once). Pure static→agentic
+  is almost never right — it spends tokens and weakens the gate.
+- **integration** → a seam; record whether it carries an LLM or is pure plumbing.
+
+**The aggregate ledger = mini-ork's cost/verifiability map**, and the flagged agentic rows = the
+cost-down roadmap. The migration produces it as a by-product of touching every part with an oracle
+in hand — the one time the whole engine gets read deliberately, function by function.
+
+## The observe → improve loop (why this compounds)
+
+Every gate failure is a **verifier gap**, and fixing it hardens mini-ork for *all* jobs, not just
+migration:
+
+| Issue observed this session | Verifier gap | Improvement (general, not migration-specific) |
+|---|---|---|
+| lib deleted while `bin/` still called it | discover stage missed `bin/` | `bin/` added to the retirement blocker-check |
+| unit-parity passed, stdout leaked | unit-parity too shallow | the end-to-end probe is now a **required** gate |
+| differential test flaked (shared-db `bug_report_sweep`) | verifier's test isolation weak | per-implementation db copies |
+| now/now-epoch boundary race | time-relative tests un-buffered | seed now-offset timestamps |
+
+This is the compounding curve: the migration is the cheap, oracle-backed workload that *pays for*
+verifier hardening; the hardened verifier then does the next un-shelling — and the next non-migration
+job — more reliably. The migration doesn't just finish; it makes the thing that finishes it better.
+
+## Open question for sanity-check
+
+Are these the right **9 features**, or is a promised capability missing (e.g. trace capture /
+observability as a standalone feature, or the HarnessBridge / cross-runtime story)? The recipe and
+the acceptance-probe scripts both gate on this list, so it's worth pinning before building them.

--- a/gates/feature_acceptance.sh
+++ b/gates/feature_acceptance.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# gates/feature_acceptance.sh — end-to-end acceptance probes for mini-ork's core
+# promised features. The self-migrate recipe's real finish line: a fork is only
+# "migrated correctly" when the FEATURE it sits under still works end-to-end,
+# not just when unit-parity passes.
+#
+# Usage:  bash gates/feature_acceptance.sh <fork-or-feature>
+#         bash gates/feature_acceptance.sh all
+# Exit 0 = probe passed; non-zero = failed. Prints a one-line PASS/FAIL per probe.
+#
+# Feature ↔ entrypoint map (from docs/migration/self-migrate-feature-manifest.md):
+#   classify plan execute verify reflect  → the 6-stage loop stages
+#   routing        → learning_governed router flips (learning-loop-live-validate)
+#   learning-loop  → reward→routing closes (learning-loop-closure-gate)
+#   verify-gate    → a real cheat is rejected / a real fix passes
+#   framework-edit → propose-not-commit self-modification
+#   resume         → durable checkpoint resume
+#   epics          → dependency-ordered multi-epic delivery
+
+set -uo pipefail
+ROOT="${MINI_ORK_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+TARGET="${1:-all}"
+rc_all=0
+
+_run() { # <label> <cmd...>  → prints PASS/FAIL, updates rc_all
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then echo "PASS  $label"; else echo "FAIL  $label"; rc_all=1; fi
+}
+
+# ── entrypoint smoke: the command runs under the Python runtime AND matches bash ──
+_probe_entrypoint() { # <cmd>
+  local cmd="$1"
+  local bin="$ROOT/bin/mini-ork-$cmd"
+  [ -f "$bin" ] || { echo "SKIP  $cmd — no bin/mini-ork-$cmd"; return 0; }
+  # (a) --help works under python runtime (exercises the delegation + arg parse)
+  _run "$cmd:help(python)" env MINI_ORK_RUNTIME=python MINI_ORK_ROOT="$ROOT" bash "$bin" --help
+  # (b) the ported module imports + exposes main (the runtime path is real)
+  _run "$cmd:module-imports" python3 -c "import importlib,sys; sys.path.insert(0,'$ROOT'); m=importlib.import_module('mini_ork.ported.mini_ork_$cmd'); assert hasattr(m,'main')"
+}
+
+# ── higher-order feature probes (delegate to existing gates where they exist) ──
+_probe_routing() {
+  local s="$ROOT/scripts/learning-loop-live-validate.sh"
+  [ -f "$s" ] || { echo "SKIP  routing — no live-validate script"; return 0; }
+  _run "routing:inspect" env MINI_ORK_ROOT="$ROOT" bash "$s"   # bare = inspect-only, no LLM
+}
+_probe_learning_loop() {
+  local s="$ROOT/scripts/learning-loop-closure-gate.sh"
+  [ -f "$s" ] || { echo "SKIP  learning-loop — no closure gate"; return 0; }
+  _run "learning-loop:closure" env MINI_ORK_ROOT="$ROOT" bash "$s"
+}
+
+case "$TARGET" in
+  classify|plan|execute|verify|reflect) _probe_entrypoint "$TARGET" ;;
+  routing)        _probe_routing ;;
+  learning-loop)  _probe_learning_loop ;;
+  all)
+    for c in classify plan execute verify reflect; do _probe_entrypoint "$c"; done
+    _probe_routing
+    _probe_learning_loop
+    ;;
+  *) echo "FAIL  unknown feature/fork: $TARGET (see header for the map)"; rc_all=1 ;;
+esac
+
+exit $rc_all

--- a/recipes/self-migrate/README.md
+++ b/recipes/self-migrate/README.md
@@ -1,0 +1,53 @@
+# `self-migrate` — verify-gated, integration-point-first self-migration
+
+Closes one **integration fork** (a bash↔Python seam) at a time as a *single
+complete unit*, so no half-migrated seam is ever left behind. Propose-not-commit:
+emits a reviewable diff + a static-feature ledger + a verdict; never applies to
+main or retires an entrypoint on the real checkout.
+
+Full design + the integration-point map + the feature manifest:
+[`docs/migration/self-migrate-feature-manifest.md`](../../docs/migration/self-migrate-feature-manifest.md).
+
+## Why forks, not libs
+Bottom-up leaf migration *splits* integration points — it makes a Python module
+native but leaves the paired bash entrypoint (and every lib/test/UI ref to it)
+live. This recipe advances a **single frontier root→down**: above it pure Python,
+below it pure bash, nothing half-open. A fork closes only when every inbound ref
+is repointed and the bash entrypoint retires.
+
+## The pipeline (per fork)
+1. **seam_mapper** (opus) → `integration-map.json` — every outbound seam + every
+   inbound ref (incl. `bin/`, `lib/`, tests, sandbox, web UI).
+2. **static_feature_ledger** (opus) → `static-feature-ledger.json` — classify
+   every behavior **static** (cheap + byte-parity verifiable — the moat) vs
+   **agentic** (a cost + verifiability liability + a cost-down candidate). This
+   ledger is the migration's strategic payload.
+3. **migrator** (codex) → `self-migrate.diff` — make Python sole, repoint every
+   inbound ref, retire the bash entrypoint in the diff.
+4. **verify** — `parity.sh` (byte-parity vs the bash oracle) · `feature-acceptance.sh`
+   (the end-to-end feature probe + pytest + pyright) · `ledger-shape.sh` (the
+   ledger is complete, every agentic row has a cost-down `opportunity`).
+5. **reviewer** (opus) → `verdict.json` — `pass == parity ∧ acceptance ∧
+   ledger_complete ∧ no_dangling_edge`.
+
+## Lane policy (set in `$MINI_ORK_HOME/config/agents.yaml`)
+| role | lane | backoff |
+|---|---|---|
+| implementer (`migrator`) | **codex** | codex |
+| mapper / ledger / reviewer | **opus** (`opus_lens`) | codex |
+| discovery lens (non-critical) | **GLM** (`glm_lens`) | codex |
+
+## Run it
+```bash
+export MINI_ORK_ROOT="$PWD/.mini-ork" MINI_ORK_HOME="$PWD/.mini-ork" MO_TARGET_CWD="$PWD"
+export MO_ALLOW_FRAMEWORK_CWD=1 MO_FORK=verify      # self-edit + name the fork
+"$MINI_ORK_ROOT/bin/mini-ork" run self-migrate recipes/self-migrate/example-kickoff.md
+```
+Recommended order (by blast radius, from the integration map): **verify** (cleanest)
+→ reflect → classify → plan → cli → **execute** (the monster: 4 outbound seams incl.
+`context_assembler` 786L, 37 inbound refs — last).
+
+## Feature-acceptance probes
+`gates/feature_acceptance.sh <fork|feature>` — the end-to-end probe suite that is
+the migration's real finish line (unit-parity alone misses feature breaks).
+`gates/feature_acceptance.sh all` runs every probe.

--- a/recipes/self-migrate/artifact_contract.yaml
+++ b/recipes/self-migrate/artifact_contract.yaml
@@ -1,0 +1,69 @@
+task_class: self_migrate
+expected_artifact: diff
+description: >
+  Produces a proposed unified diff that closes one integration fork (Python
+  made sole, inbound refs repointed, bash entrypoint retired), plus the
+  static-feature ledger and a verdict. Propose-not-commit: the publisher emits
+  run-local review artifacts and must NOT apply the diff or retire any
+  entrypoint on main.
+
+source_artifact: "${MINI_ORK_RUN_DIR}/self-migrate.diff"
+
+required_artifacts:
+  - "${MINI_ORK_RUN_DIR}/self-migrate.diff"
+  - "${MINI_ORK_RUN_DIR}/static-feature-ledger.json"
+  - "${MINI_ORK_RUN_DIR}/integration-map.json"
+  - "${MINI_ORK_RUN_DIR}/verdict.json"
+
+verdict_schema:
+  required_keys:
+    files_changed: integer
+    parity_pass: boolean
+    acceptance_pass: boolean
+    ledger_complete: boolean
+    no_dangling_edge: boolean
+    pass: boolean
+  rule: "pass == (parity_pass && acceptance_pass && ledger_complete && no_dangling_edge)"
+
+success_verifiers:
+  - verifiers/parity.sh
+  - verifiers/feature-acceptance.sh
+  - verifiers/ledger-shape.sh
+
+failure_policy: request_changes
+rollback_policy: >
+  Preserve self-migrate.diff, static-feature-ledger.json, integration-map.json,
+  verdict.json, and verifier logs in ${MINI_ORK_RUN_DIR}; abandon the isolated
+  worktree so no source change and no entrypoint retirement leaks onto the
+  checkout.
+
+publish_modes:
+  smoke_shape:
+    description: >
+      Structural recipe checks only. Use outputs: [] so the publisher takes the
+      no-commit path while verifiers still confirm recipe shape.
+    outputs: []
+  real_publish:
+    description: >
+      A live fork-close proposal. Outputs are run-local review artifacts — the
+      migration diff (including the bash-entrypoint retirement) and the ledger —
+      not canonical source files and not an auto-applied patch.
+    outputs:
+      - "${MINI_ORK_RUN_DIR}/self-migrate.diff"
+      - "${MINI_ORK_RUN_DIR}/static-feature-ledger.json"
+      - "${MINI_ORK_RUN_DIR}/verdict.json"
+
+outputs:
+  - "${MINI_ORK_RUN_DIR}/self-migrate.diff"
+  - "${MINI_ORK_RUN_DIR}/static-feature-ledger.json"
+  - "${MINI_ORK_RUN_DIR}/verdict.json"
+
+artifact_path_template: ".mini-ork/runs/{run_id}/self-migrate"
+max_size_bytes: 2097152
+retention_days: 30
+tags:
+  - migration
+  - self-edit
+  - fork-close
+  - static-feature-ledger
+  - verifier-gated

--- a/recipes/self-migrate/example-kickoff.md
+++ b/recipes/self-migrate/example-kickoff.md
@@ -1,0 +1,41 @@
+# Close the `verify` integration fork
+
+## Goal
+Close the `verify` fork: make `mini_ork/ported/mini_ork_verify.py` the sole
+implementation, repoint every inbound reference to `bin/mini-ork-verify`, and
+retire the bash entrypoint — as a reviewable diff, not applied to main.
+
+The `verify` fork is the cleanest complete fork (0 outbound seams — the Python
+side is already runtime-native — and only 5 inbound refs), so it is the proof
+case for this recipe before the harder forks (`reflect`, `cli`, `execute`).
+
+## Fork
+- **fork:** `verify`
+- **python entrypoint:** `/Volumes/docker-ssd/ps/mini-ork/mini_ork/ported/mini_ork_verify.py`
+- **bash entrypoint to retire:** `/Volumes/docker-ssd/ps/mini-ork/bin/mini-ork-verify`
+
+## Inbound references to resolve (from the integration map — all 5)
+- `/Volumes/docker-ssd/ps/mini-ork/mini_ork/ported/mini_ork_execute.py` — repoint its `bin/mini-ork-verify` invocation to the Python verify module
+- `/Volumes/docker-ssd/ps/mini-ork/mini_ork/ported/mini_ork_verify.py` — self-reference (delegation shim)
+- `/Volumes/docker-ssd/ps/mini-ork/tests/e2e/test_e2e_recipe_code_fix.sh` — repoint to `python3 -m mini_ork.ported.mini_ork_verify`
+- `/Volumes/docker-ssd/ps/mini-ork/tests/integration/test_bin_verify.sh` — convert the bash-oracle parity test to standalone Python
+- `/Volumes/docker-ssd/ps/mini-ork/tests/unit/test_mini_ork_verify_py.py` — drop the live-bash parity dependency once the oracle is gone
+
+## Acceptance criteria
+- `verifiers/parity.sh` — cross-runtime byte-parity holds (bash==python) BEFORE
+  the bash entrypoint is retired in the diff.
+- `verifiers/feature-acceptance.sh` — `gates/feature_acceptance.sh verify` passes,
+  `tests/unit/test_mini_ork_verify_py.py` green, pyright 0 on the port.
+- `verifiers/ledger-shape.sh` — `static-feature-ledger.json` classifies every
+  behavior in `mini_ork_verify.py` (static vs agentic), agentic rows carry a
+  cost-down `opportunity`.
+- No surviving reference to `bin/mini-ork-verify` anywhere in the diff'd tree.
+
+## Files in scope
+- /Volumes/docker-ssd/ps/mini-ork/mini_ork/ported/mini_ork_verify.py
+- /Volumes/docker-ssd/ps/mini-ork/bin/mini-ork-verify
+- /Volumes/docker-ssd/ps/mini-ork/mini_ork/ported/mini_ork_execute.py
+- /Volumes/docker-ssd/ps/mini-ork/tests/e2e/test_e2e_recipe_code_fix.sh
+- /Volumes/docker-ssd/ps/mini-ork/tests/integration/test_bin_verify.sh
+- /Volumes/docker-ssd/ps/mini-ork/tests/unit/test_mini_ork_verify_py.py
+- /Volumes/docker-ssd/ps/mini-ork/lib/runtime-select.sh

--- a/recipes/self-migrate/prompts/cost-verifiability-lens.md
+++ b/recipes/self-migrate/prompts/cost-verifiability-lens.md
@@ -1,0 +1,30 @@
+# Cost/verifiability lens (non-critical, cheap first pass)
+
+You run on a cheap lane (GLM), in parallel, as a NON-critical pre-pass for the
+authoritative `static_feature_ledger`. The panel tolerates your failure; if your
+lane throttles (GLM 429 "Fair Usage"), the run backs off to codex and proceeds
+without you. So be fast and cheap, not exhaustive.
+
+## Job
+Skim the fork's module + `integration-map.json` and flag the OBVIOUS
+cost/verifiability signals, so the opus ledger node can focus its judgment:
+
+- Which functions clearly call an LLM (grep for `claude`, `llm_dispatch`,
+  `cl_*`, `subprocess`→a model) → **agentic candidates**.
+- Which are clearly pure sqlite/string/math logic → **static candidates**.
+- Any function that is agentic today but looks mechanically deterministic
+  (fixed transform, no genuine judgment) → **cost-down candidate** worth the
+  ledger node's attention.
+
+## Output
+A short list to `${MINI_ORK_RUN_DIR}/cost-verifiability-lens.md`:
+
+```
+agentic:   <fn> — <why (file:line)>
+static:    <fn> — <why>
+cost-down: <fn> — agentic now, looks deterministic because <...>
+```
+
+Keep it under ~20 lines. You are a hint generator, not the authority — the
+opus ledger node makes the final call and its `static-feature-ledger.json` is
+what the `ledger_verifier` checks.

--- a/recipes/self-migrate/prompts/migrator.md
+++ b/recipes/self-migrate/prompts/migrator.md
@@ -1,0 +1,39 @@
+# Migrator — close the fork in a reviewable diff (propose-not-commit)
+
+You close ONE integration fork, working in the isolated worktree. Inputs:
+`integration-map.json` (every seam + ref) and `static-feature-ledger.json`
+(the static/agentic classification). Produce the migration as a unified diff at
+`${MINI_ORK_RUN_DIR}/self-migrate.diff` — do NOT apply to main, do NOT retire
+any entrypoint on the real checkout.
+
+## The three moves — resolve the WHOLE fork, leave no dangling edge
+
+1. **Make the Python side sole.** Rewire every outbound seam to native:
+   - AST-verify the target port is already native (real `subprocess`/`Popen`
+     nodes, not docstring mentions) before importing it. If it is NOT native,
+     port its logic first.
+   - Replace `_bash_lib_call("X","fn",args,env)` with `from mini_ork.ported
+     import X; try: X.fn(...) except Exception: 0` — the `try/except` mirrors
+     `_bash_lib_call`'s `|| echo 0`; a side-channel must never crash the caller.
+   - **Stdout discipline:** if the native fn `print()`s (some ports do, as a
+     bash-heredoc parity artifact), wrap the call in
+     `with contextlib.redirect_stdout(io.StringIO()):` so it does not leak into
+     the caller's stdout. Check the port for a real `print()` before deciding.
+
+2. **Repoint every inbound ref** from `integration-map.json`:
+   - Tests that invoke `bin/mini-ork-<fork>` as a parity oracle → convert to
+     standalone Python tests (golden values captured from the parity-verified
+     output), or repoint to `python3 -m mini_ork.ported.mini_ork_<fork>`.
+   - Lib / script / sandbox / UI refs → point at the Python entrypoint or its
+     module.
+
+3. **Retire the bash entrypoint IN THE DIFF** — `git rm bin/mini-ork-<fork>` and
+   drop its `runtime-select` fallback — ONLY once every inbound ref is repointed.
+   If any `close_blocker` remains, do NOT retire it; emit a partial diff and say
+   so in the verdict.
+
+## Hard rules
+- One fork per run. Absolute paths. Stay inside the scope the `scope_gate` allows.
+- Preserve exact behavior + return contracts; the parity verifier diffs you
+  against the live bash on the real state.db.
+- Every function you change must have a row in `static-feature-ledger.json`.

--- a/recipes/self-migrate/prompts/reviewer.md
+++ b/recipes/self-migrate/prompts/reviewer.md
@@ -1,0 +1,31 @@
+# Reviewer — is the fork actually closed, with nothing left dangling?
+
+You are the final judgment before the proposal is published. You have: the
+`self-migrate.diff`, the `integration-map.json`, the `static-feature-ledger.json`,
+and the three verifier reports (parity, feature-acceptance, ledger-shape). Use
+opus-level scrutiny — this is the moat.
+
+## Decide `pass` on four questions, each grounded in evidence
+
+1. **Parity** — did byte-parity vs the bash oracle hold on the LIVE state.db
+   (not a dry-run, not an empty fixture)? A 0-vs-0 parity on an empty db is weak
+   evidence; note it if the write path was never exercised.
+2. **Feature-acceptance** — does the affected feature's end-to-end probe pass?
+   Unit-parity is necessary but not sufficient (a rewire can pass unit-parity yet
+   break the feature — e.g. leak stdout). The probe is the real gate.
+3. **No dangling edge** — cross-check the diff against `integration-map.json`:
+   is EVERY inbound ref repointed? If the bash entrypoint is retired, grep the
+   diff'd tree for any surviving `bin/mini-ork-<fork>` reference. One survivor =
+   fail.
+4. **Ledger complete** — does every changed function have a ledger row, and is
+   each agentic flag's `opportunity` filled? The ledger is the deliverable, not
+   an afterthought.
+
+## Output
+Emit `verdict.json` with `parity_pass`, `acceptance_pass`, `no_dangling_edge`,
+`ledger_complete`, `files_changed`, and `pass == (all four)`. If you reject, say
+exactly which edge/feature/row failed and what the migrator must change — this
+escalates to rollback, and the operator reads your reason.
+
+Do not rubber-stamp. A confident-but-wrong "closed" here ships a dangling
+reference into main.

--- a/recipes/self-migrate/prompts/seam-mapper.md
+++ b/recipes/self-migrate/prompts/seam-mapper.md
@@ -1,0 +1,44 @@
+# Seam mapper — map ONE integration fork's full surface
+
+You are mapping a single **integration fork** so it can be closed completely,
+with no dangling edge left behind. The fork is named in the kickoff (e.g.
+`verify` → the `bin/mini-ork-verify` ↔ `mini_ork/ported/mini_ork_verify.py`
+seam).
+
+## Produce `${MINI_ORK_RUN_DIR}/integration-map.json`
+
+Reason about the seam — do not apply a fixed template. Compute, from the actual
+repo:
+
+1. **Outbound seams** — every place the Python entrypoint shells to bash:
+   `_bash_lib_call(...)`, `subprocess.run([... "source lib/X.sh" ...])`,
+   `bin/mini-ork-*` invocations. For each: the bash symbol, the args/env passed,
+   any side-effect (db write, file, stdout the caller captures).
+2. **Inbound refs** — every reference to the bash entrypoint `bin/mini-ork-<fork>`
+   across `bin/`, `lib/`, `mini_ork/`, `scripts/`, `tests/`, and the web UI
+   (`mini_ork/web/`). Classify each: test/parity-oracle, lib caller, script,
+   sandbox, UI route.
+3. **runtime-select coupling** — how `lib/runtime-select.sh` delegates this fork
+   and what the bash-fallback path is.
+
+```json
+{
+  "fork": "verify",
+  "outbound_seams": [
+    {"symbol": "lib/X.sh::fn", "args": "...", "side_effect": "db|file|stdout-captured|none", "port_exists": true, "port_native": true}
+  ],
+  "inbound_refs": [
+    {"path": "tests/integration/test_bin_verify.sh", "kind": "test|parity-oracle|lib|script|sandbox|ui", "how": "invokes bin/mini-ork-verify"}
+  ],
+  "runtime_select": {"delegates": true, "fallback": "bin/mini-ork-verify"},
+  "close_blockers": ["<what must be resolved before the bash entrypoint can retire>"]
+}
+```
+
+## Rules
+- **The `bin/` and `mini_ork/web/` scans are non-negotiable.** The failure mode
+  this whole recipe exists to prevent is retiring an entrypoint while a lib,
+  test, or UI route still references it.
+- Use `codegraph_explore` / grep to ground every edge in a real file:line. Do
+  not infer edges you cannot cite.
+- A fork cannot be declared closeable while any `close_blocker` is unresolved.

--- a/recipes/self-migrate/prompts/static-feature-ledger.md
+++ b/recipes/self-migrate/prompts/static-feature-ledger.md
@@ -1,0 +1,44 @@
+# Static-feature ledger — the migration's strategic payload
+
+This is not bookkeeping. It is the cost/verifiability audit that makes the
+migration worth more than a port. mini-ork's moat is **cost-down at constant
+verified correctness**, and those two goals share one root cause:
+
+| class | cost | verifiability |
+|---|---|---|
+| **static** (deterministic logic) | ~0 tokens | un-gameable — byte-parity vs an oracle |
+| **agentic** (LLM call) | tokens per call | weak — an LLM-judge is gameable |
+
+## Produce `${MINI_ORK_RUN_DIR}/static-feature-ledger.json`
+
+For **every** function/behavior in the fork being migrated (from
+`integration-map.json` + the module source), emit one row. Classify
+deliberately — this is a decision, not a description:
+
+```json
+{
+  "fork": "verify",
+  "features": [
+    {
+      "feature": "aggregate_win_rates",
+      "class": "static | agentic | integration",
+      "verifiability": "byte-parity | test | llm-judge | none",
+      "cost": "zero | tokens-per-call",
+      "decision": "keep-static | make-static | must-stay-agentic | plumbing",
+      "opportunity": "<if agentic: can it become deterministic, or be gated by a deterministic check? if so, how. else null>"
+    }
+  ],
+  "summary": {"static": 0, "agentic": 0, "integration": 0, "cost_down_candidates": 0}
+}
+```
+
+## Rules
+- **static** confirmed → a unit of the moat proven. Keep it static.
+- **agentic** flagged → a cost AND verifiability liability. Fill `opportunity`:
+  is there a deterministic replacement, or a deterministic gate that makes the
+  agentic step verifiable? Pure static→agentic is almost never right — say so if
+  the code drifted that way.
+- **integration** → a seam; note whether it carries an LLM or is pure plumbing.
+- Every behavior the `migrator` will touch MUST appear here — the
+  `ledger_verifier` fails the run if a changed function has no ledger row.
+- Ground each row in a real file:line. Do not invent features.

--- a/recipes/self-migrate/task_class.yaml
+++ b/recipes/self-migrate/task_class.yaml
@@ -1,0 +1,45 @@
+name: self_migrate
+version: "0.1.0"
+description: >
+  Verifier-gated migration of ONE integration fork (a bash↔Python seam — an
+  entrypoint whose Python side runs while the paired bash entrypoint and its
+  refs still exist). Closes the fork as a single unit: makes the Python side
+  sole, repoints every inbound reference, and retires the bash entrypoint —
+  gated on byte-parity vs the bash oracle, the affected feature-acceptance
+  probe, and a static-feature ledger classifying every behavior static vs
+  agentic. Propose-not-commit: emits a reviewable diff + ledger + verdict,
+  never auto-applies to main.
+
+matches:
+  keywords:
+    - self-migrate
+    - close-fork
+    - integration-point
+    - bash-to-python
+    - un-shell
+    - runtime-select
+    - parity-gate
+    - static-feature-ledger
+    - cost-verifiability
+    - entrypoint-retire
+  regex:
+    - "\\bmigrat(e|ion)\\b.*\\b(fork|seam|integration|entrypoint|bash|python)\\b"
+    - "\\b(close|retire)\\b.*\\b(fork|entrypoint|bin/mini-ork-)\\b"
+
+artifact_contract_ref: artifact_contract.yaml
+default_workflow: workflow.yaml
+
+default_gates:
+  - budget_gate
+  - scope_gate
+
+risk_class: medium
+
+cost_model:
+  min_usd: 3
+  max_usd: 15
+  per_lens_usd: 2
+
+runtime_model:
+  min_minutes: 8
+  max_minutes: 40

--- a/recipes/self-migrate/verifiers/feature-acceptance.sh
+++ b/recipes/self-migrate/verifiers/feature-acceptance.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# verifiers/feature-acceptance.sh — the end-to-end feature gate for a fork.
+#
+# Unit-parity is necessary but not sufficient (a rewire can pass unit-parity yet
+# break the feature — e.g. leak stdout). This runs (a) the fork's feature-
+# acceptance probe from gates/feature_acceptance.sh and (b) the fork's Python
+# test module + pyright, so a green here means the FEATURE works, not just a fn.
+#
+# Inputs (env): MINI_ORK_RUN_DIR (required), MINI_ORK_ROOT (repo root),
+#               MO_FORK (the fork/feature, e.g. "verify").
+# Output: JSON to stdout with .pass. Exit 0 always.
+
+set -uo pipefail
+RUN_DIR="${MINI_ORK_RUN_DIR:?MINI_ORK_RUN_DIR required}"
+REPO_ROOT="${MINI_ORK_ROOT:-$(pwd)}"
+FORK="${MO_FORK:-}"
+GATE="$REPO_ROOT/gates/feature_acceptance.sh"
+EVIDENCE="$RUN_DIR/verifier-feature-acceptance.log"
+: >"$EVIDENCE"
+
+pass=true
+reasons=()
+
+# (a) the feature-acceptance probe for this fork's feature
+if [ -n "$FORK" ] && [ -x "$GATE" ]; then
+  if MO_FORK="$FORK" bash "$GATE" "$FORK" >>"$EVIDENCE" 2>&1; then
+    echo "[feature-probe] $FORK PASS" >>"$EVIDENCE"
+  else
+    pass=false; reasons+=("feature-acceptance probe for '$FORK' failed")
+  fi
+elif [ -z "$FORK" ]; then
+  reasons+=("MO_FORK not set — cannot select a feature probe (shape-only)")
+fi
+
+# (b) the fork's Python test module + pyright on its port
+TESTF="$REPO_ROOT/tests/unit/test_mini_ork_${FORK}_py.py"
+if [ -n "$FORK" ] && [ -f "$TESTF" ]; then
+  if ( cd "$REPO_ROOT" && python3 -m pytest "$TESTF" -q -p no:cacheprovider ) >>"$EVIDENCE" 2>&1; then
+    echo "[pytest] $TESTF PASS" >>"$EVIDENCE"
+  else
+    pass=false; reasons+=("pytest $TESTF failed")
+  fi
+fi
+PORTF="$REPO_ROOT/mini_ork/ported/mini_ork_${FORK}.py"
+if [ -n "$FORK" ] && [ -f "$PORTF" ]; then
+  if ( cd "$REPO_ROOT" && python3 -m pyright "$PORTF" 2>&1 | grep -q '0 errors' ) ; then
+    echo "[pyright] $PORTF 0 errors" >>"$EVIDENCE"
+  else
+    pass=false; reasons+=("pyright on $PORTF not clean")
+  fi
+fi
+
+python3 - "$pass" "$EVIDENCE" "$FORK" "${reasons[@]:-}" <<'PY'
+import json, sys
+pass_str, evidence, fork = sys.argv[1], sys.argv[2], sys.argv[3]
+reasons = [r for r in sys.argv[4:] if r]
+print(json.dumps({
+    "name": "feature-acceptance",
+    "fork": fork,
+    "pass": pass_str == "true",
+    "evidence": evidence,
+    "reasons": reasons,
+}))
+PY

--- a/recipes/self-migrate/verifiers/ledger-shape.sh
+++ b/recipes/self-migrate/verifiers/ledger-shape.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# verifiers/ledger-shape.sh — enforce the static-feature ledger as a deliverable.
+#
+# The ledger is the migration's strategic payload (the cost/verifiability map),
+# so a run does not pass unless the ledger exists, is well-formed, classifies
+# every feature it lists, and fills the cost-down `opportunity` on every agentic
+# row. It also cross-checks that functions changed in self-migrate.diff have a
+# ledger row (best-effort — warns if the diff is absent, e.g. smoke shape).
+#
+# Inputs (env): MINI_ORK_RUN_DIR (required).
+# Output: JSON to stdout with .pass. Exit 0 always.
+
+set -uo pipefail
+RUN_DIR="${MINI_ORK_RUN_DIR:?MINI_ORK_RUN_DIR required}"
+LEDGER="$RUN_DIR/static-feature-ledger.json"
+DIFF="$RUN_DIR/self-migrate.diff"
+
+python3 - "$LEDGER" "$DIFF" <<'PY'
+import json, os, re, sys
+ledger_path, diff_path = sys.argv[1], sys.argv[2]
+reasons = []
+ok = True
+
+if not os.path.isfile(ledger_path):
+    print(json.dumps({"name": "ledger-shape", "pass": False,
+                      "reasons": [f"ledger missing at {ledger_path}"]}))
+    raise SystemExit(0)
+
+try:
+    led = json.load(open(ledger_path, encoding="utf-8"))
+except Exception as e:
+    print(json.dumps({"name": "ledger-shape", "pass": False,
+                      "reasons": [f"ledger not valid JSON: {e}"]}))
+    raise SystemExit(0)
+
+feats = led.get("features")
+if not isinstance(feats, list) or not feats:
+    ok = False; reasons.append("ledger.features must be a non-empty list")
+    feats = feats or []
+
+VALID_CLASS = {"static", "agentic", "integration"}
+named = set()
+for i, f in enumerate(feats):
+    name = f.get("feature")
+    named.add(name)
+    if not name:
+        ok = False; reasons.append(f"feature[{i}] missing name")
+    if f.get("class") not in VALID_CLASS:
+        ok = False; reasons.append(f"{name}: class must be one of {sorted(VALID_CLASS)}")
+    # every agentic row must carry a cost-down opportunity (or an explicit null-reason)
+    if f.get("class") == "agentic" and not f.get("opportunity"):
+        ok = False; reasons.append(f"{name}: agentic row must fill 'opportunity' (cost-down analysis)")
+
+# cross-check: functions changed in the diff should appear in the ledger
+if os.path.isfile(diff_path):
+    added = open(diff_path, encoding="utf-8", errors="replace").read()
+    changed_fns = set(re.findall(r'^\+\s*def\s+([a-zA-Z_]\w*)', added, re.M))
+    missing = [fn for fn in changed_fns if fn not in named and not fn.startswith("_")]
+    if missing:
+        ok = False
+        reasons.append("changed functions with no ledger row: " + ", ".join(sorted(missing)))
+else:
+    reasons.append("note: self-migrate.diff absent (smoke shape) — diff↔ledger cross-check skipped")
+
+print(json.dumps({"name": "ledger-shape", "pass": ok,
+                  "features": len(feats), "reasons": reasons}))
+PY

--- a/recipes/self-migrate/verifiers/parity.sh
+++ b/recipes/self-migrate/verifiers/parity.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# verifiers/parity.sh — the byte-parity moat for a fork migration.
+#
+# The un-gameable oracle: the same deterministic entrypoint invocations run
+# under both runtimes (MINI_ORK_RUNTIME=bash vs =python via runtime-select) must
+# produce identical stdout/stderr/exit-code. Reuses scripts/runtime-parity-harness.sh.
+#
+# Inputs (env): MINI_ORK_RUN_DIR (required), MINI_ORK_ROOT (repo root),
+#               MO_FORK (the fork being migrated, e.g. "verify") — informational.
+# Output: JSON to stdout with .pass. Exit code always 0; caller reads .pass.
+
+set -uo pipefail
+RUN_DIR="${MINI_ORK_RUN_DIR:?MINI_ORK_RUN_DIR required}"
+REPO_ROOT="${MINI_ORK_ROOT:-$(pwd)}"
+FORK="${MO_FORK:-}"
+HARNESS="$REPO_ROOT/scripts/runtime-parity-harness.sh"
+EVIDENCE="$RUN_DIR/verifier-parity.log"
+
+pass=true
+reasons=()
+
+if [ ! -f "$HARNESS" ]; then
+  pass=false; reasons+=("runtime-parity-harness.sh not found at $HARNESS")
+else
+  if bash "$HARNESS" >"$EVIDENCE" 2>&1; then
+    pass=true
+  else
+    pass=false; reasons+=("cross-runtime parity harness reported a divergence — see verifier-parity.log")
+  fi
+fi
+
+# JSON emit
+python3 - "$pass" "$EVIDENCE" "$FORK" "${reasons[@]:-}" <<'PY'
+import json, sys
+pass_str, evidence, fork = sys.argv[1], sys.argv[2], sys.argv[3]
+reasons = [r for r in sys.argv[4:] if r]
+print(json.dumps({
+    "name": "parity",
+    "fork": fork,
+    "pass": pass_str == "true",
+    "evidence": evidence,
+    "reasons": reasons,
+}))
+PY

--- a/recipes/self-migrate/workflow.yaml
+++ b/recipes/self-migrate/workflow.yaml
@@ -1,0 +1,104 @@
+version: "0.1.0"
+task_class: self_migrate
+description: >
+  Per-fork migration pipeline. Maps one integration fork's seams (outbound
+  shell-outs + inbound refs), builds a static-vs-agentic feature ledger,
+  makes the Python side sole and repoints every inbound reference, then gates
+  the proposed diff on byte-parity vs the bash oracle, the affected
+  feature-acceptance probe, and ledger completeness. Emits a reviewable diff +
+  ledger + verdict.json without applying to main. The bash entrypoint is
+  retired in the DIFF only — the operator reviews before it lands.
+
+nodes:
+  # ── 1. map the fork's integration surface (opus reasons per seam) ──
+  - name: seam_mapper
+    type: planner
+    model_lane: opus_lens
+    prompt_ref: prompts/seam-mapper.md
+    dispatch_mode: serial
+
+  # ── 2a. cheap first-pass static/agentic scan (GLM, non-critical, codex-backoff) ──
+  - name: cost_verifiability_lens
+    type: researcher
+    model_lane: glm_lens
+    prompt_ref: prompts/cost-verifiability-lens.md
+    dispatch_mode: parallel
+    gates: [budget_gate]
+
+  # ── 2b. the authoritative static-feature ledger (opus judgment) ──
+  - name: static_feature_ledger
+    type: researcher
+    model_lane: opus_lens
+    prompt_ref: prompts/static-feature-ledger.md
+    dispatch_mode: parallel
+    gates: [budget_gate]
+
+  # ── 3. make Python sole + repoint every inbound ref (codex implements) ──
+  - name: migrator
+    type: implementer
+    model_lane: implementer
+    prompt_ref: prompts/migrator.md
+    dispatch_mode: serial
+    gates: [scope_gate, budget_gate]
+
+  # ── 4. the verify stack = the moat, made concrete ──
+  - name: parity_verifier
+    type: verifier
+    model_lane: verifier
+    prompt_ref: null
+    verifier_ref: verifiers/parity.sh
+    dispatch_mode: serial
+
+  - name: acceptance_verifier
+    type: verifier
+    model_lane: verifier
+    prompt_ref: null
+    verifier_ref: verifiers/feature-acceptance.sh
+    dispatch_mode: serial
+
+  - name: ledger_verifier
+    type: verifier
+    model_lane: verifier
+    prompt_ref: null
+    verifier_ref: verifiers/ledger-shape.sh
+    dispatch_mode: serial
+
+  # ── 5. final judgment: fork fully closed, no dangling edge, ledger complete ──
+  - name: reviewer
+    type: reviewer
+    model_lane: opus_lens
+    prompt_ref: prompts/reviewer.md
+    dispatch_mode: serial
+    gates: [budget_gate]
+
+  - name: publisher
+    type: publisher
+    model_lane: publisher
+    prompt_ref: null
+    dispatch_mode: serial
+
+  - name: rollback
+    type: rollback
+    model_lane: rollback
+    prompt_ref: null
+    dispatch_mode: serial
+
+edges:
+  - { from: seam_mapper,            to: cost_verifiability_lens, edge_type: depends_on }
+  - { from: seam_mapper,            to: static_feature_ledger,   edge_type: depends_on }
+  - { from: cost_verifiability_lens, to: migrator,               edge_type: supplies_context_to }
+  - { from: static_feature_ledger,  to: migrator,                edge_type: supplies_context_to }
+  - { from: migrator,               to: parity_verifier,         edge_type: verifies }
+  - { from: migrator,               to: acceptance_verifier,     edge_type: verifies }
+  - { from: migrator,               to: ledger_verifier,         edge_type: verifies }
+  - { from: parity_verifier,        to: reviewer,                edge_type: depends_on }
+  - { from: acceptance_verifier,    to: reviewer,                edge_type: depends_on }
+  - { from: ledger_verifier,        to: reviewer,                edge_type: depends_on }
+  - { from: reviewer,               to: publisher,               edge_type: depends_on }
+  - { from: reviewer,               to: rollback,                edge_type: escalates_to }
+  - { from: parity_verifier,        to: rollback,                edge_type: escalates_to }
+  - { from: acceptance_verifier,    to: rollback,                edge_type: escalates_to }
+
+rollback_strategy: keep_run_artifacts_discard_worktree
+max_self_correction_iterations: 1
+source_artifact: self-migrate.diff


### PR DESCRIPTION
## Summary

Closes one integration fork (bash↔Python seam) at a time as a single complete unit:
- Makes the Python side the sole implementation
- Repoints every inbound reference to the bash entrypoint
- Retires the bash entrypoint

Gated on three verifiers:
1. **Byte-parity** vs bash oracle (cross-runtime equivalence on live state.db)
2. **Feature-acceptance** — end-to-end probe for the affected feature
3. **Static-feature ledger** — classifies every behavior static vs agentic (cost/verifiability map)

Propose-not-commit: emits a reviewable diff + ledger + verdict, never auto-applies to main.

## Why forks, not libs

Bottom-up leaf migration splits integration points — makes a Python module native but leaves the paired bash entrypoint (and every lib/test/UI ref to it) live. This recipe closes a whole fork: above = pure Python, below = pure bash, nothing half-open.

## Strategic payload: the static-feature ledger

Every migration run produces `static-feature-ledger.json`:
- **Static** = deterministic, ~0 tokens, byte-parity verifiable
- **Agentic** = LLM call, expensive, weakly verifiable, carries a cost-down `opportunity`

This ledger is mini-ork's cost/verifiability map — the migration's real deliverable.

## Integration-point map (measured blast radius)

| Fork | Outbound seams | Inbound refs |
|------|---------------|--------------|
| verify | 0 | 5 |
| reflect | 2 | 8 |
| classify | 0 | 18 |
| plan | 0 | 21 |
| execute | 4 | 37 |
| cli | 3 (dispatcher-level) | — |

Recommended order: **verify → reflect → classify → plan → cli → execute** (cleanest → monster).

## Files added

- `docs/migration/self-migrate-feature-manifest.md` — 9 core features + acceptance probes, integration map, strategy
- `recipes/self-migrate/` — complete recipe (task_class, workflow, artifact_contract, prompts, verifiers)
- `gates/feature_acceptance.sh` — end-to-end acceptance probes (classify/plan/execute/verify/reflect smokes, routing, learning-loop)

## Test plan

- [x] Recipe YAMLs validate (`mini-ork validate`)
- [x] Verify fork feature probe passes (`gates/feature_acceptance.sh verify`)
- [x] Ledger-shape gate enforces completeness (agentic rows require opportunity)
- [ ] Run full recipe on verify fork (example kickoff: `recipes/self-migrate/example-kickoff.md`)
- [ ] Run feature-acceptance.sh on all forks (classify, plan, execute, verify, reflect, routing, learning-loop)

## Usage

```bash
export MINI_ORK_ROOT="$PWD/.mini-ork" MINI_ORK_HOME="$PWD/.mini-ork" MO_TARGET_CWD="$PWD"
export MO_ALLOW_FRAMEWORK_CWD=1 MO_FORK=verify      # self-edit + name the fork
"$MINI_ORK_ROOT/bin/mini-ork" run self-migrate recipes/self-migrate/example-kickoff.md
```